### PR TITLE
E2E: expand residents coverage (transfer + summary + contacts)

### DIFF
--- a/.github/workflows/e2e-family.yml
+++ b/.github/workflows/e2e-family.yml
@@ -76,8 +76,12 @@ jobs:
             DATABASE_URL=$DATABASE_URL 
             npm run start
         run: |
-          # Run only the stabilized transfer spec for this PR
-          npx playwright test e2e/residents-transfer.spec.ts --workers=1 --reporter=line,html --trace on --timeout=60000
+          # Run stabilized set: transfer, summary, contacts
+          npx playwright test \
+            e2e/residents-transfer.spec.ts \
+            e2e/residents-summary.spec.ts \
+            e2e/residents-contacts.spec.ts \
+            --workers=1 --reporter=line,html --trace on --timeout=60000
 
       - name: Upload Playwright test artifacts (Residents) (always)
         if: always()


### PR DESCRIPTION
Droid-assisted: Expands the Residents job to include summary and contacts specs alongside the stabilized transfer spec. Uses prod server (npm run start) with dev endpoints enabled; single worker for stability.