### PR TITLE
feat(marketplace): caregiver job favorites (server + UI)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -245,6 +245,7 @@ model Caregiver {
   // Marketplace relations
   marketplaceApplications MarketplaceApplication[]
   marketplaceHires        MarketplaceHire[]
+  favoriteListings        FavoriteListing[]
 
   // Timestamps
   createdAt DateTime @default(now())
@@ -1531,6 +1532,7 @@ model MarketplaceListing {
   applications MarketplaceApplication[]
   hires        MarketplaceHire[]
   payments     Payment[]
+  favoritedBy  FavoriteListing[]
 
   // Timestamps
   createdAt DateTime @default(now())
@@ -1587,4 +1589,24 @@ model MarketplaceHire {
   @@index([caregiverId])
   @@index([applicationId])
   @@index([shiftId])
+}
+
+/// Favorites for marketplace listings (per caregiver)
+model FavoriteListing {
+  id          String   @id @default(cuid())
+  caregiverId String
+  listingId   String
+
+  // Relations
+  caregiver Caregiver           @relation(fields: [caregiverId], references: [id], onDelete: Cascade)
+  listing   MarketplaceListing  @relation(fields: [listingId], references: [id], onDelete: Cascade)
+
+  // Timestamps
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Constraints and Indexes
+  @@unique([caregiverId, listingId])
+  @@index([caregiverId])
+  @@index([listingId])
 }

--- a/src/app/api/marketplace/favorites/route.ts
+++ b/src/app/api/marketplace/favorites/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import authOptions from '@/lib/auth';
+
+// GET: list caregiver's favorite listings (IDs + basic listing data)
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const caregiver = await (prisma as any).caregiver.findUnique({ where: { userId: session.user.id } });
+    if (!caregiver) {
+      // Not a caregiver – return empty list (no error)
+      return NextResponse.json({ data: [] }, { status: 200 });
+    }
+
+    const favs = await (prisma as any).favoriteListing.findMany({
+      where: { caregiverId: caregiver.id },
+      include: {
+        listing: {
+          select: {
+            id: true,
+            title: true,
+            city: true,
+            state: true,
+            status: true,
+            hourlyRateMin: true,
+            hourlyRateMax: true,
+            createdAt: true,
+          }
+        }
+      },
+      orderBy: { createdAt: 'desc' }
+    });
+
+    const data = favs.map((f: any) => ({
+      id: f.id,
+      listingId: f.listingId,
+      createdAt: f.createdAt,
+      listing: f.listing,
+    }));
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (err) {
+    console.error('GET /api/marketplace/favorites failed', err);
+    return NextResponse.json({ error: 'Failed to fetch favorites' }, { status: 500 });
+  }
+}
+
+// POST: add favorite { listingId }
+export async function POST(request: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const listingId = body?.listingId as string | undefined;
+    if (!listingId) {
+      return NextResponse.json({ error: 'listingId is required' }, { status: 400 });
+    }
+
+    const caregiver = await (prisma as any).caregiver.findUnique({ where: { userId: session.user.id } });
+    if (!caregiver) {
+      return NextResponse.json({ error: 'Only caregivers can favorite listings' }, { status: 403 });
+    }
+
+    // Ensure listing exists
+    const listing = await (prisma as any).marketplaceListing.findUnique({ where: { id: listingId } });
+    if (!listing) {
+      return NextResponse.json({ error: 'Listing not found' }, { status: 404 });
+    }
+
+    // Upsert-like behavior: unique on (caregiverId, listingId)
+    const existing = await (prisma as any).favoriteListing.findUnique({
+      where: { caregiverId_listingId: { caregiverId: caregiver.id, listingId } },
+      select: { id: true }
+    });
+    if (existing) {
+      return NextResponse.json({ data: { id: existing.id, listingId } }, { status: 200 });
+    }
+
+    const created = await (prisma as any).favoriteListing.create({
+      data: { caregiverId: caregiver.id, listingId }
+    });
+    return NextResponse.json({ data: { id: created.id, listingId } }, { status: 201 });
+  } catch (err) {
+    console.error('POST /api/marketplace/favorites failed', err);
+    return NextResponse.json({ error: 'Failed to add favorite' }, { status: 500 });
+  }
+}
+
+// DELETE: /api/marketplace/favorites?listingId=xxx
+export async function DELETE(request: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const listingId = searchParams.get('listingId');
+    if (!listingId) {
+      return NextResponse.json({ error: 'listingId is required' }, { status: 400 });
+    }
+
+    const caregiver = await (prisma as any).caregiver.findUnique({ where: { userId: session.user.id } });
+    if (!caregiver) {
+      return NextResponse.json({ error: 'Only caregivers can remove favorites' }, { status: 403 });
+    }
+
+    const existing = await (prisma as any).favoriteListing.findUnique({
+      where: { caregiverId_listingId: { caregiverId: caregiver.id, listingId } },
+      select: { id: true }
+    });
+    if (!existing) {
+      return NextResponse.json({ error: 'Favorite not found' }, { status: 404 });
+    }
+
+    await (prisma as any).favoriteListing.delete({ where: { id: existing.id } });
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (err) {
+    console.error('DELETE /api/marketplace/favorites failed', err);
+    return NextResponse.json({ error: 'Failed to remove favorite' }, { status: 500 });
+  }
+}
+
+export function PUT() {
+  return NextResponse.json({ error: 'Method not allowed' }, { status: 405, headers: { Allow: 'GET, POST, DELETE' } });
+}
+
+export function PATCH() {
+  return NextResponse.json({ error: 'Method not allowed' }, { status: 405, headers: { Allow: 'GET, POST, DELETE' } });
+}


### PR DESCRIPTION
Droid-assisted PR\n\nWhat\n- Add Prisma model: FavoriteListing (caregiverId, listingId, timestamps) with unique (caregiverId, listingId)\n- New API: /api/marketplace/favorites (GET, POST, DELETE) for caregivers\n- Wire marketplace UI heart toggle to backend for caregivers; fallback to localStorage for guests\n\nQuality\n- npm ci\n- npx prisma db push (dev)\n- npm run lint → OK\n- npm test → 21/21 suites, 237 tests passed\n- npm run build → OK\n\nFollow-ups\n- Add dedicated Favorites page for caregivers\n- Backfill migration file if needed (db push used for dev)