### PR TITLE
perf(images): lazy load + blur placeholders across marketplace (Droid-assisted)

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -6,6 +6,7 @@ import { useSession } from "next-auth/react";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import CaregiverCard from "@/components/marketplace/CaregiverCard";
 import Image from "next/image";
+import { getBlurDataURL } from "@/lib/imageBlur";
 import RecommendedListings from "@/components/marketplace/RecommendedListings";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
@@ -1282,7 +1283,16 @@ export default function MarketplacePage() {
                     <Link href={`/marketplace/listings/${job.id}`} key={job.id} className="block bg-white border rounded-md p-4 hover:shadow-md transition-shadow">
                       <div className="flex items-start mb-2">
                         <div className="h-12 w-12 rounded-md overflow-hidden bg-gray-100 flex-shrink-0 mr-3">
-                          <Image src={`https://ui-avatars.com/api/?name=${encodeURIComponent(job.title)}&background=random&size=128`} alt={job.title} width={48} height={48} />
+                          <Image
+                            src={`https://ui-avatars.com/api/?name=${encodeURIComponent(job.title)}&background=random&size=128`}
+                            alt={job.title}
+                            width={48}
+                            height={48}
+                            placeholder="blur"
+                            blurDataURL={getBlurDataURL(48, 48)}
+                            sizes="48px"
+                            loading="lazy"
+                          />
                         </div>
                         <div>
                           <h3 className="font-semibold text-gray-900">{job.title}</h3>
@@ -1315,7 +1325,16 @@ export default function MarketplacePage() {
                     <div key={p.id} className="bg-white border rounded-md p-4">
                       <div className="flex items-start mb-2">
                         <div className="h-12 w-12 rounded-full overflow-hidden bg-gray-100 flex-shrink-0 mr-3">
-                          <Image src={`https://ui-avatars.com/api/?name=${encodeURIComponent(p.name)}&background=random&size=128`} alt={p.name} width={48} height={48} />
+                          <Image
+                            src={`https://ui-avatars.com/api/?name=${encodeURIComponent(p.name)}&background=random&size=128`}
+                            alt={p.name}
+                            width={48}
+                            height={48}
+                            placeholder="blur"
+                            blurDataURL={getBlurDataURL(48, 48)}
+                            sizes="48px"
+                            loading="lazy"
+                          />
                         </div>
                         <div>
                           <h3 className="font-semibold text-gray-900">{p.name}</h3>

--- a/src/components/marketplace/CaregiverCard.tsx
+++ b/src/components/marketplace/CaregiverCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import { getBlurDataURL } from '@/lib/imageBlur';
 import { FiUser, FiMapPin, FiCheckCircle, FiClock, FiDollarSign } from 'react-icons/fi';
 import Link from 'next/link';
 
@@ -107,6 +108,10 @@ const CaregiverCard: React.FC<CaregiverCardProps> = ({ caregiver }) => {
                 alt={caregiver.name}
                 width={64}
                 height={64}
+                placeholder="blur"
+                blurDataURL={getBlurDataURL(64, 64)}
+                sizes="64px"
+                loading="lazy"
                 className="h-full w-full object-cover"
               />
             ) : (

--- a/src/lib/imageBlur.ts
+++ b/src/lib/imageBlur.ts
@@ -1,0 +1,29 @@
+export function shimmerSVG(w: number, h: number) {
+  return `
+  <svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+    <defs>
+      <linearGradient id="g">
+        <stop stop-color="#f3f4f6" offset="20%"/>
+        <stop stop-color="#e5e7eb" offset="50%"/>
+        <stop stop-color="#f3f4f6" offset="70%"/>
+      </linearGradient>
+    </defs>
+    <rect width="${w}" height="${h}" fill="#f3f4f6"/>
+    <rect id="r" width="${w}" height="${h}" fill="url(#g)"/>
+    <animate xlink:href="#r" attributeName="x" from="-${w}" to="${w}" dur="1.2s" repeatCount="indefinite"  />
+  </svg>`;
+}
+
+export function toBase64(str: string) {
+  if (typeof window === 'undefined') {
+    // Node.js
+    return Buffer.from(str).toString('base64');
+  }
+  // Browser
+  // btoa expects binary string
+  return window.btoa(unescape(encodeURIComponent(str)));
+}
+
+export function getBlurDataURL(w: number, h: number) {
+  return `data:image/svg+xml;base64,${toBase64(shimmerSVG(w, h))}`;
+}


### PR DESCRIPTION
Summary\n- Add Next.js Image placeholder blur and explicit lazy loading for: caregivers, job listings, providers\n- Introduce reusable shimmer blur utility at src/lib/imageBlur.ts\n\nQuality checks\n- npm ci: OK\n- npm run lint: OK (no warnings)\n- npm run build: OK\n\nRationale\nImproves perceived performance and avoids layout jank while images load, especially on mobile and slower connections. No behavior changes otherwise.\n\n