### PR TITLE
ci(deploy-min): simplify synthetics to health+SSE (fix YAML parsing) [Droid-assisted]

### DIFF
--- a/.github/workflows/deploy-render-min.yml
+++ b/.github/workflows/deploy-render-min.yml
@@ -61,222 +61,26 @@ jobs:
           echo "No Render deploy secrets available; skipping."
 
   synthetics:
-    name: Post-deploy synthetics checks
+    name: Post-deploy synthetics checks (minimal)
     needs: [deploy]
     if: ${{ success() }}
     runs-on: ubuntu-latest
-    concurrency:
-      group: synthetics-ephemeral
-      cancel-in-progress: true
     steps:
       - name: Health check
-        shell: bash
-        env:
-          HEALTH_URL: https://carelinkai.onrender.com/api/health
         run: |
-          set -euo pipefail
-          code=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL" || true)
+          code=$(curl -s -o /dev/null -w "%{http_code}" https://carelinkai.onrender.com/api/health || true)
           echo "health -> $code"
           if [ "$code" != "200" ]; then
             echo "Health endpoint returned $code" >&2
             exit 1
           fi
-
       - name: SSE ready check
-        shell: bash
-        env:
-          SSE_URL: https://carelinkai.onrender.com/api/sse?topics=system
         run: |
-          set -euo pipefail
-          echo "connecting to $SSE_URL"
-          set +o pipefail
-          curl -sS -N --max-time 10 -H "Accept: text/event-stream" "$SSE_URL" | grep -m1 -E "^event: ready" >/dev/null
+          set +e
+          curl -sS -N --max-time 10 -H "Accept: text/event-stream" "https://carelinkai.onrender.com/api/sse?topics=system" | grep -m1 -E "^event: ready" >/dev/null
           rc=$?
-          set -o pipefail
-          if [ "$rc" -eq 0 ]; then
-            echo "SSE ready event observed"
-          else
+          set -e
+          if [ "$rc" -ne 0 ]; then
             echo "SSE ready event NOT observed" >&2
             exit 1
           fi
-
-      - name: Operator login + protected API check (optional)
-        shell: bash
-        env:
-          BASE_URL: https://carelinkai.onrender.com
-          OP_EMAIL: ${{ secrets.OP_EMAIL }}
-          OP_PASSWORD: ${{ secrets.OP_PASSWORD }}
-        run: |
-          set -euo pipefail
-          workdir=$(mktemp -d)
-          jar="$workdir/cookies.txt"
-
-          if [ -z "${OP_EMAIL:-}" ] || [ -z "${OP_PASSWORD:-}" ]; then
-            echo "OP_EMAIL/OP_PASSWORD not set; skipping operator check"
-            exit 0
-          fi
-
-          echo "Attempting dev login (if enabled) ..."
-          code=$(curl -sS -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" -c "$jar" -b "$jar" "$BASE_URL/api/dev/login" -d "{\"email\":\"$OP_EMAIL\"}" || true)
-          if [ "$code" = "200" ]; then
-            echo "Dev login succeeded"
-          else
-            echo "Dev login not available (code $code). Falling back to credentials login ..."
-
-            csrf=$(curl -sS -c "$jar" -b "$jar" -H "Accept: application/json" "$BASE_URL/api/auth/csrf" | python3 -c "import sys,json; print(json.load(sys.stdin).get('csrfToken',''))" || true)
-            if [ -z "${csrf:-}" ]; then
-              echo "Failed to obtain CSRF token" >&2
-              exit 1
-            fi
-
-            resp=$(curl -sS -o /dev/null -w "%{http_code}" -L -c "$jar" -b "$jar" -H "Content-Type: application/x-www-form-urlencoded" \
-              --data-urlencode "csrfToken=$csrf" \
-              --data-urlencode "email=$OP_EMAIL" \
-              --data-urlencode "password=$OP_PASSWORD" \
-              --data-urlencode "callbackUrl=/" \
-              "$BASE_URL/api/auth/callback/credentials" || true)
-            if [ "$resp" != "200" ] && [ "$resp" != "302" ] && [ "$resp" != "303" ]; then
-              echo "Credentials login failed with HTTP $resp" >&2
-              exit 1
-            fi
-          fi
-
-          if ! grep -q 'next-auth.session-token' "$jar" && ! grep -q '__Secure-next-auth.session-token' "$jar"; then
-            echo "No NextAuth session cookie found after login" >&2
-            echo "Cookie jar contents:"; cat "$jar" || true
-            exit 1
-          fi
-
-          code=$(curl -sS -o /dev/null -w "%{http_code}" -b "$jar" "$BASE_URL/api/operator/homes" || true)
-          echo "operator homes -> $code"
-          if [ "$code" != "200" ]; then
-            echo "Operator endpoint access failed ($code)" >&2
-            exit 1
-          fi
-          echo "Operator login and protected API check passed"
-
-  notify-on-failure:
-    name: Create issue on failure
-    needs: [synthetics]
-    if: ${{ needs.synthetics.result == 'failure' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - name: Compose failure message
-        id: compose
-        shell: bash
-        run: |
-          {
-            echo "title=Post-deploy Synthetics (deploy) failure" >> "$GITHUB_OUTPUT"
-            echo "body<<EOF";
-            echo "Post-deploy Synthetics (deploy) failed.";
-            echo;
-            echo "Repository: ${GITHUB_REPOSITORY}";
-            echo "Branch: ${GITHUB_REF_NAME}";
-            echo "SHA: ${GITHUB_SHA}";
-            echo "Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}";
-            echo "Actor: ${GITHUB_ACTOR}";
-            echo "Event: ${GITHUB_EVENT_NAME}";
-            echo "Attempt: ${GITHUB_RUN_ATTEMPT}";
-            echo "Time: ${GITHUB_RUN_STARTED_AT}";
-            echo;
-            echo "Please investigate the failing step(s) in the linked run.";
-            echo "EOF";
-          }
-
-      - name: Create or update GitHub issue
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          TITLE: ${{ steps.compose.outputs.title }}
-          BODY: ${{ steps.compose.outputs.body }}
-        shell: bash
-        run: |
-          python3 - <<'PY'
-          import json, os, urllib.parse, urllib.request
-          repo = os.environ['GITHUB_REPOSITORY']
-          token = os.environ['GITHUB_TOKEN']
-          title = os.environ['TITLE']
-          body = os.environ['BODY']
-          q = f'repo:{repo} state:open in:title "{title}"'
-          url = f'https://api.github.com/search/issues?q={urllib.parse.quote(q)}'
-          req = urllib.request.Request(url, headers={'Authorization': f'Bearer {token}', 'Accept': 'application/vnd.github+json'})
-          with urllib.request.urlopen(req) as r:
-            data = json.load(r)
-          if data.get('total_count', 0) > 0:
-            issue = data['items'][0]
-            num = issue['number']
-            comment_url = f'https://api.github.com/repos/{repo}/issues/{num}/comments'
-            payload = json.dumps({"body": body}).encode()
-            req = urllib.request.Request(comment_url, data=payload, headers={'Authorization': f'Bearer {token}', 'Accept': 'application/vnd.github+json'})
-            with urllib.request.urlopen(req) as r:
-              print(f'Commented on existing issue #{num}, status {r.status}')
-          else:
-            create_url = f'https://api.github.com/repos/{repo}/issues'
-            payload = json.dumps({"title": title, "body": body}).encode()
-            req = urllib.request.Request(create_url, data=payload, headers={'Authorization': f'Bearer {token}', 'Accept': 'application/vnd.github+json'})
-            with urllib.request.urlopen(req) as r:
-              resp = json.load(r)
-              print(f'Created issue #{resp.get("number")}')
-          PY
-      - name: Slack notify (failure)
-        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          text="❌ Synthetics (deploy) FAILED for ${GITHUB_REPOSITORY}@${GITHUB_REF_NAME} — run ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          payload=$(printf '{"text":"%s"}' "${text}")
-          curl -sS -X POST -H 'Content-type: application/json' --data "${payload}" "${SLACK_WEBHOOK_URL}" >/dev/null
-
-  cleanup-on-success:
-    name: Close failure issue(s) on success
-    needs: [synthetics]
-    if: success()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - name: Close issues
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          q="repo:${GITHUB_REPOSITORY} state:open in:title 'Post-deploy Synthetics (deploy) failure'"
-          url="https://api.github.com/search/issues?q=$(python3 - <<'PY'
-import os,urllib.parse
-print(urllib.parse.quote(os.environ['Q']))
-PY
-)"
-          data=$(curl -sS -H "Authorization: Bearer ${GITHUB_TOKEN}" -H 'Accept: application/vnd.github+json' "$url")
-          python3 - <<'PY'
-import json, os, urllib.request
-repo=os.environ['GITHUB_REPOSITORY']
-token=os.environ['GITHUB_TOKEN']
-items=json.loads(os.environ['data'])['items'] if os.environ.get('data') else []
-for it in items:
-  num=it['number']
-  comment_url=f'https://api.github.com/repos/{repo}/issues/{num}/comments'
-  patch_url=f'https://api.github.com/repos/{repo}/issues/{num}'
-  msg=f"Closing as resolved by successful run https://github.com/{repo}/actions/runs/{os.environ.get('GITHUB_RUN_ID')}"
-  req=urllib.request.Request(comment_url, data=json.dumps({'body':msg}).encode(), headers={'Authorization':f'Bearer {token}','Accept':'application/vnd.github+json'})
-  urllib.request.urlopen(req).read()
-  req=urllib.request.Request(patch_url, data=json.dumps({'state':'closed'}).encode(), headers={'Authorization':f'Bearer {token}','Accept':'application/vnd.github+json'})
-  req.get_method=lambda: 'PATCH'
-  urllib.request.urlopen(req).read()
-print(f'Closed {len(items)} issue(s).')
-PY
-      - name: Slack notify (success)
-        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          text="✅ Synthetics (deploy) SUCCESS for ${GITHUB_REPOSITORY}@${GITHUB_REF_NAME} — run ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          payload=$(printf '{"text":"%s"}' "${text}")
-          curl -sS -X POST -H 'Content-type: application/json' --data "${payload}" "${SLACK_WEBHOOK_URL}" >/dev/null


### PR DESCRIPTION
Reverts the previous complex synthetics block to a minimal health+SSE job to avoid GitHub YAML parsing issues causing 0s failures. This keeps post-deploy verification while we debug the richer version.