### PR TITLE
ci(synthetics): add repository_dispatch trigger for manual workflow

### DIFF
--- a/.github/workflows/post-deploy-synthetics-manual.yml
+++ b/.github/workflows/post-deploy-synthetics-manual.yml
@@ -8,6 +8,8 @@ on:
         required: false
         type: boolean
         default: false
+  repository_dispatch:
+    types: [post-deploy-synthetics]
 
 permissions:
   contents: read
@@ -29,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Simulate failure (optional)
-        if: ${{ inputs.simulate_failure }}
+        if: ${{ inputs.simulate_failure || github.event.client_payload.simulate_failure }}
         run: |
           echo "Simulating failure per input simulate_failure=true"
           exit 1


### PR DESCRIPTION
Adds repository_dispatch trigger (types: post-deploy-synthetics) and supports simulate_failure via client_payload to bypass GitHub workflow_dispatch 422. Preserves inline jobs for visibility (kickoff, ping, notify-on-failure, cleanup-on-success). [Droid-assisted]