### PR TITLE
perf(marketplace): client-side TTL caching for marketplace queries (Droid-assisted)

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -8,6 +8,7 @@ import CaregiverCard from "@/components/marketplace/CaregiverCard";
 import Image from "next/image";
 import { getBlurDataURL } from "@/lib/imageBlur";
 import RecommendedListings from "@/components/marketplace/RecommendedListings";
+import { fetchJsonCached } from "@/lib/fetchCache";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 const LAST_TAB_KEY = "marketplace:lastTab";
@@ -488,8 +489,7 @@ export default function MarketplacePage() {
         params.set("page", String(cgPage));
         params.set("pageSize", String(20));
         params.set("sortBy", cgSort);
-        const res = await fetch(`/api/marketplace/caregivers?${params.toString()}` , { signal: controller.signal });
-        const json = await res.json();
+        const json = await fetchJsonCached(`/api/marketplace/caregivers?${params.toString()}`, { signal: controller.signal }, 15000);
         setCaregivers(json?.data ?? []);
         setCgTotal(json?.pagination?.total ?? 0);
       } catch (e: any) {
@@ -529,8 +529,7 @@ export default function MarketplacePage() {
         params.set("page", String(jobPage));
         params.set("pageSize", String(20));
         params.set("sortBy", jobSort);
-        const res = await fetch(`/api/marketplace/listings?${params.toString()}` , { signal: controller.signal });
-        const json = await res.json();
+        const json = await fetchJsonCached(`/api/marketplace/listings?${params.toString()}`, { signal: controller.signal }, 15000);
         setListings(json?.data ?? []);
         setJobTotal(json?.pagination?.total ?? 0);
       } catch (e: any) {
@@ -568,8 +567,7 @@ export default function MarketplacePage() {
         params.set("page", String(providerPage));
         params.set("pageSize", String(20));
         params.set("sortBy", providerSort);
-        const res = await fetch(`/api/marketplace/providers?${params.toString()}` , { signal: controller.signal });
-        const json = await res.json();
+        const json = await fetchJsonCached(`/api/marketplace/providers?${params.toString()}`, { signal: controller.signal }, 15000);
         setProviders(json?.data ?? []);
         setProviderTotal(json?.pagination?.total ?? 0);
       } catch (e: any) {

--- a/src/lib/fetchCache.ts
+++ b/src/lib/fetchCache.ts
@@ -1,0 +1,34 @@
+type CacheEntry = { expires: number; data: any };
+
+const cache = new Map<string, CacheEntry>();
+
+export async function fetchJsonCached(
+  url: string,
+  init: RequestInit = {},
+  ttlMs = 15000
+) {
+  try {
+    const now = Date.now();
+    const hit = cache.get(url);
+    if (hit && hit.expires > now) {
+      return hit.data;
+    }
+    const res = await fetch(url, init);
+    const data = await res.json();
+    cache.set(url, { expires: now + ttlMs, data });
+    return data;
+  } catch (e) {
+    // On error, do not poison cache; rethrow
+    throw e;
+  }
+}
+
+export function clearFetchCache(prefix?: string) {
+  if (!prefix) {
+    cache.clear();
+    return;
+  }
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}


### PR DESCRIPTION
Summary\n- Add in-memory TTL cache for fetches in marketplace (caregivers/jobs/providers) via fetchJsonCached\n- Reduces repeat network calls during rapid tab switches, pagination, and back/forward\n\nQuality checks\n- npm run lint: OK\n- npm run build: OK after clearing .next cache\n\nNotes\n- TTL set to 15s; local to session and URL-keyed; respects existing AbortController cleanup