### PR TITLE
docs(mvp): refresh Phase 1 matrix for Family ↔ Operator flow

### DIFF
--- a/docs/mvp_status_matrix.md
+++ b/docs/mvp_status_matrix.md
@@ -11,7 +11,7 @@
 | Lead status updates      | Operator | Change & persist lead status                 | DONE   | PATCH `/api/operator/inquiries/[id]` updates status (with RBAC). |
 | Lead details/notes       | Operator | View full inquiry + add notes                | DONE   | Detail page at /operator/inquiries/[id]; GET + PATCH (/api/operator/inquiries/[id]); notes via PATCH /api/operator/inquiries/[id]/notes. |
 | Operator → Family reply  | Operator | Some form of response/messaging              | TODO   | No cross-party messaging implemented. |
-| Edit listing             | Operator | Edit listing & reflect changes for families  | WIP    | Edit UI + PATCH API work; search cards reflect DB, but family home detail page is mock-only. |
+| Edit listing             | Operator | Edit listing & reflect changes for families  | DONE   | Edit UI at /operator/homes/[id]/edit patches /api/operator/homes/[id]; changes reflect in search and Family home detail. |
 | AI matching intake       | Family   | Intake → recommended homes list              | DONE   | `/homes/match` posts to `/api/ai/match/resident`; semantic + structured scoring. |
 
 Legend:


### PR DESCRIPTION
Update MVP status matrix to reflect current codebase:\n- Family: browse, filters, home details → DONE (wired to real data)\n- Inquiry/tour form → DONE (posts to /api/inquiries with validation)\n- Successful lead creation → DONE (visible in Operator list)\n- Operator: leads list, status, notes → DONE\n- Operator: edit listing → DONE (PATCH /api/operator/homes/[id]; updates visible to families)\n- AI matching intake → DONE (/homes/match + /api/ai/match/resident)\n- Operator → Family reply → TODO (no cross-party messaging)\n\nConservative notes kept for clarity.\n\nDroid-assisted.