### PR TITLE
Synthetics: manual wrapper uses repo@main ref [Droid-assisted]

### DIFF
--- a/.github/workflows/post-deploy-synthetics-manual.yml
+++ b/.github/workflows/post-deploy-synthetics-manual.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   run:
-    uses: ./.github/workflows/post-deploy-synthetics-reusable.yml
+    uses: profyt7/carelinkai/.github/workflows/post-deploy-synthetics-reusable.yml@main
     with:
       simulate_failure: ${{ inputs.simulate_failure }}
     secrets: inherit


### PR DESCRIPTION
Switch manual wrapper to reference the reusable workflow via repo@main instead of local path. This should address the 0-jobs UI issue on manual runs.\n\n[Droid-assisted]