### PR TITLE
chore: trigger deploy to verify post-deploy synthetics (no-op) [Droid-assisted]

### DIFF
--- a/docs/DEPLOY_VERIFICATION.md
+++ b/docs/DEPLOY_VERIFICATION.md
@@ -1,0 +1,3 @@
+Triggering a deploy to verify post-deploy synthetics workflow_run.
+
+This is a no-op documentation change used to produce a push to main.


### PR DESCRIPTION
No-op doc change to create a push on main and verify the workflow_run-based post-deploy synthetics path.\n\n- Deploy to Render (env-aware) triggers on push to main\n- Our on-deploy synthetics workflow listens via workflow_run and should run health/SSE checks\n\nSafe to merge; does not change app behavior.