### PR TITLE
ci(synthetics): call ephemeral via workflow_call after deploy (Droid-assisted)

### DIFF
--- a/.github/workflows/post-deploy-synthetics-ephemeral.yml
+++ b/.github/workflows/post-deploy-synthetics-ephemeral.yml
@@ -16,6 +16,13 @@ on:
     types: [post-deploy-synthetics-ephemeral]
   schedule:
     - cron: '*/30 * * * *'
+  workflow_call:
+    inputs:
+      simulate_failure:
+        description: "Simulate a failing run"
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   ping:

--- a/.github/workflows/post-deploy-synthetics-on-deploy.yml
+++ b/.github/workflows/post-deploy-synthetics-on-deploy.yml
@@ -6,38 +6,12 @@ on:
     types: [completed]
 
 jobs:
-  trigger-ephemeral-synthetics:
-    name: Trigger ephemeral synthetics via repository_dispatch
+  call-ephemeral-synthetics:
+    name: Run ephemeral synthetics
     if: >-
       ${{ github.event.workflow_run.conclusion == 'success' &&
           github.event.workflow_run.head_branch == 'main' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Dispatch post-deploy synthetics
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.event.workflow_run.head_sha }}
-          REF: ${{ github.event.workflow_run.head_branch }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          body=$(cat <<JSON
-          {"event_type":"post-deploy-synthetics-ephemeral",
-           "client_payload":{
-             "reason":"workflow_run:Deploy to Render (env-aware)",
-             "sha":"${SHA}",
-             "ref":"${REF}",
-             "source_run_id":"${GITHUB_RUN_ID}"
-           }}
-          JSON
-          )
-          curl -sS -X POST \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'Content-Type: application/json' \
-            --data "${body}" \
-            "https://api.github.com/repos/${REPO}/dispatches"
-          echo "repository_dispatch sent for post-deploy-synthetics-ephemeral"
+    uses: ./.github/workflows/post-deploy-synthetics-ephemeral.yml
+    with:
+      simulate_failure: false
+    secrets: inherit


### PR DESCRIPTION
This switches the post-deploy trigger to call the existing ephemeral synthetics workflow as a reusable workflow (workflow_call).\n\nWhy: avoids flaky workflow_dispatch/dispatch API behavior while keeping cron/manual triggers intact.\n\n- Adds workflow_call to post-deploy-synthetics-ephemeral.yml with input simulate_failure\n- Updates trigger workflow to use: ./.github/workflows/post-deploy-synthetics-ephemeral.yml with secrets: inherit\n- Preserves schedule + manual triggers as backups\n\nExpected: after this PR merges, when 'Deploy to Render (env-aware)' finishes successfully on main, the reusable synthetics run will execute immediately.