### PR TITLE
Providers: show distance on cards when using radius (Droid-assisted)

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -845,7 +845,12 @@ export default function MarketplacePage() {
                         </div>
                         <div>
                           <h3 className="font-semibold text-gray-900">{p.name}</h3>
-                          <div className="text-sm text-gray-600">{[p.city, p.state].filter(Boolean).join(", ")}</div>
+                          <div className="text-sm text-gray-600">
+                            {[p.city, p.state].filter(Boolean).join(", ")}
+                            {typeof p.distanceMiles === 'number' && isFinite(p.distanceMiles) && (
+                              <span className="ml-2 text-gray-500">• {p.distanceMiles.toFixed(1)} mi</span>
+                            )}
+                          </div>
                         </div>
                       </div>
                       <div className="flex items-center text-sm mb-2">


### PR DESCRIPTION
Small UX improvement for Providers tab.\n\n- UI: Displays distance (miles) on provider cards when radius filtering is active (value comes from providers API).\n- Validation: Lint, tests, and build all pass.\n\nThis complements the radius filtering + distance sort feature.