### PR TITLE
feat(dashboard): SSR auth guard + remove client loading gate to stop spinner

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import authOptions from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardServerLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect("/auth/login");
+  }
+  return <>{children}</>;
+}

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -327,8 +327,8 @@ export default function DashboardLayout({
     console.log("[DashboardLayout] resolved profileImage:", profileImage);
   }
 
-  // Show loading state when session is loading
-  if ((status === "loading" && !sessionStall) || !mounted) {
+  // Only gate on mount to avoid indefinite spinner; SSR guard handles auth
+  if (!mounted) {
     return (
       <div className="flex h-screen w-full items-center justify-center bg-neutral-50">
         <div className="flex flex-col items-center space-y-4">
@@ -339,16 +339,7 @@ export default function DashboardLayout({
     );
   }
 
-  const contentEl = (!e2eBypass && status === "unauthenticated" && !sessionStall) ? (
-    <div className="flex-1 flex items-center justify-center">
-      <div className="flex flex-col items-center space-y-4 py-12">
-        <div className="h-10 w-10 rounded-full border-4 border-t-primary-500 border-neutral-200 animate-spin"></div>
-        <p className="text-neutral-600 font-medium">Signing you in...</p>
-      </div>
-    </div>
-  ) : (
-    <>{children}</>
-  );
+  const contentEl = (<>{children}</>);
 
   return (
     <div 


### PR DESCRIPTION
Droid-assisted\n\n- Add server-side auth guard at app/dashboard/layout.tsx using getServerSession + redirect to /auth/login\n- Remove client-side loading gate/spinner in DashboardLayout; rely on SSR guard to ensure only authenticated users render the page\n\nResult: Removes indefinite spinner on /dashboard and renders content immediately for signed-in users.\n\nValidation: npm ci (previously), lint and build pass locally.