### PR TITLE
migrations: add FavoriteListing table (favorites)

### DIFF
--- a/prisma/migrations/20250925124811_favorites_model/migration.sql
+++ b/prisma/migrations/20250925124811_favorites_model/migration.sql
@@ -1,0 +1,25 @@
+﻿-- CreateTable
+CREATE TABLE "FavoriteListing" (
+    "id" TEXT NOT NULL,
+    "caregiverId" TEXT NOT NULL,
+    "listingId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FavoriteListing_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FavoriteListing_caregiverId_listingId_key" ON "FavoriteListing"("caregiverId", "listingId");
+
+-- CreateIndex
+CREATE INDEX "FavoriteListing_caregiverId_idx" ON "FavoriteListing"("caregiverId");
+
+-- CreateIndex
+CREATE INDEX "FavoriteListing_listingId_idx" ON "FavoriteListing"("listingId");
+
+-- AddForeignKey
+ALTER TABLE "FavoriteListing" ADD CONSTRAINT "FavoriteListing_caregiverId_fkey" FOREIGN KEY ("caregiverId") REFERENCES "Caregiver"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FavoriteListing" ADD CONSTRAINT "FavoriteListing_listingId_fkey" FOREIGN KEY ("listingId") REFERENCES "MarketplaceListing"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
Droid-assisted: Adds migration for FavoriteListing table with composite unique index and FKs to Caregiver and MarketplaceListing.\n\nChecks:\n- Lint: clean\n- Tests: previously 251 passing (no code changes)\n- Build: OK\n\nNote: SQL matches Prisma schema that is already in main; this migration formalizes the DB change.