### PR TITLE
docs: trigger deploy to verify inline synthetics [Droid-assisted]

### DIFF
--- a/docs/DEPLOY_PING.md
+++ b/docs/DEPLOY_PING.md
@@ -1,0 +1,1 @@
+Trigger: inline synthetics verification — commit to trigger deploy.


### PR DESCRIPTION
No-op docs change to trigger push to main. This will exercise the Deploy to Render (env-aware) workflow, which now includes inline post-deploy synthetics (health, SSE, optional operator).