### PR TITLE
ci(automerge): auto-merge label-based workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,82 @@
+name: Auto-merge labeled PRs
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, labeled, unlabeled, reopened, ready_for_review]
+  check_suite:
+    types: [completed]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  statuses: read
+
+jobs:
+  auto-merge:
+    name: Attempt auto-merge when conditions satisfied
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge if eligible (label=automerge, base=main, checks=success, not draft)
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const OWNER = context.repo.owner;
+            const REPO = context.repo.repo;
+            const TARGET_LABEL = 'automerge';
+            const BASE_BRANCH = 'main';
+
+            async function getOpenPRsForSHA(sha) {
+              const prs = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+                owner: OWNER,
+                repo: REPO,
+                commit_sha: sha,
+              });
+              return prs.filter(pr => pr.state === 'open');
+            }
+
+            async function combinedStatusIsSuccess(sha) {
+              const { data } = await github.rest.repos.getCombinedStatusForRef({
+                owner: OWNER,
+                repo: REPO,
+                ref: sha,
+              });
+              return data.state === 'success';
+            }
+
+            async function attempt(prNumber) {
+              const { data: pr } = await github.rest.pulls.get({ owner: OWNER, repo: REPO, pull_number: prNumber });
+
+              if (pr.base.ref !== BASE_BRANCH) return core.info(`#${pr.number}: skipped (base != ${BASE_BRANCH})`);
+              if (pr.draft) return core.info(`#${pr.number}: skipped (draft)`);
+              const hasLabel = pr.labels.some(l => l.name === TARGET_LABEL);
+              if (!hasLabel) return core.info(`#${pr.number}: skipped (missing label: ${TARGET_LABEL})`);
+
+              const statusesOk = await combinedStatusIsSuccess(pr.head.sha);
+              if (!statusesOk) return core.info(`#${pr.number}: waiting (checks not green)`);
+
+              // Refresh mergeability information
+              const { data: prCheck } = await github.rest.pulls.get({ owner: OWNER, repo: REPO, pull_number: pr.number });
+              if (prCheck.mergeable === false) return core.info(`#${pr.number}: cannot merge (mergeable=false)`);
+
+              try {
+                await github.rest.pulls.merge({ owner: OWNER, repo: REPO, pull_number: pr.number, merge_method: 'merge' });
+                core.notice(`#${pr.number}: merged successfully`);
+              } catch (e) {
+                core.warning(`#${pr.number}: merge attempt failed -> ${e.message}`);
+              }
+            }
+
+            if (context.eventName === 'pull_request_target') {
+              await attempt(context.payload.pull_request.number);
+            } else if (context.eventName === 'check_suite') {
+              const sha = context.payload.check_suite.head_sha;
+              const prs = await getOpenPRsForSHA(sha);
+              for (const pr of prs) {
+                await attempt(pr.number);
+              }
+            } else {
+              core.info('Unsupported event');
+            }


### PR DESCRIPTION
This adds a safe auto-merge workflow:

- Trigger: pull_request_target + check_suite.completed
- Conditions: base=main, label=automerge, not draft, all checks green
- Action: merges with 'merge' method using GITHUB_TOKEN

Usage:
- Add label 'automerge' to any PR targeting main. The workflow will merge once CI is passing and branch protection permits.

Droid-assisted.