### PR TITLE
Fix: absolute URL for matching recommendations fetch (server component)

### DIFF
--- a/src/components/marketplace/RecommendedCaregivers.tsx
+++ b/src/components/marketplace/RecommendedCaregivers.tsx
@@ -29,18 +29,22 @@ export default async function RecommendedCaregivers({ listingId }: { listingId: 
   let applicationStatusByCaregiver: Record<string, string> = {};
   
   try {
-    const cookie = headers().get("cookie") ?? "";
+    const hdrs = headers();
+    const cookie = hdrs.get("cookie") ?? "";
+    const proto = hdrs.get("x-forwarded-proto") ?? "http";
+    const host = hdrs.get("x-forwarded-host") ?? hdrs.get("host");
+    const origin = host ? `${proto}://${host}` : "";
 
     const [recsRes, appsRes] = await Promise.all([
       fetch(
-        `/api/matching/recommendations?target=caregivers&listingId=${listingId}&limit=6`,
+        `${origin}/api/matching/recommendations?target=caregivers&listingId=${listingId}&limit=6`,
         {
           headers: { cookie },
           cache: "no-store",
         }
       ),
       fetch(
-        `/api/marketplace/applications?listingId=${listingId}`,
+        `${origin}/api/marketplace/applications?listingId=${listingId}`,
         {
           headers: { cookie },
           cache: "no-store",


### PR DESCRIPTION
Droid-assisted PR.

Summary
- Fixes server-side fetch in RecommendedCaregivers to use absolute URL to avoid ERR_INVALID_URL

Quality
- Lint: clean
- Build: pass
- Tests: 22 suites — all passing

Notes
- Scope: UI fetch fix; non-breaking
- Safe to merge; validated on Next 14 build
