### PR TITLE
workflows(entry v3): add notifier + cleanup jobs

### DIFF
--- a/.github/workflows/post-deploy-synthetics-entry3.yml
+++ b/.github/workflows/post-deploy-synthetics-entry3.yml
@@ -53,3 +53,108 @@ jobs:
             echo "SSE ready event NOT observed" >&2
             exit 1
           fi
+  notify-on-failure:
+    name: Create issue on failure
+    needs: [ping]
+    if: ${{ needs.ping.result == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Compose failure message
+        id: compose
+        shell: bash
+        run: |
+          {
+            echo "title=Post-deploy Synthetics entry v3 failure" >> "$GITHUB_OUTPUT"
+            echo "body<<EOF";
+            echo "Post-deploy Synthetics entry v3 failed.";
+            echo;
+            echo "Repository: ${GITHUB_REPOSITORY}";
+            echo "Branch: ${GITHUB_REF_NAME}";
+            echo "SHA: ${GITHUB_SHA}";
+            echo "Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}";
+            echo "Actor: ${GITHUB_ACTOR}";
+            echo "Event: ${GITHUB_EVENT_NAME}";
+            echo "Attempt: ${GITHUB_RUN_ATTEMPT}";
+            echo "Time: ${GITHUB_RUN_STARTED_AT}";
+            echo;
+            echo "Please investigate the failing step(s) in the linked run.";
+            echo "EOF";
+          }
+
+      - name: Create or update GitHub issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TITLE: ${{ steps.compose.outputs.title }}
+          BODY: ${{ steps.compose.outputs.body }}
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json, os, urllib.parse, urllib.request
+          repo = os.environ['GITHUB_REPOSITORY']
+          token = os.environ['GITHUB_TOKEN']
+          title = os.environ['TITLE']
+          body = os.environ['BODY']
+          q = f'repo:{repo} state:open in:title "{title}"'
+          url = f'https://api.github.com/search/issues?q={urllib.parse.quote(q)}'
+          req = urllib.request.Request(url, headers={'Authorization': f'Bearer {token}', 'Accept': 'application/vnd.github+json'})
+          with urllib.request.urlopen(req) as r:
+            data = json.load(r)
+          if data.get('total_count', 0) > 0:
+            issue = data['items'][0]
+            num = issue['number']
+            comment_url = f'https://api.github.com/repos/{repo}/issues/{num}/comments'
+            payload = json.dumps({"body": body}).encode()
+            req = urllib.request.Request(comment_url, data=payload, headers={'Authorization': f'Bearer {token}', 'Accept': 'application/vnd.github+json'})
+            with urllib.request.urlopen(req) as r:
+              print(f'Commented on existing issue #{num}, status {r.status}')
+          else:
+            create_url = f'https://api.github.com/repos/{repo}/issues'
+            payload = json.dumps({"title": title, "body": body}).encode()
+            req = urllib.request.Request(create_url, data=payload, headers={'Authorization': f'Bearer {token}', 'Accept': 'application/vnd.github+json'})
+            with urllib.request.urlopen(req) as r:
+              resp = json.load(r)
+              print(f'Created issue #{resp.get("number")}')
+          PY
+
+  cleanup-on-success:
+    name: Close failure issue(s) on success
+    needs: [ping]
+    if: success()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Close issues
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          q="repo:${GITHUB_REPOSITORY} state:open in:title 'Post-deploy Synthetics entry v3 failure'"
+          url="https://api.github.com/search/issues?q=$(python3 - <<'PY'
+import os,urllib.parse
+print(urllib.parse.quote(os.environ['Q']))
+PY
+)"
+          data=$(curl -sS -H "Authorization: Bearer ${GITHUB_TOKEN}" -H 'Accept: application/vnd.github+json' "$url")
+          python3 - <<'PY'
+import json, os, urllib.request
+repo=os.environ['GITHUB_REPOSITORY']
+token=os.environ['GITHUB_TOKEN']
+items=json.loads(os.environ['data'])['items'] if os.environ.get('data') else []
+for it in items:
+  num=it['number']
+  comment_url=f'https://api.github.com/repos/{repo}/issues/{num}/comments'
+  patch_url=f'https://api.github.com/repos/{repo}/issues/{num}'
+  msg=f"Closing as resolved by successful run https://github.com/{repo}/actions/runs/{os.environ.get('GITHUB_RUN_ID')}"
+  req=urllib.request.Request(comment_url, data=json.dumps({'body':msg}).encode(), headers={'Authorization':f'Bearer {token}','Accept':'application/vnd.github+json'})
+  urllib.request.urlopen(req).read()
+  req=urllib.request.Request(patch_url, data=json.dumps({'state':'closed'}).encode(), headers={'Authorization':f'Bearer {token}','Accept':'application/vnd.github+json'})
+  req.get_method=lambda: 'PATCH'
+  urllib.request.urlopen(req).read()
+print(f'Closed {len(items)} issue(s).')
+PY


### PR DESCRIPTION
Adds notify-on-failure (issues) and cleanup-on-success to entry v3 workflow. Uses job-level permissions and dedupes by title. [Droid-assisted]