### PR TITLE
fix(next): relax CSP script-src in production to allow Next.js hydrafix(next): allow Next.js hydration on auth/login via CSP ('unsafe-inline' temp) [Droid-assisted]t…

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const cspBase = [
   "default-src 'self'",
   // Scripts: disallow inline/eval in production; allow Stripe
   isProd
-    ? "script-src 'self' https://js.stripe.com"
+    ? "script-src 'self' 'unsafe-inline' https://js.stripe.com"
     : "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://js.stripe.com",
   // Connections: self + Stripe APIs
   "connect-src 'self' https://api.stripe.com",


### PR DESCRIPTION
…ion on auth/login (temporary until nonce-based CSP)