### PR TITLE
Security hardening: prod-only E2E bypass lock + API validation & rate limiting (favorites) [Droid-assisted]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 coverage/
 .turbo/
 .cache/
+test-results/
+playwright-report/
+playwright/.cache/
 
 # Env and logs
 .env

--- a/src/app/api/marketplace/favorites/route.ts
+++ b/src/app/api/marketplace/favorites/route.ts
@@ -2,11 +2,19 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import authOptions from '@/lib/auth';
+import { z } from 'zod';
+import { rateLimit, getClientIp } from '@/lib/rateLimit';
 
 // GET: list caregiver's favorite listings (IDs + basic listing data)
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    // Rate limit: 60 requests/min per user or IP
     const session = await getServerSession(authOptions);
+    const key = session?.user?.id || getClientIp(request);
+    const rr = rateLimit({ name: 'favorites:GET', key, limit: 60, windowMs: 60_000 });
+    if (!rr.allowed) {
+      return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429, headers: { 'Retry-After': String(Math.ceil(rr.resetMs / 1000)) } });
+    }
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
     }
@@ -54,15 +62,26 @@ export async function GET() {
 export async function POST(request: Request) {
   try {
     const session = await getServerSession(authOptions);
+    const key = session?.user?.id || getClientIp(request);
+    const rr = rateLimit({ name: 'favorites:POST', key, limit: 30, windowMs: 60_000 });
+    if (!rr.allowed) {
+      return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429, headers: { 'Retry-After': String(Math.ceil(rr.resetMs / 1000)) } });
+    }
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
     }
 
     const body = await request.json().catch(() => ({}));
