### PR TITLE
ci(synthetics): fix concurrency in reusable/manual for non-ref events

### DIFF
--- a/.github/workflows/post-deploy-synthetics-manual.yml
+++ b/.github/workflows/post-deploy-synthetics-manual.yml
@@ -20,7 +20,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: post-deploy-synthetics-manual-${{ github.ref }}
+  group: post-deploy-synthetics-manual-${{ github.ref || format('run-{0}', github.run_id) }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/post-deploy-synthetics-reusable.yml
+++ b/.github/workflows/post-deploy-synthetics-reusable.yml
@@ -15,7 +15,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: post-deploy-synthetics-reusable-${{ github.ref }}
+  group: post-deploy-synthetics-reusable-${{ github.ref || format('run-{0}', github.run_id) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Use \github.ref || format('run-{0}', github.run_id)\ in concurrency group to avoid 0s failures on repository_dispatch/workflow_run. [Droid-assisted]