### PR TITLE
CI: add repository_dispatch trigger for post-deploy synthetics

### DIFF
--- a/.github/workflows/post-deploy-synthetics.yml
+++ b/.github/workflows/post-deploy-synthetics.yml
@@ -1,6 +1,10 @@
 name: Post Deploy Synthetics
 
-on: [push, workflow_dispatch]
+on:
+  push:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [post-deploy-synthetics]
 
 jobs:
   smoke:


### PR DESCRIPTION
Adds repository_dispatch trigger (type: post-deploy-synthetics) so we can invoke the workflow immediately via API. Keeps push + workflow_dispatch.\n\nAfter merge, I will fire: gh api repos/profyt7/carelinkai/dispatches -f event_type=post-deploy-synthetics\n\nIncludes existing SSE ready probe and optional operator flow using OP_EMAIL/OP_PASSWORD.