### PR TITLE
E2E: shared helpers + lifecycle spec refactor

### DIFF
--- a/e2e/_helpers.ts
+++ b/e2e/_helpers.ts
@@ -1,0 +1,64 @@
+import { Page, APIRequestContext, expect } from '@playwright/test';
+
+export async function upsertOperator(request: APIRequestContext, email: string) {
+  await request.post('/api/dev/upsert-operator', { data: { email, companyName: 'Ops', homes: [{ name: 'Home A', capacity: 4 }] } });
+}
+
+export async function loginAs(page: Page, email: string) {
+  await page.goto('/');
+  await page.evaluate(async (e) => {
+    await fetch(`${location.origin}/api/dev/login`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: e }),
+    });
+  }, email);
+}
+
+export async function getFirstHomeId(page: Page) {
+  return await page.evaluate(async () => {
+    const r = await fetch(`${location.origin}/api/operator/homes`, { credentials: 'include' });
+    const j = await r.json();
+    return (j.homes?.[0]?.id as string) || null;
+  });
+}
+
+export async function getFamilyId(page: Page) {
+  const fam = await page.evaluate(async () => (await fetch(`${location.origin}/api/user/family`, { credentials: 'include' })).json());
+  return fam.familyId as string;
+}
+
+export async function createResident(page: Page, args: { familyId: string; homeId: string | null; firstName?: string; lastName?: string }) {
+  const id = await page.evaluate(async (a) => {
+    const r = await fetch(`${location.origin}/api/residents`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
+      body: JSON.stringify({ familyId: a.familyId, homeId: a.homeId, firstName: a.firstName || 'E2E', lastName: a.lastName || 'Resident', dateOfBirth: '1940-01-01', gender: 'OTHER', status: 'ACTIVE' }),
+    });
+    const j = await r.json();
+    return j.id as string;
+  }, args);
+  return id;
+}
+
+export async function openResidentDetail(page: Page, residentId: string) {
+  await page.goto(`/operator/residents/${residentId}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByText('Status:')).toBeVisible({ timeout: 10000 });
+}
+
+export async function discharge(page: Page) {
+  await page.getByRole('button', { name: 'Discharge' }).click();
+  await expect(page.getByText('Status: DISCHARGED')).toBeVisible({ timeout: 15000 });
+}
+
+export async function admit(page: Page) {
+  await page.getByRole('button', { name: 'Admit' }).click();
+  await expect(page.getByText('Status: ACTIVE')).toBeVisible({ timeout: 15000 });
+}
+
+export async function editResidentName(page: Page, newFirst: string) {
+  await page.getByRole('link', { name: 'Edit' }).click();
+  const first = page.getByPlaceholder('First name');
+  await first.waitFor({ state: 'visible', timeout: 10000 });
+  await first.fill(newFirst);
+  await page.getByRole('button', { name: 'Save Changes' }).click();
+  await expect(page.getByRole('heading', { name: new RegExp(newFirst) })).toBeVisible({ timeout: 15000 });
+}

--- a/e2e/residents-lifecycle.spec.ts
+++ b/e2e/residents-lifecycle.spec.ts
@@ -1,50 +1,15 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
+import { upsertOperator, loginAs, getFirstHomeId, getFamilyId, createResident, openResidentDetail, discharge, admit, editResidentName } from './_helpers';
 
 test('resident lifecycle: discharge -> admit -> edit', async ({ page, request }) => {
-  await page.goto('/');
-
-  // Seed operator and login (browser-context for cookies)
-  await request.post('/api/dev/upsert-operator', { data: { email: 'op-life@example.com', companyName: 'Ops Life', homes: [{ name: 'Life Home', capacity: 4 }] } });
-  await page.evaluate(async () => {
-    await fetch(`${location.origin}/api/dev/login`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email: 'op-life@example.com' }) });
-  });
-
-  // Resolve operator home id
-  const homeId = await page.evaluate(async () => {
-    const r = await fetch(`${location.origin}/api/operator/homes`, { credentials: 'include' });
-    const j = await r.json();
-    return (j.homes?.[0]?.id as string) || null;
-  });
-
-  // Create resident (ACTIVE)
-  const family = await page.evaluate(async () => (await fetch(`${location.origin}/api/user/family`, { credentials: 'include' })).json());
-  const residentId = await page.evaluate(async (args) => {
-    const r = await fetch(`${location.origin}/api/residents`, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'include',
-      body: JSON.stringify({ familyId: args.familyId, homeId: args.homeId, firstName: 'Lifecycle', lastName: 'Test', dateOfBirth: '1945-03-03', gender: 'OTHER', status: 'ACTIVE' })
-    });
-    const j = await r.json();
-    return j.id as string;
-  }, { familyId: (family.familyId as string), homeId });
-
-  // Open detail
-  await page.goto(`/operator/residents/${residentId}`, { waitUntil: 'domcontentloaded' });
-  await expect(page.getByText('Status: ACTIVE')).toBeVisible({ timeout: 10000 });
-
-  // Discharge
-  await page.getByRole('button', { name: 'Discharge' }).click();
-  await expect(page.getByText('Status: DISCHARGED')).toBeVisible({ timeout: 15000 });
-
-  // Admit
-  await page.getByRole('button', { name: 'Admit' }).click();
-  await expect(page.getByText('Status: ACTIVE')).toBeVisible({ timeout: 15000 });
-
-  // Edit basic info
-  await page.getByRole('link', { name: 'Edit' }).click();
-  const firstName = page.getByPlaceholder('First name');
-  await firstName.waitFor({ state: 'visible', timeout: 10000 });
-  await firstName.fill('Lifecycle-Updated');
-  await page.getByRole('button', { name: 'Save Changes' }).click();
-  // After save, page navigates back to detail
-  await expect(page.getByRole('heading', { name: /Lifecycle-Updated/ })).toBeVisible({ timeout: 15000 });
+  const email = 'op-life@example.com';
+  await upsertOperator(request, email);
+  await loginAs(page, email);
+  const homeId = await getFirstHomeId(page);
+  const familyId = await getFamilyId(page);
+  const residentId = await createResident(page, { familyId, homeId, firstName: 'Lifecycle', lastName: 'Test' });
+  await openResidentDetail(page, residentId);
+  await discharge(page);
+  await admit(page);
+  await editResidentName(page, 'Lifecycle-Updated');
 });


### PR DESCRIPTION
Droid-assisted: Adds e2e/_helpers.ts (login, upsert operator, create resident, open detail, discharge/admit, edit name) and refactors residents-lifecycle.spec.ts to use them. No app code changes.