### PR TITLE
Synthetics v4: add optional operator login flow

### DIFF
--- a/.github/workflows/post-deploy-synthetics-v4.yml
+++ b/.github/workflows/post-deploy-synthetics-v4.yml
@@ -40,3 +40,57 @@ jobs:
             echo "SSE ready event NOT observed" >&2
             exit 1
           fi
+      - name: Operator login + protected API check (optional)
+        if: ${{ secrets.OP_EMAIL != '' && secrets.OP_PASSWORD != '' }}
+        shell: bash
+        env:
+          BASE_URL: https://carelinkai.onrender.com
+          OP_EMAIL: ${{ secrets.OP_EMAIL }}
+          OP_PASSWORD: ${{ secrets.OP_PASSWORD }}
+        run: |
+          set -euo pipefail
+          workdir=$(mktemp -d)
+          jar="$workdir/cookies.txt"
+
+          echo "Attempting dev login (if enabled) ..."
+          code=$(curl -sS -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" -c "$jar" -b "$jar" "$BASE_URL/api/dev/login" -d "{\"email\":\"$OP_EMAIL\"}" || true)
+          if [ "$code" = "200" ]; then
+            echo "Dev login succeeded"
+          else
+            echo "Dev login not available (code $code). Falling back to credentials login ..."
+
+            # Get CSRF token
+            csrf=$(curl -sS -c "$jar" -b "$jar" -H "Accept: application/json" "$BASE_URL/api/auth/csrf" | python3 -c "import sys,json; print(json.load(sys.stdin).get('csrfToken',''))" || true)
+            if [ -z "${csrf:-}" ]; then
+              echo "Failed to obtain CSRF token" >&2
+              exit 1
+            fi
+
+            # Credentials login via NextAuth
+            resp=$(curl -sS -o /dev/null -w "%{http_code}" -L -c "$jar" -b "$jar" -H "Content-Type: application/x-www-form-urlencoded" \
+              --data-urlencode "csrfToken=$csrf" \
+              --data-urlencode "email=$OP_EMAIL" \
+              --data-urlencode "password=$OP_PASSWORD" \
+              --data-urlencode "callbackUrl=/" \
+              "$BASE_URL/api/auth/callback/credentials" || true)
+            if [ "$resp" != "200" ] && [ "$resp" != "302" ] && [ "$resp" != "303" ]; then
+              echo "Credentials login failed with HTTP $resp" >&2
+              exit 1
+            fi
+          fi
+
+          # Ensure a NextAuth session cookie exists
+          if ! grep -q 'next-auth.session-token' "$jar" && ! grep -q '__Secure-next-auth.session-token' "$jar"; then
+            echo "No NextAuth session cookie found after login" >&2
+            echo "Cookie jar contents:"; cat "$jar" || true
+            exit 1
+          fi
+
+          # Access operator-only endpoint to verify role-based access
+          code=$(curl -sS -o /dev/null -w "%{http_code}" -b "$jar" "$BASE_URL/api/operator/homes" || true)
+          echo "operator homes -> $code"
+          if [ "$code" != "200" ]; then
+            echo "Operator endpoint access failed ($code)" >&2
+            exit 1
+          fi
+          echo "Operator login and protected API check passed"


### PR DESCRIPTION
Adds an optional operator authentication step to post-deploy synthetics v4.\n\n- Tries /api/dev/login when enabled\n- Falls back to NextAuth credentials with CSRF\n- Verifies access to /api/operator/homes\n\nDroid-assisted.