### PR TITLE
feat: runtime mock toggle via /api/runtime/mocks (marketplace + search)

### DIFF
--- a/src/app/api/runtime/mocks/route.ts
+++ b/src/app/api/runtime/mocks/route.ts
@@ -1,0 +1,14 @@
+ import { NextResponse } from "next/server";
+
+export async function GET() {
+  const raw = (process.env.SHOW_SITE_MOCKS || process.env.NEXT_PUBLIC_SHOW_MOCK_DASHBOARD || "").toString().toLowerCase();
+  const show = ["1", "true", "yes", "on"].includes(raw);
+  return new NextResponse(JSON.stringify({ show }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      // ensure we always re-evaluate at request time
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -68,10 +68,22 @@ export default function MarketplacePage() {
   const searchParams = useSearchParams();
   const didInitFromUrl = useRef(false);
 
-  // Environment-gated mock data toggle (reuse dashboard flag)
-  const showMock = ["1", "true", "yes", "on"].includes(
-    String(process.env.NEXT_PUBLIC_SHOW_MOCK_DASHBOARD || "").toLowerCase()
-  );
+  // Runtime mock toggle fetched from API (works in Docker/runtime envs)
+  const [showMock, setShowMock] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/runtime/mocks', { cache: 'no-store' });
+        if (!res.ok) return;
+        const j = await res.json();
+        if (!cancelled) setShowMock(!!j?.show);
+      } catch {
+        if (!cancelled) setShowMock(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   // Include "providers" as a valid tab option
   const [activeTab, setActiveTab] = useState<"jobs" | "caregivers" | "providers">(

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -81,10 +81,22 @@ export default function SearchPage() {
   // Search params and router for query handling
   const searchParams = useSearchParams();
   const router = useRouter();
-  // Environment-gated mock data toggle (reuse dashboard flag)
-  const showMock = ["1", "true", "yes", "on"].includes(
-    String(process.env.NEXT_PUBLIC_SHOW_MOCK_DASHBOARD || "").toLowerCase()
-  );
+  // Runtime mock toggle fetched from API
+  const [showMock, setShowMock] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/runtime/mocks', { cache: 'no-store' });
+        if (!res.ok) return;
+        const j = await res.json();
+        if (!cancelled) setShowMock(!!j?.show);
+      } catch {
+        if (!cancelled) setShowMock(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
   
   // State for view type (map or list)
   const [viewType, setViewType] = useState<"list" | "grid" | "map">("grid");


### PR DESCRIPTION
Summary\n- Add /api/runtime/mocks to read SHOW_SITE_MOCKS or NEXT_PUBLIC_SHOW_MOCK_DASHBOARD at request time with no-store cache\n- Update marketplace and search pages to fetch toggle at runtime (client) instead of build-time NEXT_PUBLIC_* env\n\nWhy\nRender Docker only injects env vars at runtime; NEXT_PUBLIC_* are inlined at build, so production didn’t see toggles. This removes build-time dependency.\n\nHow to use\n- Set SHOW_SITE_MOCKS=1 (or NEXT_PUBLIC_SHOW_MOCK_DASHBOARD=1) in Render env. No rebuild required; changes take effect on next request.\n\nValidation\n- npm ci, lint OK (warnings: exhaustive-deps on mock constants), build OK\n- Manual checks: pages render; when API returns show=true, mock data appears and RecommendedListings hidden.\n\nNotes\n- Keeps SSR stable; toggle fetched client-side to avoid absolute URL issues.\n\nDroid-assisted