### PR TITLE
workflows(entry): add workflow_dispatch with simulate_failure input

### DIFF
--- a/.github/workflows/post-deploy-synthetics-entry.yml
+++ b/.github/workflows/post-deploy-synthetics-entry.yml
@@ -5,6 +5,13 @@ on:
     branches: [ main ]
     paths:
       - .github/workflows/post-deploy-synthetics-entry.yml
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: "Simulate a failing run"
+        type: boolean
+        default: false
+        required: false
   repository_dispatch:
     types: [post-deploy-synthetics]
   workflow_run:


### PR DESCRIPTION
Droid-assisted. Adds manual trigger (workflow_dispatch) for the inlined entry synthetics workflow with a boolean simulate_failure input for quick manual testing. Local validation previously green.