### PR TITLE
Synthetics: fix notifier condition to depend on ping failure [Droid-assisted]

### DIFF
--- a/.github/workflows/post-deploy-synthetics-reusable.yml
+++ b/.github/workflows/post-deploy-synthetics-reusable.yml
@@ -140,7 +140,7 @@ jobs:
           }
 
       - name: Create or update GitHub issue
-        if: ${{ failure() }}
+        if: ${{ needs.ping.result == 'failure' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TITLE: ${{ steps.compose.outputs.title }}
@@ -176,7 +176,7 @@ jobs:
           PY
 
       - name: Slack notify (optional)
-        if: ${{ failure() }}
+        if: ${{ needs.ping.result == 'failure' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         shell: bash


### PR DESCRIPTION
Fixes the failure notifier gating in the reusable workflow: the steps now check \
eeds.ping.result == 'failure'\ instead of \ailure()\ so issues/Slack are only emitted when the ping job failed.\n\nThis should restore failure notifications for manual runs.\n\n[Droid-assisted]