### PR TITLE
Synthetics: add kickoff job to manual wrapper [Droid-assisted]

### DIFF
--- a/.github/workflows/post-deploy-synthetics-manual.yml
+++ b/.github/workflows/post-deploy-synthetics-manual.yml
@@ -15,6 +15,12 @@ permissions:
   issues: write
 
 jobs:
+  kickoff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Kickoff
+        run: echo "Manual wrapper started for ${{ github.repository }}@${{ github.ref_name }} (${GITHUB_SHA})"
+
   run:
     uses: profyt7/carelinkai/.github/workflows/post-deploy-synthetics-reusable.yml@main
     with:


### PR DESCRIPTION
Adds a small kickoff job to the manual wrapper so at least one native job is visible in the UI. The main 'run' job still calls the reusable workflow via repo@main.\n\nThis should mitigate the 0-jobs visibility issue when the called workflow fails early.\n\n[Droid-assisted]