### PR TITLE
perf(api): add Cache-Control headers to providers GET (Droid-assisted)

### DIFF
--- a/src/app/api/marketplace/providers/route.ts
+++ b/src/app/api/marketplace/providers/route.ts
@@ -112,7 +112,7 @@ export async function GET(request: Request) {
           totalPages: Math.ceil(totalCount / pageSize)
         }
       },
-      { status: 200 }
+      { status: 200, headers: { 'Cache-Control': 'public, max-age=15, s-maxage=15, stale-while-revalidate=60' } }
     );
   } catch (error) {
     console.error('Error fetching providers:', error);

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -649,7 +649,7 @@ export default function MarketplacePage() {
     if (activeTab !== 'caregivers') return;
     const obs = new IntersectionObserver((entries) => {
       const entry = entries[0];
-      if (entry.isIntersecting && !caregiversLoading && cgHasMore) {
+      if (entry && entry.isIntersecting && !caregiversLoading && cgHasMore) {
         setCgPage((p) => p + 1);
       }
     }, { rootMargin: '200px' });
@@ -663,7 +663,7 @@ export default function MarketplacePage() {
     if (activeTab !== 'jobs') return;
     const obs = new IntersectionObserver((entries) => {
       const entry = entries[0];
-      if (entry.isIntersecting && !listingsLoading && jobHasMore) {
+      if (entry && entry.isIntersecting && !listingsLoading && jobHasMore) {
         setJobPage((p) => p + 1);
       }
     }, { rootMargin: '200px' });
@@ -677,7 +677,7 @@ export default function MarketplacePage() {
     if (activeTab !== 'providers') return;
     const obs = new IntersectionObserver((entries) => {
       const entry = entries[0];
-      if (entry.isIntersecting && !providersLoading && prHasMore) {
+      if (entry && entry.isIntersecting && !providersLoading && prHasMore) {
         setProviderPage((p) => p + 1);
       }
     }, { rootMargin: '200px' });


### PR DESCRIPTION
Align providers API with caregivers/listings by adding Cache-Control headers for short-term caching (15s) and stale-while-revalidate.\n\nQuality\n- Lint and build pass locally