### PR TITLE
ci(synthetics): manual adds push-on-path trigger for deterministic runs

### DIFF
--- a/.github/workflows/post-deploy-synthetics-manual.yml
+++ b/.github/workflows/post-deploy-synthetics-manual.yml
@@ -1,6 +1,10 @@
 name: Post Deploy Synthetics (manual)
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - .github/workflows/post-deploy-synthetics-manual.yml
   workflow_dispatch:
     inputs:
       simulate_failure:


### PR DESCRIPTION
Add a path-limited push trigger for the manual workflow so we can reliably run it on merge. This keeps normal CI quiet and only fires when the manual workflow file changes.\n\nDroid-assisted.