### PR TITLE
fix(dashboard): prevent indefinite spinner with session timeout fallback

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -209,16 +209,18 @@ export default function DashboardLayout({
   // Note: NextAuth session cookies are HttpOnly in production, so client JS cannot read them.
   // Instead of relying on cookies, add a short timeout fallback to prevent indefinite spinners.
   useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
     if (status === 'loading') {
-      const t = setTimeout(() => setSessionStall(true), 2000);
-      return () => clearTimeout(t);
+      timer = setTimeout(() => setSessionStall(true), 2000);
+    } else if (status === 'unauthenticated') {
+      timer = setTimeout(() => setSessionStall(true), 2500);
+    } else {
+      // Reset stall when authenticated
+      setSessionStall(false);
     }
-    if (status === 'unauthenticated') {
-      const t = setTimeout(() => setSessionStall(true), 2500);
-      return () => clearTimeout(t);
-    }
-    // Reset stall when authenticated
-    setSessionStall(false);
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
   }, [status]);
 
   // Redirect to login if not authenticated (skip during e2e to allow mocking; add short grace period)


### PR DESCRIPTION
Droid-assisted: Implements a resilient timeout-based fallback in DashboardLayout to avoid indefinite loading spinners when NextAuth session status remains 'loading' in production due to HttpOnly cookies.\n\nChanges:\n- Use short timeouts (2000ms for loading, 2500ms for unauthenticated) to set a stall state\n- Proper timer setup/cleanup and stall reset when authenticated\n\nValidation:\n- Lint: passed (npm run lint)\n- Build: passed (next build)\n\nMerged to base after checks should resolve the dashboard spinner on staging.