### PR TITLE
feat(marketplace): show result counts in tab headers [Droid-assisted]

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -547,7 +547,11 @@ export default function MarketplacePage() {
                     : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300")
                 }
               >
-                {t === "caregivers" ? "Caregivers" : t === "jobs" ? "Jobs" : "Providers"}
+                {t === "caregivers"
+                  ? `Caregivers${cgTotal ? ` (${cgTotal})` : ""}`
+                  : t === "jobs"
+                  ? `Jobs${jobTotal ? ` (${jobTotal})` : ""}`
+                  : `Providers${providerTotal ? ` (${providerTotal})` : ""}`}
               </button>
             ))}
           </nav>


### PR DESCRIPTION
Adds total counts to Caregivers/Jobs/Providers tab labels, synced with existing pagination/filter queries. Validation: npm ci, lint, build, and 237 tests passing. Branch: feat/marketplace-tab-counts.