### PR TITLE
Re-enable caregiver Setting & Care Types filters

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -238,6 +238,9 @@ model Caregiver {
   backgroundCheckProvider  String?
   backgroundCheckReportUrl String?
   specialties              String[]
+  // New marketplace facets
+  settings                 String[] @default([])
+  careTypes                String[] @default([])
 
   // Marketplace relations
   marketplaceApplications MarketplaceApplication[]

--- a/src/app/api/marketplace/caregivers/route.ts
+++ b/src/app/api/marketplace/caregivers/route.ts
@@ -23,6 +23,8 @@ export async function GET(request: Request) {
     const maxRate = searchParams.get('maxRate') ? parseFloat(searchParams.get('maxRate')!) : null;
     const minExperience = searchParams.get('minExperience') ? parseInt(searchParams.get('minExperience')!, 10) : null;
     const specialties = searchParams.get('specialties')?.split(',').filter(Boolean);
+    const settings = searchParams.get('settings')?.split(',').filter(Boolean);
+    const careTypes = searchParams.get('careTypes')?.split(',').filter(Boolean);
     const lat = searchParams.get('lat') ? parseFloat(searchParams.get('lat')!) : null;
     const lng = searchParams.get('lng') ? parseFloat(searchParams.get('lng')!) : null;
     const radiusMiles = searchParams.get('radiusMiles') ? parseFloat(searchParams.get('radiusMiles')!) : null;
@@ -85,6 +87,20 @@ export async function GET(request: Request) {
     if (specialties && specialties.length > 0) {
       where.specialties = {
         hasSome: specialties
+      };
+    }
+
+    // Settings filter
+    if (settings && settings.length > 0) {
+      where.settings = {
+        hasSome: settings
+      };
+    }
+
+    // Care types filter
+    if (careTypes && careTypes.length > 0) {
+      where.careTypes = {
+        hasSome: careTypes
       };
     }
     

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -133,6 +133,8 @@ export default function MarketplacePage() {
         if (city) params.set("city", city);
         if (state) params.set("state", state);
         if (specialties.length > 0) params.set("specialties", specialties.join(","));
+        if (settings.length > 0) params.set("settings", settings.join(","));
+        if (careTypes.length > 0) params.set("careTypes", careTypes.join(","));
         if (minRate) params.set("minRate", minRate);
         if (maxRate) params.set("maxRate", maxRate);
         if (minExperience) params.set("minExperience", minExperience);
@@ -155,7 +157,7 @@ export default function MarketplacePage() {
       }
     };
     run();
-  }, [activeTab, search, city, state, specialties, minRate, maxRate, minExperience, cgPage, cgSort, cgRadius, cgGeoLat, cgGeoLng]);
+  }, [activeTab, search, city, state, specialties, settings, careTypes, minRate, maxRate, minExperience, cgPage, cgSort, cgRadius, cgGeoLat, cgGeoLng]);
 
   useEffect(() => {
     if (activeTab !== "jobs") return;
@@ -267,7 +269,9 @@ export default function MarketplacePage() {
       if (minRate) list.push({ key: `minRate:${minRate}`, label: `Min $${minRate}/hr`, remove: () => { setMinRate(""); setCgPage(1); } });
       if (maxRate) list.push({ key: `maxRate:${maxRate}`, label: `Max $${maxRate}/hr`, remove: () => { setMaxRate(""); setCgPage(1); } });
       if (minExperience) list.push({ key: `minExp:${minExperience}`, label: `Min ${minExperience} yrs`, remove: () => { setMinExperience(""); setCgPage(1); } });
+      settings.forEach((s) => list.push({ key: `setting:${s}`, label: (categories['SETTING']?.find(x => x.slug === s)?.name) || s, remove: () => { toggleSetting(s); setCgPage(1); } }));
       specialties.forEach((s) => list.push({ key: `spec:${s}`, label: (categories['SPECIALTY']?.find(x => x.slug === s)?.name) || s, remove: () => { toggleSpecialty(s); setCgPage(1); } }));
+      careTypes.forEach((c) => list.push({ key: `care:${c}`, label: (categories['CARE_TYPE']?.find(x => x.slug === c)?.name) || c, remove: () => { toggleCareType(c); setCgPage(1); } }));
     }
 
     if (activeTab === 'jobs') {
@@ -389,6 +393,32 @@ export default function MarketplacePage() {
                         placeholder="Min Experience" 
                         className="w-full px-3 py-2 border border-gray-300 rounded-md"
                       />
+                    </div>
+                    <div className="mt-4">
+                      <h4 className="font-medium text-sm mb-2">Setting</h4>
+                      {(categories['SETTING'] || []).map((item) => (
+                        <label key={item.slug} className="flex items-center gap-2 text-sm whitespace-nowrap">
+                          <input
+                            type="checkbox"
+                            checked={settings.includes(item.slug)}
+                            onChange={() => toggleSetting(item.slug)}
+                          />
+                          <span>{item.name}</span>
+                        </label>
+                      ))}
+                    </div>
+                    <div className="mt-4">
+                      <h4 className="font-medium text-sm mb-2">Care Types</h4>
+                      {(categories['CARE_TYPE'] || []).map((careType) => (
+                        <label key={careType.slug} className="flex items-center gap-2 text-sm whitespace-nowrap">
+                          <input 
+                            type="checkbox" 
+                            checked={careTypes.includes(careType.slug)} 
+                            onChange={() => toggleCareType(careType.slug)} 
+                          />
+                          <span>{careType.name}</span>
+                        </label>
+                      ))}
                     </div>
                     <div className="mt-4">
                       <h4 className="font-medium text-sm mb-2">Specialties</h4>
@@ -715,6 +745,26 @@ export default function MarketplacePage() {
                 )}
                 
                 <div className="flex flex-wrap items-center gap-2">
+                  {activeTab === "caregivers" && (categories['SETTING'] || []).map((item) => (
+                    <label key={item.slug} className="flex items-center gap-1 text-sm whitespace-nowrap">
+                      <input 
+                        type="checkbox" 
+                        checked={settings.includes(item.slug)} 
+                        onChange={() => toggleSetting(item.slug)} 
+                      />
+                      <span>{item.name}</span>
+                    </label>
+                  ))}
+                  {activeTab === "caregivers" && (categories['CARE_TYPE'] || []).map((careType) => (
+                    <label key={careType.slug} className="flex items-center gap-1 text-sm whitespace-nowrap">
+                      <input 
+                        type="checkbox" 
+                        checked={careTypes.includes(careType.slug)} 
+                        onChange={() => toggleCareType(careType.slug)} 
+                      />
+                      <span>{careType.name}</span>
+                    </label>
+                  ))}
                   {activeTab === "caregivers" && (categories['SPECIALTY'] || []).map((specialty) => (
                     <label key={specialty.slug} className="flex items-center gap-1 text-sm whitespace-nowrap">
                       <input 


### PR DESCRIPTION
Droid-assisted: Restores Setting and Care Types filters on Caregivers tab, adds Prisma schema fields (settings, careTypes) with default [], updates caregivers API to support hasSome filters, wires UI to pass params and display chips. Includes full lint/build validation. Note: migration files not generated due to non-interactive env; DB updated via prisma db push. Please run locally: npm run prisma:migrate -- --name add-caregiver-settings-caretypes or create migration and deploy.