### PR TITLE
feat(mock): site-wide mock data for marketplace and search

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -68,6 +68,11 @@ export default function MarketplacePage() {
   const searchParams = useSearchParams();
   const didInitFromUrl = useRef(false);
 
+  // Environment-gated mock data toggle (reuse dashboard flag)
+  const showMock = ["1", "true", "yes", "on"].includes(
+    String(process.env.NEXT_PUBLIC_SHOW_MOCK_DASHBOARD || "").toLowerCase()
+  );
+
   // Include "providers" as a valid tab option
   const [activeTab, setActiveTab] = useState<"jobs" | "caregivers" | "providers">(
     "caregivers"
@@ -153,6 +158,149 @@ export default function MarketplacePage() {
   const [prGeoLat, setPrGeoLat] = useState<number | null>(null);
   const [prGeoLng, setPrGeoLng] = useState<number | null>(null);
   const [linkCopied, setLinkCopied] = useState(false);
+
+  // Mock data (only used when showMock is true)
+  const MOCK_CATEGORIES: Record<string, { slug: string; name: string }[]> = {
+    SERVICE: [
+      { slug: "transportation", name: "Transportation" },
+      { slug: "meal-prep", name: "Meal Prep" },
+      { slug: "housekeeping", name: "Housekeeping" },
+    ],
+    CARE_TYPE: [
+      { slug: "assisted-living", name: "Assisted Living" },
+      { slug: "memory-care", name: "Memory Care" },
+      { slug: "skilled-nursing", name: "Skilled Nursing" },
+    ],
+    SPECIALTY: [
+      { slug: "dementia", name: "Dementia" },
+      { slug: "medication-management", name: "Medication Management" },
+      { slug: "companionship", name: "Companionship" },
+    ],
+    SETTING: [
+      { slug: "in-home", name: "In-Home" },
+      { slug: "facility", name: "Facility" },
+      { slug: "respite", name: "Respite" },
+    ],
+  };
+
+  const MOCK_CAREGIVERS: Caregiver[] = [
+    {
+      id: "cg_1",
+      name: "Ava Johnson",
+      city: "Seattle",
+      state: "WA",
+      hourlyRate: 28,
+      yearsExperience: 5,
+      specialties: ["dementia", "medication-management", "companionship"],
+      bio: "Experienced caregiver focused on dignity and independence.",
+      photoUrl: null,
+      backgroundCheckStatus: "CLEAR",
+      distanceMiles: 2.3,
+    },
+    {
+      id: "cg_2",
+      name: "Noah Williams",
+      city: "Bellevue",
+      state: "WA",
+      hourlyRate: 25,
+      yearsExperience: 3,
+      specialties: ["companionship"],
+      bio: "Friendly and reliable with flexible evenings/weekends.",
+      photoUrl: null,
+      backgroundCheckStatus: "PENDING",
+      distanceMiles: 7.8,
+    },
+    {
+      id: "cg_3",
+      name: "Sophia Martinez",
+      city: "Redmond",
+      state: "WA",
+      hourlyRate: 32,
+      yearsExperience: 7,
+      specialties: ["memory-care", "dementia"],
+      bio: "Memory care specialist with a calm, supportive approach.",
+      photoUrl: null,
+      backgroundCheckStatus: "CLEAR",
+      distanceMiles: 12.1,
+    },
+  ];
+
+  const MOCK_LISTINGS: Listing[] = [
+    {
+      id: "job_1",
+      title: "Evening Companion Needed",
+      description: "Seeking a kind caregiver for light conversation, walks, and meal prep.",
+      city: "Seattle",
+      state: "WA",
+      hourlyRateMin: 22,
+      hourlyRateMax: 28,
+      createdAt: new Date().toISOString(),
+      status: "OPEN",
+      applicationCount: 3,
+      hireCount: 0,
+      distanceMiles: 3.4,
+      appliedByMe: false,
+    },
+    {
+      id: "job_2",
+      title: "Overnight Care (Fri-Sun)",
+      description: "Provide overnight support and safety checks for an elder with mild dementia.",
+      city: "Kirkland",
+      state: "WA",
+      hourlyRateMin: 25,
+      hourlyRateMax: 30,
+      createdAt: new Date().toISOString(),
+      status: "OPEN",
+      applicationCount: 8,
+      hireCount: 1,
+      distanceMiles: 9.1,
+      appliedByMe: false,
+    },
+    {
+      id: "job_3",
+      title: "Transportation to Appointments",
+      description: "Help with weekly appointments and occasional errands.",
+      city: "Bellevue",
+      state: "WA",
+      hourlyRateMin: 20,
+      hourlyRateMax: 24,
+      createdAt: new Date().toISOString(),
+      status: "OPEN",
+      applicationCount: 1,
+      hireCount: 0,
+      distanceMiles: 6.0,
+      appliedByMe: false,
+    },
+  ];
+
+  const MOCK_PROVIDERS: Provider[] = [
+    {
+      id: "pr_1",
+      name: "CarePlus Transport",
+      city: "Seattle",
+      state: "WA",
+      services: ["transportation"],
+      hourlyRate: 40,
+      perMileRate: 1.5,
+      ratingAverage: 4.7,
+      reviewCount: 58,
+      badges: ["Licensed", "Insured"],
+      distanceMiles: 4.2,
+    },
+    {
+      id: "pr_2",
+      name: "Comfort Meals Co.",
+      city: "Redmond",
+      state: "WA",
+      services: ["meal-prep", "housekeeping"],
+      hourlyRate: 35,
+      perMileRate: null,
+      ratingAverage: 4.5,
+      reviewCount: 31,
+      badges: ["Background Checked"],
+      distanceMiles: 11.3,
+    },
+  ];
   // Caregiver favorites (for families; local fallback for others)
   const CG_FAV_KEY = 'marketplace:caregiver-favorites:v1';
   const [caregiverFavorites, setCaregiverFavorites] = useState<Set<string>>(new Set());
@@ -613,6 +761,10 @@ export default function MarketplacePage() {
   useEffect(() => {
     // Load marketplace categories once
     const loadCategories = async () => {
+      if (showMock) {
+        setCategories(MOCK_CATEGORIES);
+        return;
+      }
       try {
         const res = await fetch("/api/marketplace/categories");
         const json = await res.json();
@@ -622,7 +774,7 @@ export default function MarketplacePage() {
       }
     };
     loadCategories();
-  }, []);
+  }, [showMock]);
 
   // Saved searches: load/save helpers
   useEffect(() => {
@@ -666,6 +818,13 @@ export default function MarketplacePage() {
     const run = async () => {
       setCaregiversLoading(true);
       try {
+        if (showMock) {
+          setCaregivers(MOCK_CAREGIVERS);
+          setCgTotal(MOCK_CAREGIVERS.length);
+          setCgHasMoreSvr(false);
+          setCgCursor(null);
+          return;
+        }
         const params = new URLSearchParams();
         if (debouncedSearch) params.set("q", debouncedSearch);
         if (debouncedCity) params.set("city", debouncedCity);
@@ -704,7 +863,7 @@ export default function MarketplacePage() {
     return () => {
       controller.abort();
     };
-  }, [activeTab, debouncedSearch, debouncedCity, debouncedState, specialties, settings, careTypes, debouncedMinRate, debouncedMaxRate, debouncedMinExperience, cgPage, cgSort, cgRadius, cgGeoLat, cgGeoLng, cgCursor]);
+  }, [activeTab, debouncedSearch, debouncedCity, debouncedState, specialties, settings, careTypes, debouncedMinRate, debouncedMaxRate, debouncedMinExperience, cgPage, cgSort, cgRadius, cgGeoLat, cgGeoLng, cgCursor, showMock]);
 
   // Reset caregivers list when non-page filters change
   const cgQueryKey = useMemo(() => JSON.stringify({
@@ -732,6 +891,13 @@ export default function MarketplacePage() {
     const run = async () => {
       setListingsLoading(true);
       try {
+        if (showMock) {
+          setListings(MOCK_LISTINGS);
+          setJobTotal(MOCK_LISTINGS.length);
+          setJobHasMoreSvr(false);
+          setJobCursor(null);
+          return;
+        }
         const params = new URLSearchParams();
         if (debouncedSearch) params.set("q", debouncedSearch);
         if (debouncedCity) params.set("city", debouncedCity);
@@ -771,7 +937,7 @@ export default function MarketplacePage() {
     return () => {
       controller.abort();
     };
-  }, [activeTab, debouncedSearch, debouncedCity, debouncedState, specialties, debouncedZip, settings, careTypes, services, postedByMe, hideClosed, session, jobPage, jobSort, jobRadius, geoLat, geoLng, jobCursor]);
+  }, [activeTab, debouncedSearch, debouncedCity, debouncedState, specialties, debouncedZip, settings, careTypes, services, postedByMe, hideClosed, session, jobPage, jobSort, jobRadius, geoLat, geoLng, jobCursor, showMock]);
 
   // Reset jobs list when non-page filters change
   const jobQueryKey = useMemo(() => JSON.stringify({
@@ -801,6 +967,13 @@ export default function MarketplacePage() {
     const run = async () => {
       setProvidersLoading(true);
       try {
+        if (showMock) {
+          setProviders(MOCK_PROVIDERS);
+          setProviderTotal(MOCK_PROVIDERS.length);
+          setProviderHasMoreSvr(false);
+          setProviderCursor(null);
+          return;
+        }
         const params = new URLSearchParams();
         if (debouncedSearch) params.set("q", debouncedSearch);
         if (debouncedCity) params.set("city", debouncedCity);
@@ -833,7 +1006,7 @@ export default function MarketplacePage() {
     return () => {
       controller.abort();
     };
-  }, [activeTab, debouncedSearch, debouncedCity, debouncedState, providerServices, providerPage, providerSort, prRadius, prGeoLat, prGeoLng, providerCursor]);
+  }, [activeTab, debouncedSearch, debouncedCity, debouncedState, providerServices, providerPage, providerSort, prRadius, prGeoLat, prGeoLng, providerCursor, showMock]);
 
   // Reset providers list when non-page filters change
   const prQueryKey = useMemo(() => JSON.stringify({
@@ -1721,7 +1894,7 @@ export default function MarketplacePage() {
                 </div>
               ) : (
                 <>
-                  {session?.user?.role === "CAREGIVER" && (
+                  {!showMock && session?.user?.role === "CAREGIVER" && (
                     <div className="mb-6">
                       <RecommendedListings />
                       <div className="my-4" />

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -81,6 +81,10 @@ export default function SearchPage() {
   // Search params and router for query handling
   const searchParams = useSearchParams();
   const router = useRouter();
+  // Environment-gated mock data toggle (reuse dashboard flag)
+  const showMock = ["1", "true", "yes", "on"].includes(
+    String(process.env.NEXT_PUBLIC_SHOW_MOCK_DASHBOARD || "").toLowerCase()
+  );
   
   // State for view type (map or list)
   const [viewType, setViewType] = useState<"list" | "grid" | "map">("grid");
@@ -177,6 +181,61 @@ export default function SearchPage() {
 
   // Ref for suggestions dropdown
   const suggestionsRef = useRef<HTMLDivElement>(null);
+
+  // Mock homes for demo mode
+  const MOCK_HOMES: SearchResultItem[] = [
+    {
+      id: "home_1",
+      name: "Sunrise Memory Care",
+      description: "Specialized memory care community with secure gardens and art therapy.",
+      address: { street: "123 Maple St", city: "San Francisco", state: "CA", zipCode: "94109" },
+      careLevel: [CareLevel.MEMORY_CARE],
+      priceRange: { min: 5500, max: 7200, formattedMin: "$5,500", formattedMax: "$7,200" },
+      capacity: 80,
+      availability: 5,
+      gender: "ALL",
+      amenities: ["Secure Memory Wing", "Garden/Patio", "Art Therapy"],
+      imageUrl: "https://placehold.co/1200x800?text=Sunrise",
+      operator: { name: "Sunrise Care", email: "info@sunrise.example" },
+      aiMatchScore: 92,
+      aiMatchFactors: { careLevel: 95, budget: 80, location: 88, amenities: 90, gender: 100, social: 85, medical: 90 },
+      aiMatchWeights: { careLevel: 30, budget: 20, location: 20, amenities: 15, gender: 5, social: 5, medical: 5 },
+    },
+    {
+      id: "home_2",
+      name: "Bayview Assisted Living",
+      description: "Waterfront views, transportation, and daily activities.",
+      address: { street: "200 Ocean Ave", city: "San Francisco", state: "CA", zipCode: "94112" },
+      careLevel: [CareLevel.ASSISTED, CareLevel.INDEPENDENT],
+      priceRange: { min: 3800, max: 5200, formattedMin: "$3,800", formattedMax: "$5,200" },
+      capacity: 120,
+      availability: 12,
+      gender: "ALL",
+      amenities: ["Transportation", "Activity Room", "Garden/Patio"],
+      imageUrl: "https://placehold.co/1200x800?text=Bayview",
+      operator: { name: "Bayview Communities", email: "hello@bayview.example" },
+      aiMatchScore: 86,
+      aiMatchFactors: { careLevel: 85, budget: 88, location: 82, amenities: 80, gender: 100, social: 90, medical: 70 },
+      aiMatchWeights: { careLevel: 25, budget: 25, location: 20, amenities: 15, gender: 5, social: 5, medical: 5 },
+    },
+    {
+      id: "home_3",
+      name: "Cedar Grove Senior Living",
+      description: "Cozy community with private rooms and pet-friendly policy.",
+      address: { street: "50 Cedar Ln", city: "Oakland", state: "CA", zipCode: "94610" },
+      careLevel: [CareLevel.INDEPENDENT, CareLevel.ASSISTED],
+      priceRange: { min: 3200, max: 4600, formattedMin: "$3,200", formattedMax: "$4,600" },
+      capacity: 60,
+      availability: 2,
+      gender: "ALL",
+      amenities: ["Private Rooms", "Pet Friendly", "Housekeeping"],
+      imageUrl: "https://placehold.co/1200x800?text=Cedar+Grove",
+      operator: { name: "Cedar Grove Ops", email: "contact@cedar.example" },
+      aiMatchScore: 78,
+      aiMatchFactors: { careLevel: 75, budget: 84, location: 70, amenities: 76, gender: 100, social: 72, medical: 60 },
+      aiMatchWeights: { careLevel: 25, budget: 25, location: 20, amenities: 15, gender: 5, social: 5, medical: 5 },
+    },
+  ];
 
   // Handle filter changes
   const handleFilterChange = (name: string, value: any) => {
@@ -312,6 +371,34 @@ export default function SearchPage() {
     setIsLoading(true);
     
     try {
+      if (showMock) {
+        const page = params.page || 1;
+        const limit = params.limit || 10;
+        const start = (page - 1) * limit;
+        const slice = MOCK_HOMES.slice(start, start + limit);
+        setSearchResponse({
+          success: true,
+          query: {
+            text: params.query || '',
+            location: params.location || null,
+            careLevels: params.careLevels || null,
+            priceRange: params.priceMin || params.priceMax
+              ? { min: params.priceMin?.toString() || null, max: params.priceMax?.toString() || null }
+              : null,
+            gender: params.gender || 'ALL',
+            availability: !!params.availability,
+            amenities: params.amenities || null,
+          },
+          pagination: {
+            page,
+            limit,
+            totalResults: MOCK_HOMES.length,
+            totalPages: Math.max(1, Math.ceil(MOCK_HOMES.length / limit)),
+          },
+          results: slice,
+        });
+        return;
+      }
       const response = await searchHomes(params);
       setSearchResponse(response);
     } catch (error) {


### PR DESCRIPTION
Droid-assisted PR.

What:
- Add environment-gated mock data across site (marketplace: categories/caregivers/jobs/providers; search: homes with AI match data)
- Reuse existing flag: NEXT_PUBLIC_SHOW_MOCK_DASHBOARD
- Hide RecommendedListings in mock mode to avoid server calls

Why:
- Enable demos and dev without live backend dependencies

Validation:
- Clean build (Next 14), lint warnings limited to exhaustive-deps for mock constants
- Local manual verify pages render with mock data when flag is set