### PR TITLE
chore(observability): set Sentry release + footer version label

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -5,6 +5,13 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env['NEXT_PUBLIC_SENTRY_DSN'] || process.env['SENTRY_DSN'] || '',
   tracesSampleRate: Number(process.env['NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE'] || process.env['SENTRY_TRACES_SAMPLE_RATE'] || 0.1),
+  environment: process.env['NEXT_PUBLIC_SENTRY_ENVIRONMENT'] || process.env.NODE_ENV,
+  release: (() => {
+    const version = process.env['NEXT_PUBLIC_APP_VERSION'] || process.env['npm_package_version'];
+    const sha = process.env['NEXT_PUBLIC_COMMIT_SHA'];
+    if (sha) return `${version || '0.0.0'}@${String(sha).slice(0, 7)}`;
+    return version ? `v${version}` : undefined;
+  })(),
   replaysSessionSampleRate: 0.0,
   replaysOnErrorSampleRate: 0.0,
   beforeSend(event) {

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -4,9 +4,21 @@ import * as Sentry from '@sentry/nextjs';
 export function register() {
   // Initialize OpenTelemetry if configured
   try { initTracing(); } catch { }
+  const env = process.env['SENTRY_ENVIRONMENT'] || process.env.NODE_ENV;
+  const version = process.env['APP_VERSION'] || process.env['npm_package_version'];
+  const sha = process.env['RENDER_GIT_COMMIT']
+    || process.env['VERCEL_GIT_COMMIT_SHA']
+    || process.env['GITHUB_SHA']
+    || process.env['GIT_COMMIT'];
+  const release = sha
+    ? `${version || '0.0.0'}@${String(sha).slice(0, 7)}`
+    : (version ? `v${version}` : undefined);
+
   Sentry.init({
     dsn: process.env['SENTRY_DSN'] || '',
     tracesSampleRate: Number(process.env['SENTRY_TRACES_SAMPLE_RATE'] || 0.1),
+    environment: env,
+    release,
     beforeSend(event) {
       if (event.request) {
         delete (event.request as any).cookies;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -99,6 +99,23 @@ export const viewport: Viewport = {
   viewportFit: "cover",
 };
 
+// Version/commit info for footer diagnostics
+const _appVersion = process.env['APP_VERSION'] || process.env['npm_package_version'] || '0.0.0';
+const _commitSha = (
+  process.env['RENDER_GIT_COMMIT'] ||
+  process.env['VERCEL_GIT_COMMIT_SHA'] ||
+  process.env['GITHUB_SHA'] ||
+  process.env['GIT_COMMIT'] ||
+  process.env['NEXT_PUBLIC_COMMIT_SHA'] || ''
+).slice(0, 7);
+const _branch = (
+  process.env['RENDER_GIT_BRANCH'] ||
+  process.env['VERCEL_GIT_COMMIT_REF'] ||
+  process.env['GITHUB_REF_NAME'] ||
+  process.env['GIT_BRANCH'] || ''
+);
+const _versionLabel = `v${_appVersion}${_branch ? ` • ${_branch}` : ''}${_commitSha ? `@${_commitSha}` : ''}`;
+
 export default function RootLayout({
   children,
 }: {
@@ -195,6 +212,14 @@ export default function RootLayout({
                 <main id="main-content" className="flex-1">
                   {children}
                 </main>
+
+                {/* Global footer with version and commit diagnostics */}
+                <footer className="border-t border-neutral-200/70 bg-white/60 py-2 text-xs text-neutral-500">
+                  <div className="mx-auto flex max-w-7xl items-center justify-between px-4">
+                    <span>CareLinkAI</span>
+                    <span suppressHydrationWarning>{_versionLabel}</span>
+                  </div>
+                </footer>
               </div>
 
               {/* Global toaster for notifications */}


### PR DESCRIPTION
Droid-assisted

- Add Sentry release/environment in both instrumentation.ts and instrumentation-client.ts
- Footer: show build version label (version • branch@sha) for easy diagnostics
- /api/version already exposes the same info for automation/health checks

Validation (local):
- next lint → clean
- tsc --noEmit → clean
- jest → 29/29 passing
- next build → clean