-    const listingId = body?.listingId as string | undefined;
-    if (!listingId) {
-      return NextResponse.json({ error: 'listingId is required' }, { status: 400 });
+    const Schema = z.object({ listingId: z.string().min(1) });
+    const parsed = Schema.safeParse(body);
+    if (!parsed.success) {
+      const flat = parsed.error.flatten();
+      if (flat.fieldErrors?.listingId) {
+        return NextResponse.json({ error: 'listingId is required' }, { status: 400 });
+      }
+      return NextResponse.json({ error: 'Invalid request', details: flat }, { status: 400 });
     }
+    const { listingId } = parsed.data;
 
     const caregiver = await (prisma as any).caregiver.findUnique({ where: { userId: session.user.id } });
     if (!caregiver) {
@@ -98,14 +117,25 @@ export async function POST(request: Request) {
 export async function DELETE(request: Request) {
   try {
     const session = await getServerSession(authOptions);
+    const key = session?.user?.id || getClientIp(request);
+    const rr = rateLimit({ name: 'favorites:DELETE', key, limit: 30, windowMs: 60_000 });
+    if (!rr.allowed) {
+      return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429, headers: { 'Retry-After': String(Math.ceil(rr.resetMs / 1000)) } });
+    }
     if (!session?.user?.id) {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
     }
 
     const { searchParams } = new URL(request.url);
     const listingId = searchParams.get('listingId');
-    if (!listingId) {
-      return NextResponse.json({ error: 'listingId is required' }, { status: 400 });
+    const Schema = z.object({ listingId: z.string().min(1) });
+    const parsed = Schema.safeParse({ listingId });
+    if (!parsed.success) {
+      const flat = parsed.error.flatten();
+      if (flat.fieldErrors?.listingId) {
+        return NextResponse.json({ error: 'listingId is required' }, { status: 400 });
+      }
+      return NextResponse.json({ error: 'Invalid request', details: flat }, { status: 400 });
     }
 
     const caregiver = await (prisma as any).caregiver.findUnique({ where: { userId: session.user.id } });

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -347,7 +347,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     []
   );
 
-  const e2eBypass = process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1';
+  const e2eBypass = process.env['NODE_ENV'] !== 'production' && process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1';
   const mockSession = e2eBypass
     ? {
         user: {

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -198,9 +198,9 @@ export default function DashboardLayout({
     }
   }, [showMobileSearch]);
 
-  // Redirect to login if not authenticated (skip during e2e to allow mocking)
+  // Redirect to login if not authenticated (skip during e2e to allow mocking; never in production)
   useEffect(() => {
-    const bypass = process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1';
+    const bypass = process.env['NODE_ENV'] !== 'production' && process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1';
     if (!bypass && status === "unauthenticated") {
       router.push("/auth/login");
     }
@@ -313,7 +313,7 @@ export default function DashboardLayout({
     );
   }
 
-  const e2eBypass = process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1';
+  const e2eBypass = process.env['NODE_ENV'] !== 'production' && process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1';
   if (!e2eBypass && status === "unauthenticated") {
     return null;
   }

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,70 @@
+// Simple in-memory rate limiter per key using a sliding window.
+// Note: Works for single-process dev/preview. For production, use a shared store (e.g., Redis/Upstash).
+
+type Bucket = {
+  windowMs: number;
+  limit: number;
+  hits: number[]; // epoch ms timestamps
+};
+
+// Global map keyed by `${name}:${key}`
+const buckets: Map<string, Bucket> = new Map();
+
+export type RateLimitOptions = {
+  /** Unique limiter name per route or purpose */
+  name: string;
+  /** Unique key (e.g., userId or IP) */
+  key: string;
+  /** Max requests within window */
+  limit: number;
+  /** Window size in ms */
+  windowMs: number;
+};
+
+export type RateLimitResult = {
+  allowed: boolean;
+  remaining: number;
+  resetMs: number; // time until reset in ms
+};
+
+export function rateLimit(opts: RateLimitOptions): RateLimitResult {
+  const { name, key, limit, windowMs } = opts;
+  const now = Date.now();
+  const bucketKey = `${name}:${key}`;
+  let bucket = buckets.get(bucketKey);
+  if (!bucket) {
+    bucket = { windowMs, limit, hits: [] };
+    buckets.set(bucketKey, bucket);
+  }
+
+  // Drop hits older than window
+  bucket.hits = bucket.hits.filter((t) => now - t < windowMs);
+
+  if (bucket.hits.length >= limit) {
+    const oldest = bucket.hits[0] ?? now;
+    const resetMs = Math.max(0, windowMs - (now - oldest));
+    return { allowed: false, remaining: 0, resetMs };
+  }
+
+  bucket.hits.push(now);
+  const remaining = Math.max(0, limit - bucket.hits.length);
+  const oldest = bucket.hits[0] ?? now;
+  const resetMs = Math.max(0, windowMs - (now - oldest));
+  return { allowed: true, remaining, resetMs };
+}
+
+export function getClientIp(req: Request): string {
+  try {
+    // App Router Request has headers.get
+    const fwd = req.headers.get('x-forwarded-for');
+    if (typeof fwd === 'string' && fwd.length > 0) {
+      const first = (fwd.split(',')[0] ?? fwd).trim();
+      if (first) return first;
+    }
+    const realIp = req.headers.get('x-real-ip');
+    if (typeof realIp === 'string' && realIp.length > 0) {
+      return realIp.trim();
+    }
+  } catch {}
+  return 'unknown';
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,12 +6,12 @@ export default withAuth(
   // `withAuth` augments your Request with the user's token
   function middleware(req) {
     try {
-      // Allow unauthenticated access during E2E runs
-      if (process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1') {
+      // Allow unauthenticated access during E2E runs (never in production)
+      if (process.env['NODE_ENV'] !== 'production' && process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1') {
         return NextResponse.next();
       }
       // Or via explicit header for test runners
-      if (req.headers.get('x-e2e-bypass') === '1') {
+      if (process.env['NODE_ENV'] !== 'production' && req.headers.get('x-e2e-bypass') === '1') {
         return NextResponse.next();
       }
       const { pathname } = req.nextUrl;
@@ -45,10 +45,10 @@ export default withAuth(
       authorized({ req, token }) {
         // E2E bypass via env flag or explicit header
         try {
-          if (process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1') return true;
+          if (process.env['NODE_ENV'] !== 'production' && process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1') return true;
           // Some Next versions expose headers on req.headers
           const headerVal = req?.headers?.get?.('x-e2e-bypass');
-          if (headerVal === '1') return true;
+          if (process.env['NODE_ENV'] !== 'production' && headerVal === '1') return true;
         } catch {}
         // If there is a token, the user is authenticated
         return !!token;


### PR DESCRIPTION
- Disable E2E auth bypass in production (env/header guards in middleware, providers, layout)\n- Add Zod input validation to favorites API preserving legacy error messages\n- Add lightweight in-memory rate limiting per user/IP for favorites (60r/m GET, 30r/m POST/DELETE)\n- Keep unit tests & e2e green; build passes\n\nValidation logs:\n- Lint: OK\n- Unit tests: 251 passed\n- E2E: 1 passed\n- Build: OK