### PR TITLE
API hardening: applications rate limit + validation; E2E: favorites page and apply/withdraw

### DIFF
--- a/e2e/marketplace-applications.spec.ts
+++ b/e2e/marketplace-applications.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Marketplace applications (caregiver apply/withdraw)', () => {
+  test('apply and withdraw to a job', async ({ page }) => {
+    // Mock caregiver session
+    await page.route('**/api/auth/session', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ user: { id: 'u1', role: 'CAREGIVER' }, expires: new Date(Date.now() + 3600_000).toISOString() })
+      })
+    );
+
+    // Categories
+    await page.route('**/api/marketplace/categories', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: {} }) })
+    );
+
+    const listings = [
+      { id: 'job-1', title: 'Caregiver Needed', description: 'Day care', city: 'Austin', state: 'TX', hourlyRateMin: 20, hourlyRateMax: 28, createdAt: new Date().toISOString(), status: 'OPEN' },
+    ];
+
+    // Listings for jobs tab
+    await page.route('**/api/marketplace/listings?**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: listings, pagination: { total: 1 } }) })
+    );
+
+    // Applications endpoints
+    await page.route('**/api/marketplace/applications', (route) => {
+      const method = route.request().method();
+      if (method === 'POST') {
+        return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ data: { id: 'app-1', listingId: 'job-1', caregiverId: 'cg-1', status: 'APPLIED' } }) });
+      }
+      return route.continue();
+    });
+    // DELETE with query string
+    await page.route('**/api/marketplace/applications?**', (route) => {
+      if (route.request().method() === 'DELETE') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+      }
+      return route.continue();
+    });
+
+    await page.goto('/marketplace?tab=jobs');
+
+    // Wait for Jobs tab and card
+    await expect(page.getByRole('button', { name: /Jobs \(1\)/i })).toBeVisible();
+    const card = page.locator('a[href="/marketplace/listings/job-1"]');
+    await expect(card).toBeVisible();
+
+    // Apply
+    const applyBtn = card.getByRole('button', { name: /apply/i });
+    await applyBtn.click();
+
+    // Should show Applied badge and offer Withdraw button
+    await expect(card.getByText(/Applied/i)).toBeVisible();
+    await expect(card.getByRole('button', { name: /withdraw/i })).toBeVisible();
+
+    // Withdraw
+    const withdrawBtn = card.getByRole('button', { name: /withdraw/i });
+    await withdrawBtn.click();
+
+    // Back to Quick apply, and withdraw should disappear on this card
+    await expect(card.getByRole('button', { name: /withdraw/i })).toHaveCount(0);
+    await expect(card.getByRole('button', { name: /quick apply/i })).toBeVisible();
+  });
+});

--- a/e2e/marketplace-favorites-page.spec.ts
+++ b/e2e/marketplace-favorites-page.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Favorites page (caregiver)', () => {
+  test('list favorites and unfavorite from page', async ({ page }) => {
+    // Mock caregiver session
+    await page.route('**/api/auth/session', (route) =>
+      route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: { id: 'u1', role: 'CAREGIVER', name: 'CG' },
+        expires: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    })
+    );
+
+    // Categories
+    await page.route('**/api/marketplace/categories', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: {} }) })
+    );
+
+    // Favorites list
+    const now = new Date().toISOString();
+    const favs = [
+      { id: 'fav-1', listingId: 'job-1', createdAt: now, listing: { id: 'job-1', title: 'Caregiver Needed', description: 'Day care', city: 'Austin', state: 'TX', status: 'OPEN', hourlyRateMin: 22, hourlyRateMax: 28, createdAt: now }},
+      { id: 'fav-2', listingId: 'job-2', createdAt: now, listing: { id: 'job-2', title: 'Night Shift', description: 'Overnight', city: 'Dallas', state: 'TX', status: 'OPEN', hourlyRateMin: 20, hourlyRateMax: 30, createdAt: now }},
+    ];
+
+    await page.route('**/api/marketplace/favorites', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: favs }) });
+      }
+      if (route.request().method() === 'DELETE') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+      }
+      return route.continue();
+    });
+
+    await page.goto('/marketplace/favorites');
+
+    // Ensure two cards are present
+    await expect(page.getByRole('heading', { name: 'Caregiver Needed' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Night Shift' })).toBeVisible();
+
+    // Click Remove from favorites on first card
+    const firstCard = page.locator('div.relative.bg-white').filter({ has: page.getByRole('heading', { name: 'Caregiver Needed' }) });
+    await firstCard.getByRole('button', { name: /Remove from favorites/i }).click();
+
+    // After unfavorite, first card should disappear
+    await expect(page.getByRole('heading', { name: 'Caregiver Needed' })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
This PR hardens the marketplace applications API and adds E2E coverage.\n\nChanges:\n- Rate limiting: GET (60/min), POST/DELETE (30/min) using in-memory sliding window keyed by user/IP\n- Validation: Zod schema for DELETE query preserving legacy error message for listingId\n- E2E tests: favorites page unfavorite flow; apply/withdraw job flow with robust network mocks\n- All checks: lint, unit, type, build, and e2e passing locally\n\nNotes:\n- Rate limiter is in-memory and intended for single-instance/dev. Consider Redis/Upstash for prod multi-instance.\n\nCloses: N/A