### PR TITLE
chore(compose): avoid Postgres port conflict (use 5434)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - '5433:5432'
+      - '${POSTGRES_PORT:-5434}:5432'
     volumes:
       - db_data:/var/lib/postgresql/data
 


### PR DESCRIPTION
Avoids collision with existing local Postgres on 5433 by defaulting to host port 5434. No runtime changes. Adds POSTGRES_PORT override.\n\nDroid-assisted.