### PR TITLE
chore(workflows): stabilize post-deploy synthetics (ephemeral)

### DIFF
--- a/.github/workflows/post-deploy-synthetics-ephemeral.yml
+++ b/.github/workflows/post-deploy-synthetics-ephemeral.yml
@@ -1,5 +1,9 @@
 name: Post Deploy Synthetics (ephemeral)
 
+concurrency:
+  group: synthetics-ephemeral
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
     inputs:
@@ -10,10 +14,6 @@ on:
         required: false
   repository_dispatch:
     types: [post-deploy-synthetics-ephemeral]
-  push:
-    branches: [main]
-    paths:
-      - '.github/workflows/post-deploy-synthetics-ephemeral.yml'
   schedule:
     - cron: '*/30 * * * *'
 


### PR DESCRIPTION
- Remove push trigger (manual+schedule only)\n- Add concurrency to avoid overlapping runs\n\nDroid-assisted.