### PR TITLE
ci(header-health): add permissions + sanity step; stabilize run logs [Droid-assisted]

### DIFF
--- a/.github/workflows/header-health.yml
+++ b/.github/workflows/header-health.yml
@@ -7,15 +7,22 @@ on:
     branches: [ main ]
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   check-headers:
     name: Validate Set-Cookie headers on production
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
         endpoint: ["/", "/api/auth/session"]
     steps:
+      - name: Sanity
+        run: |
+          echo "Runner OK"; uname -a; curl --version | head -n1
       - name: Fetch response headers
         id: fetch
         run: |


### PR DESCRIPTION
Adds explicit permissions, timeout, and an initial 'Sanity' step to ensure logs are captured and avoid 0s failures. Keeps robust cookie checks.