### PR TITLE
workflows(entry2): remove concurrency block to fix 0s/0-jobs

### DIFF
--- a/.github/workflows/post-deploy-synthetics-entry2.yml
+++ b/.github/workflows/post-deploy-synthetics-entry2.yml
@@ -25,10 +25,6 @@ permissions:
   actions: read
   issues: write
 
-concurrency:
-  group: post-deploy-synthetics-entry-fresh-${{ github.ref || format('run-{0}', github.run_id) }}
-  cancel-in-progress: false
-
 jobs:
   kickoff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hypothesis: concurrency group expression evaluation aborts before job creation. Remove concurrency from entry2 only to test. If runs start showing jobs, we’ll re-introduce a minimal-safe group later.