### PR TITLE
fix(ui): move job favorite button to top-left to avoid text overlap (fix(ui): move job favorite button to top-left to avoid text overlap (Droid-assisted)This moves the job favorite button from bottom-left to top-left so it never overlaps the job description or the Quick apply button. Lint, tests (257), and build all passed locally.Includes:…

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -1794,7 +1794,7 @@ export default function MarketplacePage() {
                           onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleJobFavorite(job.id); }}
                           aria-label={jobFavorites.has(job.id) ? 'Unfavorite job' : 'Favorite job'}
                           aria-pressed={jobFavorites.has(job.id)}
-                          className="absolute left-3 bottom-3 z-10 inline-flex items-center justify-center h-8 w-8 rounded-full bg-white/90 border hover:bg-white"
+                          className="absolute left-3 top-3 z-10 inline-flex items-center justify-center h-8 w-8 rounded-full bg-white/90 border hover:bg-white"
                           title={jobFavorites.has(job.id) ? 'Unfavorite' : 'Favorite'}
                         >
                           <svg viewBox="0 0 24 24" className={`h-5 w-5 ${jobFavorites.has(job.id) ? 'text-rose-600' : 'text-gray-400'}`} fill={jobFavorites.has(job.id) ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">


### PR DESCRIPTION
…Droid-assisted)