### PR TITLE
feat(workflow): optional operator auth check in Deploy to Render Minimal synthetics

### DIFF
--- a/.github/workflows/deploy-render-min.yml
+++ b/.github/workflows/deploy-render-min.yml
@@ -112,3 +112,37 @@ jobs:
           msg="${emoji} Post-deploy synthetics: ${status} — ${RUN_URL}"
           payload=$(printf '{"text":"%s"}' "${msg}")
           curl -fsSL -X POST -H 'Content-type: application/json' --data "${payload}" "${SLACK_WEBHOOK_URL}"
+
+  operator-check:
+    name: Operator session check (optional)
+    needs: [synthetics]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify operator auth with signed JWT cookie
+        env:
+          SYNTH_OP_EMAIL: ${{ secrets.SYNTH_OP_EMAIL }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+        run: |
+          set -e
+          if [ -z "${SYNTH_OP_EMAIL:-}" ] || [ -z "${NEXTAUTH_SECRET:-}" ]; then
+            echo "No SYNTH_OP_EMAIL/NEXTAUTH_SECRET; skipping operator check."
+            exit 0
+          fi
+          header='{"alg":"HS256","typ":"JWT"}'
+          now=$(date +%s)
+          exp=$((now+600))
+          payload=$(printf '{"email":"%s","role":"OPERATOR","name":"Synthetics Ops","exp":%s}' "${SYNTH_OP_EMAIL}" "${exp}")
+          b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+          header_b64=$(printf '%s' "$header" | b64url)
+          payload_b64=$(printf '%s' "$payload" | b64url)
+          to_sign="$header_b64.$payload_b64"
+          signature=$(printf '%s' "$to_sign" | openssl dgst -binary -sha256 -hmac "$NEXTAUTH_SECRET" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+          token="$to_sign.$signature"
+          url="https://carelinkai.onrender.com/api/protected/ping"
+          code=$(curl -s -o /dev/null -w "%{http_code}" -H "Cookie: __Secure-next-auth.session-token=$token; next-auth.session-token=$token" "$url" || true)
+          echo "operator ping -> $code"
+          if [ "$code" != "200" ]; then
+            echo "Operator check failed with code $code" >&2
+            exit 1
+          fi

--- a/src/app/api/protected/ping/route.ts
+++ b/src/app/api/protected/ping/route.ts
@@ -1,0 +1,26 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/lib/auth-db-simple';
+
+/**
+ * Protected ping endpoint used by post-deploy synthetics.
+ * Returns 200 when a valid NextAuth session is present.
+ * If a role is present on the session, it is echoed back.
+ * No database lookups are required for success.
+ */
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ ok: false, reason: 'unauthenticated' }, { status: 401 });
+    }
+    const role = (session.user as any).role ?? null;
+    const email = (session.user as any).email ?? null;
+    return NextResponse.json({ ok: true, role, email });
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Droid-assisted: adds a protected ping endpoint and an optional operator session check after minimal synthetics.\n\n- New API: GET /api/protected/ping (200 when a valid NextAuth session is present; echoes role/email)\n- Workflow: generates short-lived HS256 JWT using NEXTAUTH_SECRET and SYNTH_OP_EMAIL; hits /api/protected/ping with session cookie\n- Fully optional: step exits 0 when secrets are not configured\n- Keeps existing health + SSE checks and Slack notify\n\nValidation: npm ci, lint, type-check, build all pass locally.