### PR TITLE
Fix: provider detail fetch uses absolute URL (server component)

### DIFF
--- a/src/app/marketplace/providers/[id]/page.tsx
+++ b/src/app/marketplace/providers/[id]/page.tsx
@@ -24,8 +24,13 @@ type Provider = {
 
 async function getProviderById(id: string): Promise<Provider | null> {
   try {
-    const cookie = headers().get("cookie") ?? "";
-    const res = await fetch(`/api/marketplace/providers/${encodeURIComponent(id)}`, { headers: { cookie }, cache: 'no-store' });
+    const h = headers();
+    const cookie = h.get("cookie") ?? "";
+    const host = h.get("x-forwarded-host") ?? h.get("host");
+    const proto = h.get("x-forwarded-proto") ?? "http";
+    const base = host ? `${proto}://${host}` : (process.env["NEXT_PUBLIC_APP_URL"] || "http://localhost:3000");
+    const url = `${base}/api/marketplace/providers/${encodeURIComponent(id)}`;
+    const res = await fetch(url, { headers: { cookie }, cache: 'no-store' });
     if (!res.ok) return null;
     const json = await res.json();
     return (json?.data as Provider) || null;


### PR DESCRIPTION
Droid-assisted PR.

Summary
- Fixes provider detail page fetch to use absolute URL on server to avoid URL parse errors

Quality
- Lint: clean
- Build: pass
- Tests: 22 suites, 251 tests — all passing

Notes
- Scope: server component fetch fix only
- Safe to merge; validated on Next 14 build
