### PR TITLE
Marketplace: display distance on provider cards when radius filtering

### DIFF
--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -845,7 +845,12 @@ export default function MarketplacePage() {
                         </div>
                         <div>
                           <h3 className="font-semibold text-gray-900">{p.name}</h3>
-                          <div className="text-sm text-gray-600">{[p.city, p.state].filter(Boolean).join(", ")}</div>
+                          <div className="text-sm text-gray-600">
+                            {[p.city, p.state].filter(Boolean).join(", ")}
+                            {typeof p.distanceMiles === 'number' && isFinite(p.distanceMiles) && (
+                              <span className="ml-2 text-gray-500">• {p.distanceMiles.toFixed(1)} mi</span>
+                            )}
+                          </div>
                         </div>
                       </div>
                       <div className="flex items-center text-sm mb-2">


### PR DESCRIPTION
Droid-assisted PR.

Summary
- Shows distance on provider cards when radius filter is active
- Complements providers radius filter + API distanceMiles field

Quality
- Lint: clean
- Build: pass
- Tests: 21 suites, 237 tests — all passing

Notes
- Scope: UI only
- Safe to merge; validated on Next 14 build
