### PR TITLE
feat(operator): Operator → Family reply

### DIFF
--- a/docs/mvp_status_matrix.md
+++ b/docs/mvp_status_matrix.md
@@ -10,7 +10,7 @@
 | Leads list               | Operator | See list of incoming leads                   | DONE   | `/operator/inquiries` lists DB inquiries with filtering by operator scope. |
 | Lead status updates      | Operator | Change & persist lead status                 | DONE   | PATCH `/api/operator/inquiries/[id]` updates status (with RBAC). |
 | Lead details/notes       | Operator | View full inquiry + add notes                | DONE   | Detail page at /operator/inquiries/[id]; GET + PATCH (/api/operator/inquiries/[id]); notes via PATCH /api/operator/inquiries/[id]/notes. |
-| Operator → Family reply  | Operator | Some form of response/messaging              | TODO   | No cross-party messaging implemented. |
+| Operator → Family reply  | Operator | Some form of response/messaging              | DONE   | Operators can send a response on the Lead detail; stored on Lead and optional email sent to family. |
 | Edit listing             | Operator | Edit listing & reflect changes for families  | DONE   | Edit UI at /operator/homes/[id]/edit patches /api/operator/homes/[id]; changes reflect in search and Family home detail. |
 | AI matching intake       | Family   | Intake → recommended homes list              | DONE   | `/homes/match` posts to `/api/ai/match/resident`; semantic + structured scoring. |
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -611,6 +611,9 @@ model Inquiry {
   message      String?       @db.Text
   /// Operator-internal notes for this lead (not visible to families)
   internalNotes String?      @db.Text
+  /// Last response message sent by the operator to the family (Phase 1)
+  operatorResponse String?   @db.Text
+  operatorResponseAt DateTime?
   tourDate     DateTime?
   aiMatchScore Float? // AI-generated placement likelihood score
 

--- a/src/app/api/operator/inquiries/[id]/respond/route.ts
+++ b/src/app/api/operator/inquiries/[id]/respond/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/lib/auth';
+import { PrismaClient, UserRole } from '@prisma/client';
+import { z } from 'zod';
+import emailService from '@/lib/email/sendgrid';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const prisma = new PrismaClient();
+
+const RespondSchema = z.object({
+  message: z.string().min(1).max(5000),
+});
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+    if (!user || (user.role !== UserRole.OPERATOR && user.role !== UserRole.ADMIN)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const inquiry = await prisma.inquiry.findUnique({
+      where: { id: params.id },
+      include: {
+        home: { select: { operatorId: true, name: true } },
+        family: { select: { user: { select: { email: true, firstName: true } } } },
+      },
+    });
+    if (!inquiry) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    if (user.role !== UserRole.ADMIN) {
+      const operator = await prisma.operator.findUnique({ where: { userId: user.id } });
+      if (!operator || inquiry.home.operatorId !== operator.id) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+    }
+
+    const json = await req.json().catch(() => ({}));
+    const parsed = RespondSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid payload', details: parsed.error.format() }, { status: 400 });
+    }
+
+    const now = new Date();
+    const updated = await prisma.inquiry.update({
+      where: { id: inquiry.id },
+      data: { operatorResponse: parsed.data.message, operatorResponseAt: now },
+      select: { id: true, operatorResponse: true, operatorResponseAt: true },
+    });
+
+    // Optional: email notification to family
+    if (inquiry.family.user.email) {
+      await emailService.sendNotificationEmail(
+        inquiry.family.user.email,
+        `New response from ${inquiry.home.name}`,
+        {
+          firstName: inquiry.family.user.firstName || 'there',
+          message: parsed.data.message,
+          actionUrl: undefined,
+          actionText: undefined,
+          category: 'lead-response',
+        }
+      ).catch(() => void 0);
+    }
+
+    return NextResponse.json({ id: updated.id, operatorResponse: updated.operatorResponse, operatorResponseAt: updated.operatorResponseAt });
+  } catch (e) {
+    console.error('Operator respond failed', e);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/src/app/api/operator/inquiries/[id]/route.ts
+++ b/src/app/api/operator/inquiries/[id]/route.ts
@@ -49,6 +49,8 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
       tourDate: inquiry.tourDate ? inquiry.tourDate.toISOString() : null,
       message: inquiry.message || null,
       internalNotes: inquiry.internalNotes || '',
+      operatorResponse: inquiry.operatorResponse || null,
+      operatorResponseAt: inquiry.operatorResponseAt ? inquiry.operatorResponseAt.toISOString() : null,
       home: { id: inquiry.home.id, name: inquiry.home.name },
       family: {
         id: inquiry.family.id,


### PR DESCRIPTION
This PR implements Operator ? Family reply for leads.

Key changes:
- Schema: add operatorResponse, operatorResponseAt to Inquiry
- API: POST /api/operator/inquiries/[id]/respond with RBAC, zod validation, Prisma update, optional email to family
- API: include response fields in GET /api/operator/inquiries/[id]
- UI: add "Response to Family" section on operator inquiry detail page
- Docs: mark MVP status matrix row as DONE

Quality:
- Lint ?
- Type-check ?
- Tests ? (277 passed)
- Build ?

Droid-assisted
