### PR TITLE
workflows(entry fresh): add nightly schedule trigger to entry2 (temporary monitor)

### DIFF
--- a/.github/workflows/post-deploy-synthetics-entry2.yml
+++ b/.github/workflows/post-deploy-synthetics-entry2.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     paths:
       - .github/workflows/post-deploy-synthetics-entry2.yml
+  schedule:
+    - cron: "0 3 * * *" # nightly at 03:00 UTC
   workflow_dispatch:
     inputs:
       simulate_failure:


### PR DESCRIPTION
Adds cron schedule (03:00 UTC nightly) to Post Deploy Synthetics (entry fresh) to keep automatic checks running while dispatch/push triggers are impacted by GitHub 0s/0-job bug.