### PR TITLE
Caregivers: Radius filtering + distance sort/display

### DIFF
--- a/src/components/marketplace/CaregiverCard.tsx
+++ b/src/components/marketplace/CaregiverCard.tsx
@@ -18,6 +18,7 @@ interface CaregiverCardProps {
     ratingAverage?: number | null;
     reviewCount?: number | null;
     badges?: string[];
+    distanceMiles?: number;
   };
 }
 
@@ -116,10 +117,15 @@ const CaregiverCard: React.FC<CaregiverCardProps> = ({ caregiver }) => {
           </div>
           <div className="ml-3">
             <h3 className="font-medium text-gray-900">{caregiver.name}</h3>
-            {location && (
+            {(location || typeof caregiver.distanceMiles === 'number') && (
               <div className="flex items-center text-sm text-gray-500">
                 <FiMapPin className="mr-1" size={14} />
-                <span>{location}</span>
+                <span>
+                  {location || 'Location'}
+                  {typeof caregiver.distanceMiles === 'number' && isFinite(caregiver.distanceMiles) && (
+                    <span className="ml-2 text-gray-500">• {caregiver.distanceMiles.toFixed(1)} mi</span>
+                  )}
+                </span>
               </div>
             )}
           </div>


### PR DESCRIPTION
Droid-assisted.

- API (/api/marketplace/caregivers): support lat/lng + radiusMiles with Haversine filter; add sortBy=distanceAsc; include distanceMiles in results.
- UI (Marketplace → Caregivers): add Radius (miles) + 'Use my location'; enable ‘Distance: Nearest’ sort; show distance on cards.

All checks green (lint, tests, build).