### PR TITLE
fix(csp): relax CSP for Next/Stripe/Fonts to unblock dashboard

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -118,19 +118,21 @@ function applySecurityHeaders(req: Request, res: NextResponse) {
   const cspParts = [
     "default-src 'self'",
     // Allow Next.js inline styles; tighten in prod if hashed
-    isProd ? "style-src 'self' 'unsafe-inline'" : "style-src 'self' 'unsafe-inline'",
+    isProd ? "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com" : "style-src 'self' 'unsafe-inline'",
     // Scripts: allow self; allow unsafe-eval in dev for React Refresh
-    isProd ? "script-src 'self'" : "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
+    isProd ? "script-src 'self' 'unsafe-inline' https://js.stripe.com" : "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
     // Images from self, data URIs, and https
     "img-src 'self' data: blob: https:",
     // Fonts
-    "font-src 'self' data: https:",
+    "font-src 'self' data: https: https://fonts.gstatic.com",
     // Connections (API, websockets for dev)
-    isProd ? "connect-src 'self' https:" : "connect-src 'self' ws: wss: http: https:",
+    isProd ? "connect-src 'self' https: https://js.stripe.com https://api.stripe.com" : "connect-src 'self' ws: wss: http: https:",
     // Media
     "media-src 'self'",
     // Frames
     "frame-ancestors 'none'",
+    // Allow Stripe iframes
+    "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
     // Workers
     "worker-src 'self' blob:",
     // Base URI


### PR DESCRIPTION
Droid-assisted\n\nAdjust CSP in middleware for production:\n- script-src: add 'unsafe-inline' and https://js.stripe.com\n- style-src: allow https://fonts.googleapis.com\n- font-src: allow https://fonts.gstatic.com\n- connect-src: allow Stripe endpoints\n- frame-src: allow Stripe iframes\n\nReason: dashboard hydration and Stripe Elements were blocked by strict CSP.\n\nValidation: lint+build passed locally.