### PR TITLE
ci(synthetics on-deploy): trigger on all workflow_run, gate by name/branch (fix missing runs) [Droid-assisted]

### DIFF
--- a/.github/workflows/post-deploy-synthetics-on-deploy.yml
+++ b/.github/workflows/post-deploy-synthetics-on-deploy.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   workflow_run:
-    workflows: ["Deploy to Render (env-aware)"]
+    # Listen to all completed workflow runs, we'll gate by name/branch below
     types: [completed]
 
 jobs:
@@ -14,6 +14,7 @@ jobs:
     name: Run checks
     if: >-
       ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.name == 'Deploy to Render (env-aware)' &&
           github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Remove workflows filter so workflow_run fires reliably, and gate execution in the job with:\n- name == 'Deploy to Render (env-aware)'\n- head_branch == 'main'\n\nThis addresses cases where workflow_run didn't fire for workflow_dispatch or reruns.\n\n[Droid-assisted]