### PR TITLE
ci(playwright): install Chromium via Playwright CLI on ubuntu-24.04 [Droid-assisted]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       - run: npm run lint
       - run: npm test --silent
       - run: npm run build
-      - name: Install Playwright Browsers
-        uses: microsoft/playwright-github-action@v1
+      - name: Install Playwright (Chromium only)
+        run: npx playwright install --with-deps chromium
       - name: E2E tests (Playwright)
         run: npm run test:e2e
         env:


### PR DESCRIPTION
Replace microsoft/playwright-github-action with explicit 'npx playwright install --with-deps chromium' to fix browser install failures on ubuntu-24.04.

- Keeps unit tests and build as-is
- E2E runs against dev server started by Playwright config

This should stabilize CI for Playwright steps.