### PR TITLE
CI: speed up E2E by caching Playwright browsers and Next.js build cache

### DIFF
--- a/.github/workflows/e2e-family.yml
+++ b/.github/workflows/e2e-family.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Get Playwright version
         id: pw-version
         shell: bash
-        run: echo "version=$(node -p \"require('playwright/package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          v=$(npx playwright --version | awk '{print $2}')
+          echo "version=$v" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -169,7 +171,9 @@ jobs:
       - name: Get Playwright version
         id: pw-version
         shell: bash
-        run: echo "version=$(node -p \"require('playwright/package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          v=$(npx playwright --version | awk '{print $2}')
+          echo "version=$v" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4


### PR DESCRIPTION
Droid-assisted: Adds actions/cache for Playwright browsers (~/.cache/ms-playwright) and Next.js .next/cache for faster E2E runs. No code changes; workflow-only.