### PR TITLE
Add SSE smoke check to post-deploy synthetics

### DIFF
--- a/.github/workflows/post-deploy-synthetics.yml
+++ b/.github/workflows/post-deploy-synthetics.yml
@@ -50,6 +50,21 @@ jobs:
           done
           echo "All synthetic checks passed."
 
+      - name: Check SSE endpoint (ready event)
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE=https://carelinkai.onrender.com
+          echo "Probing SSE endpoint..."
+          # Read a few lines within timeout and assert 'event: ready' is present
+          OUT=$(curl -sS --max-time 5 "$BASE/api/sse?topics=synthetic" | head -n 5 || true)
+          echo "$OUT"
+          if ! echo "$OUT" | grep -qi "event: ready"; then
+            echo "SSE did not emit 'ready' event within timeout" >&2
+            exit 1
+          fi
+          echo "SSE ready event received."
+
       - name: Synthetic (optional): operator login + create/view resident
         # Allow either repository Variables or Secrets to provide credentials
         if: ${{ (vars.OP_EMAIL != '' && vars.OP_PASSWORD != '') || (secrets.OP_EMAIL != '' && secrets.OP_PASSWORD != '') }}


### PR DESCRIPTION
This PR adds a lightweight SSE smoke check to the post-deploy synthetics workflow.

- Verifies /api/health and key routes
- NEW: Probes /api/sse?topics=synthetic and asserts an initial 'ready' event within 5s
- Keeps checks opt-in via vars.SYNTHETICS_ENABLED or presence of Render deploy secrets

All local checks pass (lint, type-check, tests, build).