### PR TITLE
chore(docker): regenerate Prisma Client in runtime image [Droid-assisted]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,8 @@ COPY --from=build /app/public ./public
 COPY --from=build /app/prisma ./prisma
 COPY package.json ./package.json
 
+# Regenerate Prisma Client in the runtime image to guarantee presence
+RUN npx prisma generate
+
 EXPOSE 3000
 CMD ["sh", "-c", "npx prisma migrate deploy && npm start"]


### PR DESCRIPTION
Force-generate Prisma Client in the runtime image to guarantee presence of .prisma/client even if multi-stage COPY misses it.\n\nChanges:\n- Add RUN 'npx prisma generate' in final stage.\n- Still copy .prisma and @prisma from build as a belt-and-suspenders approach.\n\nValidation:\n- Local lint/build pass.\n\nAction:\n- Deploy this commit on Render (clear build cache) to eliminate 'Cannot find module .prisma/client/default'.