### PR TITLE
ci(synthetics): entry wrapper triggering reusable via repository_dispatch and workflow_run

### DIFF
--- a/.github/workflows/post-deploy-synthetics-entry.yml
+++ b/.github/workflows/post-deploy-synthetics-entry.yml
@@ -1,0 +1,24 @@
+name: Post Deploy Synthetics (entry)
+
+on:
+  repository_dispatch:
+    types: [post-deploy-synthetics]
+  workflow_run:
+    workflows: ["Header Health Check"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+concurrency:
+  group: post-deploy-synthetics-entry-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  run-reusable:
+    uses: ./.github/workflows/post-deploy-synthetics-reusable.yml
+    with:
+      simulate_failure: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.simulate_failure || false }}
+    secrets: inherit


### PR DESCRIPTION
Adds an entry workflow that triggers on repository_dispatch (type: post-deploy-synthetics) and workflow_run (Header Health Check completed). It calls the existing reusable workflow and inherits secrets. Workaround for GitHub workflow_dispatch metadata bug. [Droid-assisted]