### PR TITLE
ci(synthetics): fix entry concurrency group for non-ref events

### DIFF
--- a/.github/workflows/post-deploy-synthetics-entry.yml
+++ b/.github/workflows/post-deploy-synthetics-entry.yml
@@ -13,7 +13,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: post-deploy-synthetics-entry-${{ github.ref }}
+  group: post-deploy-synthetics-entry-${{ github.ref || format('run-{0}', github.run_id) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Use github.ref || format('run-{0}', github.run_id) in concurrency group to avoid 0s failures on repository_dispatch/workflow_run. [Droid-assisted]