### PR TITLE
Marketplace: Setting multi-select for caregivers and jobs (Droid-assisted)

### DIFF
--- a/src/app/api/marketplace/listings/route.ts
+++ b/src/app/api/marketplace/listings/route.ts
@@ -26,6 +26,7 @@ export async function GET(request: Request) {
     const radiusMiles = searchParams.get('radiusMiles') ? parseFloat(searchParams.get('radiusMiles')!) : null;
     const status = searchParams.get('status');
     const setting = searchParams.get('setting');
+    const settings = searchParams.get('settings')?.split(',').filter(Boolean);
     const careTypes = searchParams.get('careTypes')?.split(',').filter(Boolean);
     const services = searchParams.get('services')?.split(',').filter(Boolean);
     const specialties = searchParams.get('specialties')?.split(',').filter(Boolean);
@@ -56,8 +57,12 @@ export async function GET(request: Request) {
     // Status filter
     if (status) where.status = status;
     
-    // Setting filter
-    if (setting) where.setting = setting;
+    // Setting filter (supports legacy single 'setting' and new multi 'settings')
+    if (settings && settings.length > 0) {
+      where.setting = { in: settings };
+    } else if (setting) {
+      where.setting = setting;
+    }
     
     // Array filters
     if (careTypes && careTypes.length > 0) {


### PR DESCRIPTION
Implements multi-select for Setting across caregivers and jobs tabs.\n\n- UI: Replaces single-select with checkboxes; adds removable chips; clears correctly.\n- API: Listings endpoint now supports 'settings' (comma list) with legacy 'setting' fallback.\n- Validation: Lint, tests, and production build all pass.\n\nProviders API ignores settings (unchanged), but UI consistency is improved.