### PR TITLE
perf(api): Cache-Control headers for marketplace endpoints (Droid-assisted)

### DIFF
--- a/src/app/api/marketplace/caregivers/route.ts
+++ b/src/app/api/marketplace/caregivers/route.ts
@@ -274,7 +274,7 @@ export async function GET(request: Request) {
             total: mockCaregivers.length
           }
         },
-        { status: 200 }
+        { status: 200, headers: { 'Cache-Control': 'public, max-age=15, s-maxage=15, stale-while-revalidate=60' } }
       );
     }
     
@@ -287,7 +287,7 @@ export async function GET(request: Request) {
           total: totalCount
         }
       },
-      { status: 200 }
+      { status: 200, headers: { 'Cache-Control': 'public, max-age=15, s-maxage=15, stale-while-revalidate=60' } }
     );
   } catch (error) {
     console.error('Error fetching caregivers:', error);

--- a/src/app/api/marketplace/listings/route.ts
+++ b/src/app/api/marketplace/listings/route.ts
@@ -154,12 +154,15 @@ export async function GET(request: Request) {
       process.env.NODE_ENV !== 'production'
     ) {
       const mockJobs = generateMockListings(12);
-      return NextResponse.json({ data: mockJobs, pagination: { page, pageSize, total: mockJobs.length } }, { status: 200 });
+      return NextResponse.json(
+        { data: mockJobs, pagination: { page, pageSize, total: mockJobs.length } },
+        { status: 200, headers: { 'Cache-Control': 'public, max-age=15, s-maxage=15, stale-while-revalidate=60' } }
+      );
     }
 
     return NextResponse.json(
       { data: formattedListings, pagination: { page, pageSize, total: totalCount } },
-      { status: 200 }
+      { status: 200, headers: { 'Cache-Control': 'public, max-age=15, s-maxage=15, stale-while-revalidate=60' } }
     );
   } catch (error) {
     console.error('Error fetching marketplace listings:', error);


### PR DESCRIPTION
Summary\n- Add HTTP caching headers to caregivers and listings GET route handlers\n- 15s cache with stale-while-revalidate to reduce repeat queries during rapid filter changes\n\nQuality\n- Lint/build pass locally\n\nNotes\n- Only success responses are cached; errors remain uncached