### PR TITLE
fix(api): GET /api/residents with RBAC, filters, pagination, CSV

### DIFF
--- a/src/app/api/residents/route.ts
+++ b/src/app/api/residents/route.ts
@@ -7,6 +7,95 @@ import { prisma } from '@/lib/prisma';
 import { requireOperatorOrAdmin } from '@/lib/rbac';
 import { createAuditLogFromRequest } from '@/lib/audit';
 
+// GET /api/residents
+// Lists residents for operators (scoped to their homes) or all for admins.
+// Supports filters: q (name contains), status, homeId, familyId
+// Pagination: limit (default 50, max 200), cursor (resident.id)
+// CSV export: format=csv
+export async function GET(req: NextRequest) {
+  try {
+    const { session, error } = await requireOperatorOrAdmin();
+    if (error) return error;
+    const userId = (session as any)?.user?.id as string | undefined;
+    const role = (session as any)?.user?.role as string | undefined;
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { searchParams } = new URL(req.url);
+    const q = (searchParams.get('q') || '').trim();
+    const status = (searchParams.get('status') || '').trim();
+    const homeId = (searchParams.get('homeId') || '').trim();
+    const familyId = (searchParams.get('familyId') || '').trim();
+    const cursor = (searchParams.get('cursor') || '').trim();
+    const format = (searchParams.get('format') || '').trim().toLowerCase();
+    let limit = parseInt(searchParams.get('limit') || '50', 10);
+    if (Number.isNaN(limit) || limit <= 0) limit = 50;
+    if (limit > 200) limit = 200;
+
+    // Compute operator scope if not admin
+    let allowedHomeIds: string[] | null = null;
+    if (role !== 'ADMIN') {
+      const operator = await prisma.operator.findUnique({ where: { userId }, select: { id: true } });
+      if (!operator) return NextResponse.json({ items: [], nextCursor: null });
+      const homes = await prisma.assistedLivingHome.findMany({ where: { operatorId: operator.id }, select: { id: true } });
+      allowedHomeIds = homes.map(h => h.id);
+      if (allowedHomeIds.length === 0) {
+        return NextResponse.json({ items: [], nextCursor: null });
+      }
+    }
+
+    const where: any = {};
+    if (q) {
+      where.OR = [
+        { firstName: { contains: q, mode: 'insensitive' } },
+        { lastName: { contains: q, mode: 'insensitive' } },
+      ];
+    }
+    if (status) where.status = status as any;
+    if (homeId) where.homeId = homeId;
+    if (familyId) where.familyId = familyId;
+    if (allowedHomeIds) {
+      // Show only residents in operator-managed homes; allow nulls only when explicitly filtered by homeId=null (not supported here)
+      where.homeId = where.homeId ? where.homeId : { in: allowedHomeIds };
+    }
+
+    const queryOpts: any = {
+      where,
+      take: limit + 1, // over-fetch to determine next cursor
+      orderBy: { id: 'asc' },
+      select: { id: true, firstName: true, lastName: true, status: true },
+    };
+    if (cursor) queryOpts.cursor = { id: cursor };
+    if (cursor) queryOpts.skip = 1;
+
+    const rows = await prisma.resident.findMany(queryOpts);
+    let nextCursor: string | null = null;
+    let items = rows;
+    if (rows.length > limit) {
+      const next = rows[rows.length - 1];
+      nextCursor = next.id;
+      items = rows.slice(0, limit);
+    }
+
+    if (format === 'csv') {
+      const header = 'id,firstName,lastName,status\n';
+      const body = items.map(r => `${r.id},${JSON.stringify(r.firstName).slice(1, -1)},${JSON.stringify(r.lastName).slice(1, -1)},${r.status}`).join('\n');
+      const csv = header + body + (body ? '\n' : '');
+      return new NextResponse(csv, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Cache-Control': 'no-store',
+        },
+      });
+    }
+
+    return NextResponse.json({ items, nextCursor }, { status: 200 });
+  } catch (e) {
+    console.error('Residents GET error', e);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+
 async function assertOperatorHomeOwnership(userId: string, homeId?: string | null) {
   if (!homeId) return true; // Allow creating unassigned residents
   const operator = await prisma.operator.findUnique({ where: { userId } });


### PR DESCRIPTION
Droid-assisted\n\nAdds GET /api/residents endpoint.\n- RBAC: operators scoped to their homes; admins see all\n- Filters: q, status, homeId, familyId\n- Pagination: cursor + limit (50 default, 200 max)\n- CSV export: format=csv\n\nAlso keeps POST route unchanged.\n\nQA:\n- Type-check/build to run in CI\n- Quality + E2E expected to pass\n\nOn merge: fixes operator residents page error and enables CSV export.