### PR TITLE
feat(operator-leads): operator lead detail view with notes + status updates

### DIFF
--- a/prisma/migrations/20251201161000_add_inquiry_internal_notes/migration.sql
+++ b/prisma/migrations/20251201161000_add_inquiry_internal_notes/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Inquiry" ADD COLUMN "internalNotes" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -609,6 +609,8 @@ model Inquiry {
   homeId       String
   status       InquiryStatus @default(NEW)
   message      String?       @db.Text
+  /// Operator-internal notes for this lead (not visible to families)
+  internalNotes String?      @db.Text
   tourDate     DateTime?
   aiMatchScore Float? // AI-generated placement likelihood score
 

--- a/src/app/api/operator/inquiries/[id]/notes/route.ts
+++ b/src/app/api/operator/inquiries/[id]/notes/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/lib/auth';
+import { PrismaClient, UserRole } from '@prisma/client';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const prisma = new PrismaClient();
+
+const NotesSchema = z.object({
+  notes: z.string().max(20000).optional().default(''),
+});
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+    if (!user || (user.role !== UserRole.OPERATOR && user.role !== UserRole.ADMIN)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const inquiry = await prisma.inquiry.findUnique({
+      where: { id: params.id },
+      include: { home: { select: { operatorId: true } } },
+    });
+    if (!inquiry) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    if (user.role !== UserRole.ADMIN) {
+      const operator = await prisma.operator.findUnique({ where: { userId: user.id } });
+      if (!operator || inquiry.home.operatorId !== operator.id) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+    }
+
+    const json = await req.json().catch(() => ({}));
+    const parsed = NotesSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid payload', details: parsed.error.format() }, { status: 400 });
+    }
+
+    const updated = await prisma.inquiry.update({
+      where: { id: inquiry.id },
+      data: { internalNotes: parsed.data.notes || '' },
+      select: { id: true, internalNotes: true },
+    });
+
+    return NextResponse.json({ id: updated.id, internalNotes: updated.internalNotes || '' });
+  } catch (e) {
+    console.error('Update notes failed', e);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/src/app/operator/inquiries/[id]/page.tsx
+++ b/src/app/operator/inquiries/[id]/page.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import DashboardLayout from '@/components/layout/DashboardLayout';
+import Link from 'next/link';
+import { InquiryStatus } from '@prisma/client';
+
+type InquiryDetail = {
+  id: string;
+  status: InquiryStatus;
+  createdAt: string;
+  tourDate: string | null;
+  message: string | null;
+  internalNotes: string;
+  home: { id: string; name: string };
+  family: { id: string; name: string; email: string; phone: string | null };
+};
+
+export default function OperatorLeadDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const [data, setData] = useState<InquiryDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notes, setNotes] = useState('');
+  const [savingNotes, setSavingNotes] = useState(false);
+  const [updatingStatus, setUpdatingStatus] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await fetch(`/api/operator/inquiries/${id}`, { cache: 'no-store' });
+        if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || res.statusText);
+        const j = await res.json();
+        if (cancelled) return;
+        setData(j.inquiry);
+        setNotes(j.inquiry.internalNotes || '');
+      } catch (e: any) {
+        if (!cancelled) setError(e?.message || 'Failed to load');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const statuses: InquiryStatus[] = [
+    'NEW',
+    'CONTACTED',
+    'TOUR_SCHEDULED',
+    'TOUR_COMPLETED',
+    'PLACEMENT_OFFERED',
+    'PLACEMENT_ACCEPTED',
+    'CLOSED_LOST',
+  ];
+
+  const updateStatus = async (status: InquiryStatus) => {
+    if (!data || updatingStatus) return;
+    setUpdatingStatus(true);
+    const prev = data;
+    setData({ ...data, status });
+    try {
+      const res = await fetch(`/api/operator/inquiries/${data.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || res.statusText);
+    } catch (e: any) {
+      alert(e?.message || 'Failed to update status');
+      setData(prev);
+    } finally {
+      setUpdatingStatus(false);
+    }
+  };
+
+  const saveNotes = async () => {
+    if (!data || savingNotes) return;
+    setSavingNotes(true);
+    try {
+      const res = await fetch(`/api/operator/inquiries/${data.id}/notes`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notes }),
+      });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || res.statusText);
+    } catch (e: any) {
+      alert(e?.message || 'Failed to save notes');
+    } finally {
+      setSavingNotes(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <DashboardLayout title="Inquiry Details">
+        <div className="p-6">
+          <div className="h-10 w-10 animate-spin rounded-full border-4 border-neutral-200 border-t-primary-500" />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <DashboardLayout title="Inquiry Details">
+        <div className="p-6">
+          <div className="rounded-md border border-red-200 bg-red-50 p-4 text-red-700">{error || 'Not found'}</div>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout title={`Lead - ${data.home.name}`} showSearch={false}>
+      <div className="p-4 sm:p-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <button className="text-sm text-neutral-600 hover:text-neutral-800" onClick={() => router.push('/operator/inquiries')}>
+            ← Back to Leads
+          </button>
+          <Link className="text-sm text-primary-600 hover:underline" href={`/homes/${data.home.id}`}>View Listing</Link>
+        </div>
+
+        {/* Summary card */}
+        <div className="rounded-lg border border-neutral-200 bg-white p-4">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div>
+              <div className="text-xs text-neutral-500">Home</div>
+              <div className="font-medium text-neutral-900">{data.home.name}</div>
+            </div>
+            <div>
+              <div className="text-xs text-neutral-500">Submitted</div>
+              <div className="font-medium text-neutral-900">{new Date(data.createdAt).toLocaleString()}</div>
+            </div>
+            <div>
+              <div className="text-xs text-neutral-500">Tour</div>
+              <div className="font-medium text-neutral-900">{data.tourDate ? new Date(data.tourDate).toLocaleString() : '-'}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          {/* Left column */}
+          <div className="space-y-6 lg:col-span-2">
+            {/* Family contact */}
+            <div className="rounded-lg border border-neutral-200 bg-white p-4">
+              <div className="mb-3 text-sm font-medium text-neutral-800">Family Contact</div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <div className="text-xs text-neutral-500">Name</div>
+                  <div className="font-medium text-neutral-900">{data.family.name}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-neutral-500">Email</div>
+                  <a className="font-medium text-primary-600 hover:underline" href={`mailto:${data.family.email}`}>{data.family.email}</a>
+                </div>
+                <div>
+                  <div className="text-xs text-neutral-500">Phone</div>
+                  <div className="font-medium text-neutral-900">{data.family.phone || '-'}</div>
+                </div>
+              </div>
+            </div>
+
+            {/* Inquiry details */}
+            <div className="rounded-lg border border-neutral-200 bg-white p-4">
+              <div className="mb-3 text-sm font-medium text-neutral-800">Inquiry Details</div>
+              <pre className="whitespace-pre-wrap text-sm text-neutral-800">{data.message || '—'}</pre>
+            </div>
+
+            {/* Internal notes */}
+            <div className="rounded-lg border border-neutral-200 bg-white p-4">
+              <div className="mb-2 flex items-center justify-between">
+                <div className="text-sm font-medium text-neutral-800">Internal Notes</div>
+                <button onClick={saveNotes} disabled={savingNotes} className="rounded-md bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-600 disabled:bg-neutral-300">
+                  {savingNotes ? 'Saving…' : 'Save Notes'}
+                </button>
+              </div>
+              <textarea
+                className="h-40 w-full rounded-md border border-neutral-300 p-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Add private notes for your team…"
+              />
+            </div>
+          </div>
+
+          {/* Right column */}
+          <div className="space-y-6">
+            <div className="rounded-lg border border-neutral-200 bg-white p-4">
+              <div className="mb-3 text-sm font-medium text-neutral-800">Lead Status</div>
+              <select
+                className="w-full form-select"
+                value={data.status}
+                onChange={(e) => updateStatus(e.target.value as InquiryStatus)}
+                disabled={updatingStatus}
+              >
+                {statuses.map((s) => (
+                  <option key={s} value={s}>{s.replace(/_/g, ' ')}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/components/operator/OperatorInquiriesTable.tsx
+++ b/src/components/operator/OperatorInquiriesTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from 'react';
+import Link from 'next/link';
 import { InquiryStatus } from '@prisma/client';
 
 type Inquiry = {
@@ -79,7 +80,11 @@ export default function OperatorInquiriesTable({ initial }: { initial: Inquiry[]
           <tbody>
             {filtered.map((i) => (
               <tr key={i.id} className="border-t">
-                <td className="py-2 pr-4">{i.home.name}</td>
+                <td className="py-2 pr-4">
+                  <Link href={`/operator/inquiries/${i.id}`} className="text-primary-600 hover:underline">
+                    {i.home.name}
+                  </Link>
+                </td>
                 <td className="py-2 pr-4">{new Date(i.createdAt).toLocaleDateString()}</td>
                 <td className="py-2 pr-4">{i.tourDate ? new Date(i.tourDate).toLocaleString() : '-'}</td>
                 <td className="py-2 pr-4">


### PR DESCRIPTION
This PR adds the operator-facing Lead detail experience.\n\nHighlights\n- New GET /api/operator/inquiries/[id] returns full inquiry details with RBAC (operator/admin) including family contact, message, and internal notes.\n- New PATCH /api/operator/inquiries/[id]/notes to update internalNotes with RBAC.\n- New page /operator/inquiries/[id] with: summary, family contact, inquiry message, internal notes editor (Save), and status dropdown wired to existing PATCH.\n- Link from OperatorInquiriesTable to detail page.\n- Prisma schema: added internalNotes to Inquiry (migration included).\n\nQuality\n- npm run lint, type-check, and build all pass.\n- Prisma client regenerated.\n\nNotes\n- Migration file provided; run your normal migration process in non-dev envs.\n\nDroid-assisted