### PR TITLE
E2E: expand residents coverage (documents + compliance)

### DIFF
--- a/.github/workflows/e2e-family.yml
+++ b/.github/workflows/e2e-family.yml
@@ -76,11 +76,13 @@ jobs:
             DATABASE_URL=$DATABASE_URL 
             npm run start
         run: |
-          # Run stabilized set: transfer, summary, contacts
+          # Run expanded set: transfer, summary, contacts, documents, compliance
           npx playwright test \
             e2e/residents-transfer.spec.ts \
             e2e/residents-summary.spec.ts \
             e2e/residents-contacts.spec.ts \
+            e2e/residents-documents.spec.ts \
+            e2e/residents-compliance.spec.ts \
             --workers=1 --reporter=line,html --trace on --timeout=60000
 
       - name: Upload Playwright test artifacts (Residents) (always)


### PR DESCRIPTION
Droid-assisted: Adds residents-documents and residents-compliance specs to the Residents job. Keeps single worker and production server for stability.