### PR TITLE
chore(cd): add Render deploy workflow (Droid-assisted)

### DIFF
--- a/.github/workflows/deploy-render.yml
+++ b/.github/workflows/deploy-render.yml
@@ -1,0 +1,24 @@
+name: Deploy to Render
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    if: ${{ secrets.RENDER_API_KEY && secrets.RENDER_SERVICE_ID }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Trigger Render deploy
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${RENDER_API_KEY}" \
+            -H "Content-Type: application/json" \
+            https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys


### PR DESCRIPTION
Adds GitHub Actions workflow to trigger a Render deploy of the existing service via API whenever main updates, or on manual dispatch. Set the following GitHub Secrets to activate it:

- RENDER_API_KEY
- RENDER_SERVICE_ID

If secrets are not present, the job is skipped. CI remains green (lint, tests, build).