### PR TITLE
Operator Residents: Transfer action UI (Droid-assisted)

### DIFF
--- a/src/app/operator/residents/page.tsx
+++ b/src/app/operator/residents/page.tsx
@@ -106,7 +106,7 @@ export default async function ResidentsPage({ searchParams }: { searchParams?: {
                 <td className="px-4 py-2 text-sm text-neutral-800">{r.firstName} {r.lastName}</td>
                 <td className="px-4 py-2 text-sm text-neutral-700"><StatusPill status={r.status} /></td>
                 <td className="px-4 py-2 text-right flex items-center gap-3 justify-end">
-                  <InlineActions id={r.id} status={r.status} />
+                  <InlineActions id={r.id} status={r.status} homes={homes} />
                   <Link className="text-primary-600 hover:underline text-sm" href={`/operator/residents/${r.id}`}>Details</Link>
                 </td>
               </tr>


### PR DESCRIPTION
Adds Transfer action with operator home selector to Residents list. Utilizes existing POST /api/residents/[id]/transfer with RBAC and audit. Includes:
- Pass operator homes into InlineActions
- Inline popover select to choose target home and execute transfer

Assumptions:
- Operators can transfer only within their own homes (enforced by API)
- Effective date defaults to now; stored via CareTimelineEvent when provided

Quality checks:
- Lint, type-check, tests, and build passed locally

