### PR TITLE
ci(e2e): add nightly scheduled run on main (06:00 UTC)

### DIFF
--- a/.github/workflows/e2e-family.yml
+++ b/.github/workflows/e2e-family.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "**" ]
   workflow_dispatch:
+  schedule:
+    # Nightly at 06:00 UTC on default branch
+    - cron: '0 6 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
Droid-assisted: Adds a cron schedule to run the existing E2E (Residents + Family split) workflow nightly on the default branch at 06:00 UTC. Keeps push, PR, and manual dispatch triggers intact.