### PR TITLE
Family shortlist: caregivers filter + dedicated page + e2e (Droid-assisted)

### DIFF
--- a/e2e/marketplace-caregiver-shortlist.spec.ts
+++ b/e2e/marketplace-caregiver-shortlist.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Family caregiver shortlist', () => {
+  test('toggle shortlist on marketplace and filter by shortlist only', async ({ page }) => {
+    // Mock family session
+    await page.route('**/api/auth/session', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user: { id: 'fam-1', role: 'FAMILY', name: 'Family User' },
+          expires: new Date(Date.now() + 3600_000).toISOString(),
+        }),
+      })
+    );
+
+    // Categories for filters
+    await page.route('**/api/marketplace/categories', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: {} }) })
+    );
+
+    const caregivers = [
+      {
+        id: 'cg-1',
+        userId: 'u1',
+        name: 'Alice Johnson',
+        city: 'Austin',
+        state: 'TX',
+        hourlyRate: 25,
+        yearsExperience: 5,
+        specialties: ['alzheimers-care', 'mobility-assistance'],
+        bio: 'Experienced caregiver',
+        backgroundCheckStatus: 'CLEAR',
+        photoUrl: null,
+        ratingAverage: 4.8,
+        reviewCount: 12,
+        badges: ['Top Rated'],
+      },
+      {
+        id: 'cg-2',
+        userId: 'u2',
+        name: 'Bob Smith',
+        city: 'Dallas',
+        state: 'TX',
+        hourlyRate: 22,
+        yearsExperience: 3,
+        specialties: ['diabetes-care'],
+        bio: 'Friendly and reliable',
+        backgroundCheckStatus: 'CLEAR',
+        photoUrl: null,
+        ratingAverage: 4.5,
+        reviewCount: 8,
+        badges: [],
+      },
+    ];
+
+    // Initial family favorites: none
+    await page.route('**/api/marketplace/caregiver-favorites', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
+      }
+      if (route.request().method() === 'POST') {
+        return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ data: { id: 'fav-1', caregiverId: 'cg-1' } }) });
+      }
+      if (route.request().method() === 'DELETE') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+      }
+      return route.continue();
+    });
+
+    // Caregivers fetch
+    await page.route('**/api/marketplace/caregivers?**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: caregivers, pagination: { total: caregivers.length } }),
+      })
+    );
+
+    await page.goto('/marketplace?tab=caregivers');
+    await expect(page.getByRole('button', { name: /Caregivers \(2\)/i })).toBeVisible();
+
+    // Cards are rendered via Virtuoso; assert by caregiver names
+    await expect(page.getByRole('heading', { name: 'Alice Johnson' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Bob Smith' })).toBeVisible();
+
+    // Toggle shortlist for first caregiver
+    const aliceCard = page.locator('div.relative').filter({ has: page.getByRole('heading', { name: 'Alice Johnson' }) }).first();
+    await aliceCard.getByRole('button', { name: /Add to shortlist/i }).click();
+    await expect(aliceCard.getByRole('button', { name: /Remove from shortlist/i })).toBeVisible();
+
+    // Enable Shortlist only filter (desktop sidebar has md:w-72)
+    const shortlistOnly = page.locator('div.md\\:w-72').getByLabel('Shortlist only').first();
+    await shortlistOnly.check({ force: true });
+
+    // Should only show Alice now
+    await expect(page.getByRole('heading', { name: 'Alice Johnson' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Bob Smith' })).toHaveCount(0);
+
+    // Remove from shortlist and expect empty state
+    await aliceCard.getByRole('button', { name: /Remove from shortlist/i }).click();
+    await expect(page.getByText('No caregivers found')).toBeVisible();
+  });
+
+  test('dedicated shortlist page lists and removes caregivers', async ({ page }) => {
+    // Mock family session
+    await page.route('**/api/auth/session', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ user: { id: 'fam-1', role: 'FAMILY', name: 'Family User' }, expires: new Date(Date.now() + 3600_000).toISOString() })
+      })
+    );
+
+    // Favorites (ids)
+    await page.route('**/api/marketplace/caregiver-favorites', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: ['cg-1', 'cg-2'] }) });
+      }
+      if (route.request().method() === 'DELETE') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+      }
+      return route.continue();
+    });
+
+    // Caregivers by ids
+    const favCaregivers = [
+      { id: 'cg-1', name: 'Alice Johnson', city: 'Austin', state: 'TX', hourlyRate: 25, yearsExperience: 5, specialties: [], bio: null, photoUrl: null, backgroundCheckStatus: 'CLEAR', ratingAverage: 4.8, reviewCount: 12, badges: [] },
+      { id: 'cg-2', name: 'Bob Smith', city: 'Dallas', state: 'TX', hourlyRate: 22, yearsExperience: 3, specialties: [], bio: null, photoUrl: null, backgroundCheckStatus: 'CLEAR', ratingAverage: 4.5, reviewCount: 8, badges: [] },
+    ];
+    await page.route('**/api/marketplace/caregivers?ids=*', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: favCaregivers, pagination: { total: favCaregivers.length } }) })
+    );
+
+    await page.goto('/marketplace/caregivers/favorites');
+
+    await expect(page.getByRole('heading', { name: 'My Caregiver Shortlist' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Alice Johnson' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Bob Smith' })).toBeVisible();
+
+    // Remove Alice from shortlist
+    const aliceRow = page.locator('div.relative').filter({ has: page.getByRole('heading', { name: 'Alice Johnson' }) }).first();
+    await aliceRow.getByRole('button', { name: /Remove from shortlist/i }).click();
+
+    // After removal, Alice should disappear (optimistic update)
+    await expect(page.getByRole('heading', { name: 'Alice Johnson' })).toHaveCount(0);
+  });
+});

