### PR TITLE
fix(docker-staging): ensure Prisma client present in runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,21 @@ ENV NODE_ENV=production \
 WORKDIR /app
 
 # Only copy necessary files
-COPY --from=deps /app/node_modules ./node_modules
+# Use node_modules from the build stage to include generated Prisma client artifacts
+COPY --from=build /app/node_modules ./node_modules
+# Ensure Prisma Client generated artifacts are present in the runtime image
+# Copy both the generated JS client and the native engines
+COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=build /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=build /app/.next ./.next
 COPY --from=build /app/public ./public
 COPY --from=build /app/prisma ./prisma
 COPY package.json ./package.json
+
+# Force-regenerate Prisma Client in the runtime image using a pinned CLI
+# This does not rely on devDependencies being present
+RUN npx -y prisma@5.22.0 generate --schema=./prisma/schema.prisma \
+  && node -e "require('fs').accessSync('node_modules/.prisma/client/default.js'); console.log('Prisma client present')"
 
 EXPOSE 3000
 CMD ["sh", "-c", "npx prisma migrate deploy && npm start"]


### PR DESCRIPTION
Droid-assisted

This PR applies the same Docker fix from main to the staging deploy branch.

Changes
- Use node_modules from build stage in runner (contains generated Prisma Client)
- Copy .prisma and @prisma from build
- Run pinned prisma generate in runner and verify presence

Why
Runner previously copied node_modules from deps (built with --ignore-scripts), so .prisma/client was missing at runtime → Cannot find module '.prisma/client/default'.

Local validation
- npm ci/build/lint/test: OK (25 suites passing)

Post-merge
- Redeploy the Render service that targets chore/render-staging-migrations with Clear build cache & deploy.