### PR TITLE
feat(mocks): public querystring toggle ?mock=1 with cookie + clean redirect [Droid-assisted]

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,11 @@ export default withAuth(
   // `withAuth` augments your Request with the user's token
   function middleware(req) {
     try {
+      const urlObj = req.nextUrl
+      const qsMock = urlObj?.searchParams?.get?.('mock')?.toString().trim().toLowerCase() || '';
+      const qsOn = ['1','true','yes','on'].includes(qsMock);
+      const qsOff = ['0','false','no','off'].includes(qsMock);
+
       // Runtime mock toggle: cookie takes precedence, then env
       const cookieRaw = req.cookies?.get?.('carelink_mock_mode')?.value?.toString().trim().toLowerCase() || '';
       const cookieOn = ['1', 'true', 'yes', 'on'].includes(cookieRaw);
@@ -14,7 +19,28 @@ export default withAuth(
         .trim()
         .toLowerCase();
       const envOn = ['1', 'true', 'yes', 'on'].includes(rawMock);
-      const showMocks = cookieOn || envOn;
+      let showMocks = cookieOn || envOn || qsOn;
+
+      // If query string explicitly toggles mock, set cookie and strip the param
+      if (qsOn || qsOff) {
+        const res = NextResponse.next();
+        try {
+          res.cookies.set('carelink_mock_mode', qsOn ? '1' : '0', {
+            httpOnly: true,
+            sameSite: 'lax',
+            secure: process.env['NODE_ENV'] === 'production',
+            path: '/',
+            maxAge: qsOn ? 60 * 60 * 24 * 7 : 0,
+          });
+        } catch {}
+        // Clean the URL (remove the mock param) while preserving path
+        try {
+          const clean = new URL(req.url);
+          clean.searchParams.delete('mock');
+          return applySecurityHeaders(req, NextResponse.redirect(clean));
+        } catch {}
+        return applySecurityHeaders(req, res);
+      }
 
       // Allow unauthenticated access during E2E runs (never in production)
       if (process.env['NODE_ENV'] !== 'production' && process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1') {
@@ -67,12 +93,14 @@ export default withAuth(
         try {
           const cookieRaw = req?.cookies?.get?.('carelink_mock_mode')?.value?.toString().trim().toLowerCase() || '';
           const cookieOn = ['1', 'true', 'yes', 'on'].includes(cookieRaw);
+          const qsMock = req?.nextUrl?.searchParams?.get?.('mock')?.toString().trim().toLowerCase() || '';
+          const qsOn = ['1','true','yes','on'].includes(qsMock);
           const rawMock = (process.env['SHOW_SITE_MOCKS'] || process.env['NEXT_PUBLIC_SHOW_MOCK_DASHBOARD'] || '')
             .toString()
             .trim()
             .toLowerCase();
           const envOn = ['1', 'true', 'yes', 'on'].includes(rawMock);
-          const showMocks = cookieOn || envOn;
+          const showMocks = cookieOn || envOn || qsOn;
           if (showMocks) {
             const pathname = req?.nextUrl?.pathname || '';
             if (pathname === '/' || pathname === '/search' || pathname.startsWith('/marketplace')) {


### PR DESCRIPTION
Adds querystring-based toggle in middleware to enable mock mode for public routes without admin login.\n\nKey changes:\n- Parse ?mock=1|0 and set HttpOnly carelink_mock_mode cookie\n- Redirect to clean URL after setting\n- Treat cookie/env/qs as enabling condition for public /marketplace and /search\n\nValidation:\n- npm ci, lint, build all pass\n- Middleware compiled successfully\n\nAfter merge:\n- Merge main into chore/render-staging-migrations to deploy to Render.\n- Test: https://carelinkai.onrender.com/marketplace?mock=1 and /search?mock=1