--- a/src/app/api/marketplace/caregivers/route.ts
+++ b/src/app/api/marketplace/caregivers/route.ts
@@ -30,6 +30,8 @@ export async function GET(request: Request) {
     }
     
     // Extract filter parameters
+    const idsParam = searchParams.get('ids');
+    const ids = idsParam ? idsParam.split(',').map((s) => s.trim()).filter(Boolean) : null;
     const q = searchParams.get('q');
     const city = searchParams.get('city');
     const state = searchParams.get('state');
@@ -51,6 +53,85 @@ export async function GET(request: Request) {
     const sortBy = searchParams.get('sortBy') || 'recency';
     const skip = (page - 1) * pageSize;
     
+    // If explicit IDs are provided, short-circuit to fetch those caregivers only
+    if (ids && ids.length > 0) {
+      const caregivers = await prisma.caregiver.findMany({
+        where: { id: { in: ids } },
+        include: {
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              profileImageUrl: true,
+              addresses: true,
+            },
+          },
+        },
+      });
+
+      // rating aggregates
+      const reviewAgg = await prisma.caregiverReview.groupBy({
+        by: ['caregiverId'],
+        where: { caregiverId: { in: caregivers.map((c) => c.id) } },
+        _avg: { rating: true },
+        _count: { _all: true },
+      });
+      const reviewMap = new Map(
+        reviewAgg.map((r) => [
+          r.caregiverId,
+          {
+            avg: r._avg.rating ?? 0,
+            count: r._count._all,
+          },
+        ])
+      );
+
+      const deriveBadges = (avg: number, count: number, yearsExp: number | null, bgStatus: string) => {
+        const badges: string[] = [];
+        if (bgStatus === 'CLEAR') badges.push('Background Check Clear');
+        if (yearsExp !== null && yearsExp >= 5) badges.push('Experienced');
+        if (count >= 5 && avg >= 4.5) badges.push('Top Rated');
+        return badges;
+      };
+
+      const formattedCaregivers = caregivers.map((caregiver: any) => {
+        const address = caregiver.user.addresses && caregiver.user.addresses.length > 0 ? caregiver.user.addresses[0] : null;
+        let photoUrl = null as string | null;
+        if (caregiver.user.profileImageUrl) {
+          if (typeof caregiver.user.profileImageUrl === 'string') photoUrl = caregiver.user.profileImageUrl;
+          else if ((caregiver.user.profileImageUrl as any).medium) photoUrl = (caregiver.user.profileImageUrl as any).medium;
+          else if ((caregiver.user.profileImageUrl as any).thumbnail) photoUrl = (caregiver.user.profileImageUrl as any).thumbnail;
+          else if ((caregiver.user.profileImageUrl as any).large) photoUrl = (caregiver.user.profileImageUrl as any).large;
+        }
+        const ratingInfo = reviewMap.get(caregiver.id) ?? { avg: 0, count: 0 };
+        return {
+          id: caregiver.id,
+          userId: caregiver.user.id,
+          name: `${caregiver.user.firstName} ${caregiver.user.lastName}`,
+          city: address?.city || null,
+          state: address?.state || null,
+          hourlyRate: caregiver.hourlyRate ? parseFloat(caregiver.hourlyRate.toString()) : null,
+          yearsExperience: caregiver.yearsExperience,
+          specialties: caregiver.specialties || [],
+          bio: caregiver.bio || null,
+          backgroundCheckStatus: caregiver.backgroundCheckStatus,
+          photoUrl,
+          ratingAverage: Number((ratingInfo.avg ?? 0).toFixed(1)) || 0,
+          reviewCount: ratingInfo.count,
+          badges: deriveBadges(ratingInfo.avg ?? 0, ratingInfo.count, caregiver.yearsExperience, caregiver.backgroundCheckStatus),
+        };
+      });
+
+      return NextResponse.json(
+        {
+          data: formattedCaregivers,
+          pagination: { page: 1, pageSize: formattedCaregivers.length, total: formattedCaregivers.length },
+        },
+        { status: 200, headers: { 'Cache-Control': 'public, max-age=15, s-maxage=15, stale-while-revalidate=60', ...(typeof __rl_caregivers_get !== 'undefined' ? buildRateLimitHeaders(__rl_caregivers_get.rr, __rl_caregivers_get.limit) : {}) } }
+      );
+    }
+
     // Build where clause for filtering
     const where: any = {};
     

