### PR TITLE
CI: shard Residents E2E across 2 parallel jobs (workers=1 per shard)

### DIFF
--- a/.github/workflows/e2e-family.yml
+++ b/.github/workflows/e2e-family.yml
@@ -17,6 +17,10 @@ concurrency:
 jobs:
   e2e-residents:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     timeout-minutes: 45
     services:
       postgres:
@@ -90,7 +94,7 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
-      - name: Run Playwright (Residents core)
+      - name: Run Playwright (Residents core) (shard ${{ matrix.shard }}/2)
         env:
           # Run production server for stability; still enable dev endpoints and use CI DB/secret
           PLAYWRIGHT_WEB_SERVER_CMD: >-
@@ -110,13 +114,13 @@ jobs:
             e2e/residents-csv-export.spec.ts \
             e2e/residents-assessments-incidents-edit.spec.ts \
             e2e/residents-assessments-incidents-update.spec.ts \
-            --workers=1 --reporter=line,html --trace on --timeout=60000
+            --workers=1 --shard=${{ matrix.shard }}/2 --reporter=line,html --trace on --timeout=60000
 
-      - name: Upload Playwright test artifacts (Residents) (always)
+      - name: Upload Playwright test artifacts (Residents shard ${{ matrix.shard }}) (always)
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-test-results-residents
+          name: playwright-test-results-residents-shard-${{ matrix.shard }}
           path: |
             test-results
             playwright-report


### PR DESCRIPTION
Droid-assisted: Introduces matrix sharding (2 shards) for the e2e-residents job using Playwright --shard. Keeps workers=1 per shard to preserve stability while halving wall time.