### PR TITLE
ci(e2e): re-enable full Residents suite [Droid-assisted]

### DIFF
--- a/.github/workflows/e2e-family.yml
+++ b/.github/workflows/e2e-family.yml
@@ -76,8 +76,14 @@ jobs:
             DATABASE_URL=$DATABASE_URL 
             npm run start
         run: |
-          # Temporarily scope to assessments/incidents specs to stabilize update flow
+          # Re-enable full Residents suite now that it is stable
           npx playwright test \
+            e2e/residents-transfer.spec.ts \
+            e2e/residents-summary.spec.ts \
+            e2e/residents-contacts.spec.ts \
+            e2e/residents-documents.spec.ts \
+            e2e/residents-compliance.spec.ts \
+            e2e/residents-csv-export.spec.ts \
             e2e/residents-assessments-incidents-edit.spec.ts \
             e2e/residents-assessments-incidents-update.spec.ts \
             --workers=1 --reporter=line,html --trace on --timeout=60000


### PR DESCRIPTION
Re-enables the entire Residents E2E suite now that assessments/incidents flows are stable.\n\n- Runs on production server for stability\n- Uses single worker\n- Explicit spec list (transfer, summary, contacts, documents, compliance, csv-export, edit, update)\n\nPlease review.