### PR TITLE
RecommendedCaregivers: extract absolute URL helper + unit tests

### DIFF
--- a/src/components/marketplace/RecommendedCaregivers.tsx
+++ b/src/components/marketplace/RecommendedCaregivers.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { FiUser, FiDollarSign } from "react-icons/fi";
 import { headers } from "next/headers";
+import { getOriginFromHeaders } from "@/lib/http";
 import InviteCaregiverButton from "@/components/marketplace/InviteCaregiverButton";
 type RecommendedCaregiver = {
   id: string;
@@ -31,9 +32,7 @@ export default async function RecommendedCaregivers({ listingId }: { listingId: 
   try {
     const hdrs = headers();
     const cookie = hdrs.get("cookie") ?? "";
-    const proto = hdrs.get("x-forwarded-proto") ?? "http";
-    const host = hdrs.get("x-forwarded-host") ?? hdrs.get("host");
-    const origin = host ? `${proto}://${host}` : "";
+    const origin = getOriginFromHeaders(hdrs as any);
 
     const [recsRes, appsRes] = await Promise.all([
       fetch(

--- a/src/components/marketplace/__tests__/RecommendedCaregivers.test.tsx
+++ b/src/components/marketplace/__tests__/RecommendedCaregivers.test.tsx
@@ -1,0 +1,10 @@
+import { getOriginFromHeaders } from '@/lib/http';
+
+describe('RecommendedCaregivers server component', () => {
+  test('builds absolute URLs using forwarded headers', () => {
+    const h = {
+      get: (k: string) => ({ 'x-forwarded-proto': 'http', 'x-forwarded-host': 'localhost:3000' }[k.toLowerCase()] || null),
+    } as any;
+    expect(getOriginFromHeaders(h)).toBe('http://localhost:3000');
+  });
+});

--- a/src/lib/__tests__/http.test.ts
+++ b/src/lib/__tests__/http.test.ts
@@ -1,0 +1,31 @@
+import { getOriginFromHeaders, HeaderGetter } from "@/lib/http";
+
+function makeHeaders(map: Record<string, string | undefined>): HeaderGetter {
+  return {
+    get: (k: string) => (map[k.toLowerCase()] ?? null) as any,
+  };
+}
+
+describe("getOriginFromHeaders", () => {
+  it("prefers x-forwarded-proto and x-forwarded-host", () => {
+    const h = makeHeaders({
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "example.com",
+      host: "ignored.local",
+    });
+    expect(getOriginFromHeaders(h)).toBe("https://example.com");
+  });
+
+  it("falls back to host when x-forwarded-host missing", () => {
+    const h = makeHeaders({
+      "x-forwarded-proto": "http",
+      host: "localhost:3000",
+    });
+    expect(getOriginFromHeaders(h)).toBe("http://localhost:3000");
+  });
+
+  it("returns empty string when no host available", () => {
+    const h = makeHeaders({});
+    expect(getOriginFromHeaders(h)).toBe("");
+  });
+});

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,11 @@
+export type HeaderGetter = { get: (key: string) => string | null };
+
+export function getOriginFromHeaders(h: HeaderGetter): string {
+  try {
+    const proto = (h.get('x-forwarded-proto') || 'http').toString();
+    const host = (h.get('x-forwarded-host') || h.get('host') || '').toString();
+    return host ? `${proto}://${host}` : '';
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
This PR extracts absolute URL construction into src/lib/http.ts and updates RecommendedCaregivers to use it. Adds focused unit tests to avoid TSX parsing issues in Jest.\n\n- All tests pass (255)\n- Lint passes\n- Build succeeds\n\nDroid-assisted.