### PR TITLE
Synthetics: pass permissions to called workflow at call site [Droid-assisted]

### DIFF
--- a/.github/workflows/post-deploy-synthetics-manual.yml
+++ b/.github/workflows/post-deploy-synthetics-manual.yml
@@ -22,6 +22,10 @@ jobs:
         run: echo "Manual wrapper started for ${{ github.repository }}@${{ github.ref_name }} (${GITHUB_SHA})"
 
   run:
+    permissions:
+      contents: read
+      actions: read
+      issues: write
     uses: profyt7/carelinkai/.github/workflows/post-deploy-synthetics-reusable.yml@main
     with:
       simulate_failure: ${{ inputs.simulate_failure }}


### PR DESCRIPTION
Explicitly passes permissions (contents read, actions read, issues write) at the call site so the called workflow has a GITHUB_TOKEN with issue write access.\n\nThis should enable failure issue creation.\n\n[Droid-assisted]