### PR TITLE
workflows(ephemeral): add push+schedule triggers for reliable runs

### DIFF
--- a/.github/workflows/post-deploy-synthetics-ephemeral.yml
+++ b/.github/workflows/post-deploy-synthetics-ephemeral.yml
@@ -10,6 +10,12 @@ on:
         required: false
   repository_dispatch:
     types: [post-deploy-synthetics-ephemeral]
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/post-deploy-synthetics-ephemeral.yml'
+  schedule:
+    - cron: '*/30 * * * *'
 
 jobs:
   ping:


### PR DESCRIPTION
Adds push (path-limited) and 30-min cron schedule to the ephemeral synthetics workflow. This ensures runs even if workflow_dispatch is flaky. [Droid-assisted]