--- a/src/app/marketplace/caregivers/favorites/page.tsx
+++ b/src/app/marketplace/caregivers/favorites/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useMemo, useState, useCallback } from "react";
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import CaregiverCard from "@/components/marketplace/CaregiverCard";
+
+type Caregiver = {
+  id: string;
+  name: string;
+  city: string | null;
+  state: string | null;
+  hourlyRate: number | null;
+  yearsExperience: number | null;
+  specialties: string[];
+  bio: string | null;
+  photoUrl: string | null;
+  backgroundCheckStatus: string;
+  ratingAverage?: number;
+  reviewCount?: number;
+  badges?: string[];
+};
+
+export default function FamilyShortlistPage() {
+  const { data: session } = useSession();
+  const [ids, setIds] = useState<string[]>([]);
+  const [caregivers, setCaregivers] = useState<Caregiver[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const pageSize = 20;
+
+  const isFamily = session?.user?.role === 'FAMILY';
+
+  const loadFavorites = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/marketplace/caregiver-favorites', { cache: 'no-store' });
+      if (!res.ok) throw new Error('failed');
+      const j = await res.json();
+      const favIds: string[] = j?.data || [];
+      setIds(favIds);
+      if (favIds.length > 0) {
+        const resp = await fetch(`/api/marketplace/caregivers?ids=${encodeURIComponent(favIds.join(','))}`);
+        const data = await resp.json();
+        setCaregivers(data?.data || []);
+      } else {
+        setCaregivers([]);
+      }
+    } catch {
+      setIds([]);
+      setCaregivers([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadFavorites();
+  }, [loadFavorites]);
+
+  const totalPages = Math.max(1, Math.ceil(caregivers.length / pageSize));
+  const pageItems = useMemo(
+    () => caregivers.slice((page - 1) * pageSize, page * pageSize),
+    [caregivers, page]
+  );
+
+  const removeFromShortlist = async (caregiverId: string) => {
+    try {
+      // optimistic
+      setCaregivers((prev) => prev.filter((c) => c.id !== caregiverId));
+      setIds((prev) => prev.filter((id) => id !== caregiverId));
+      const res = await fetch(`/api/marketplace/caregiver-favorites?caregiverId=${encodeURIComponent(caregiverId)}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('failed');
+    } catch {
+      // fallback reload
+      loadFavorites();
+    }
+  };
+
+  return (
+    <div className="px-4 md:px-6 py-4">
+      <div className="mb-4 flex items-center gap-3">
+        <Link href="/marketplace" className="text-sm text-primary-600 hover:underline">← Back to Marketplace</Link>
+        <h1 className="text-base font-medium text-gray-900">My Caregiver Shortlist</h1>
+      </div>
+
+      {!session?.user ? (
+        <div className="rounded-md border bg-white p-6 text-center text-gray-700">
+          Please sign in to view your shortlist.
+        </div>
+      ) : !isFamily ? (
+        <div className="rounded-md border bg-white p-6 text-center text-gray-700">
+          Shortlists are available for family accounts.
+        </div>
+      ) : loading ? (
+        <div className="py-16 text-center text-gray-500">Loading shortlist…</div>
+      ) : ids.length === 0 ? (
+        <div className="py-16 text-center">
+          <div className="text-lg font-medium text-gray-900 mb-1">No caregivers shortlisted</div>
+          <div className="text-sm text-gray-600">Tap the heart on caregiver cards to add them to your shortlist.</div>
+          <div className="mt-4">
+            <Link href="/marketplace?tab=caregivers" className="inline-flex items-center rounded-md bg-primary-600 px-3 py-2 text-sm text-white hover:bg-primary-700">Browse caregivers</Link>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-4">
+            {pageItems.map((cg) => (
+              <div key={cg.id} className="relative">
+                <button
+                  onClick={(e) => { e.preventDefault(); e.stopPropagation(); removeFromShortlist(cg.id); }}
+                  aria-label="Remove from shortlist"
+                  aria-pressed={true}
+                  className="absolute right-3 top-3 z-10 inline-flex items-center justify-center h-8 w-8 rounded-full bg-white/90 border hover:bg-white"
+                  title="Shortlisted"
+                >
+                  <svg viewBox="0 0 24 24" className="h-5 w-5 text-rose-600" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z" />
+                  </svg>
+                </button>
+                <CaregiverCard caregiver={cg} />
+              </div>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="mt-6 flex items-center justify-center gap-3">
+              <button
+                disabled={page <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-50"
+              >
+                Previous
+              </button>
+              <div className="text-sm text-gray-600">Page {page} of {totalPages}</div>
+              <button
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
This PR finalizes the family caregiver shortlist experience.

Highlights:
- Add Playwright e2e covering family shortlist workflows (marketplace toggle/filter and dedicated page remove)
- Fix caregivers grid to respect `Shortlist only` filter and show proper empty state
- Add dedicated page at /marketplace/caregivers/favorites with pagination + optimistic remove
- Caregivers API now supports `ids` param for fetching specific caregivers for shortlist page

Quality gates:
- Lint: ✓
- Unit tests: ✓
- Build: ✓
- Playwright e2e: ✓ (5 tests passing)

Marking as Droid-assisted.
