### PR TITLE
fix(auth): add /auth/error page (Droid-assisted)

### DIFF
--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+type Props = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+const errorMap: Record<string, string> = {
+  CredentialsSignin: "Invalid email or password.",
+  AccessDenied: "Access denied.",
+  EmailSignin: "Email sign-in failed.",
+  Verification: "Email verification failed or expired.",
+};
+
+export default function AuthErrorPage({ searchParams }: Props) {
+  const raw = (searchParams?.["error"] as string) || "";
+  const decoded = decodeURIComponent(raw);
+  const message = errorMap[decoded] || decoded || "Authentication error.";
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50 p-6">
+      <div className="w-full max-w-md bg-white rounded-lg shadow p-8 text-center">
+        <h1 className="text-xl font-semibold text-gray-900 mb-3">Sign-in error</h1>
+        <p className="text-sm text-gray-700 mb-6">{message}</p>
+        <Link
+          href="/auth/login"
+          className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Back to login
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
This PR adds a dedicated /auth/error page to handle NextAuth error redirects.\n\n- Displays friendly messages for common NextAuth error codes (e.g., CredentialsSignin)\n- Shows any custom message passed in the error param\n- Provides a clear link back to /auth/login\n\nValidation:\n- npm ci\n- npm run lint (clean)\n- npm run build (success)\n\nContext:\nProduction/staging auth redirects land on /auth/error when sign-in fails (e.g., invalid credentials). Previously this path 404’d. This fixes the 404 and improves UX.\n\nFollow-ups:\n- Create admin user in production DB (use /api/dev/upsert-admin with ALLOW_DEV_ENDPOINTS=1 temporarily), then disable the flag.\n