### PR TITLE
fix(mock): send cookies when checking runtime mock toggle (marketplace + search)

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -74,7 +74,7 @@ export default function MarketplacePage() {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch('/api/runtime/mocks', { cache: 'no-store' });
+        const res = await fetch('/api/runtime/mocks', { cache: 'no-store', credentials: 'include' as RequestCredentials });
         if (!res.ok) return;
         const j = await res.json();
         if (!cancelled) setShowMock(!!j?.show);

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -87,7 +87,7 @@ export default function SearchPage() {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch('/api/runtime/mocks', { cache: 'no-store' });
+        const res = await fetch('/api/runtime/mocks', { cache: 'no-store', credentials: 'include' as RequestCredentials });
         if (!res.ok) return;
         const j = await res.json();
         if (!cancelled) setShowMock(!!j?.show);


### PR DESCRIPTION
This PR ensures the client includes HttpOnly cookies when calling /api/runtime/mocks so the cookie-based mock-mode works in production.\n\nChanges:\n- marketplace/page.tsx: fetch('/api/runtime/mocks', { cache: 'no-store', credentials: 'include' })\n- search/page.tsx: same as above\n\nWhy:\n- In prod, the admin toggle sets an HttpOnly 'carelink_mock_mode' cookie. Without credentials, the browser omits it, the API returns {show:false}, and pages don’t switch to mock data.\n\nValidation:\n- npm ci, lint, build, and tests (257/257) all pass locally.\n\nDroid-assisted