### PR TITLE
docs(aides-mvp): update caregiver marketplace MVP status matrix [Droid-assisted]

### DIFF
--- a/docs/mvp_status_aides.md
+++ b/docs/mvp_status_aides.md
@@ -1,0 +1,23 @@
+# CareLinkAI – Phase 1 MVP Status Matrix (Aide / Caregiver Marketplace)
+
+| Area                     | Role      | Capability                                          | Status | Notes / Gaps |
+|--------------------------|-----------|-----------------------------------------------------|--------|--------------|
+| Aide signup              | Aide      | Create account and log in                           | DONE   | Registration supports CAREGIVER role; email verification flow. API: src/app/api/auth/register/route.ts; UI: /auth/register, /auth/login. |
+| Aide profile basics      | Aide      | Create/edit profile (name, bio, photo)             | DONE   | Profile edit incl. bio, yearsExperience, hourlyRate, address, photo upload. API: /api/profile, /api/profile/photo; UI: /settings/profile. |
+| Aide skills & tags       | Aide      | Add skills, certifications, experience              | WIP    | Credentials upload DONE (see below). Skills/specialties exist in model (Caregiver.specialties) and marketplace filtering, but no caregiver UI/API to edit specialties/settings/careTypes via /api/profile. |
+| Aide availability        | Aide      | Set/update availability (days/times)                | WIP    | AvailabilitySlot model and availability JSON on caregiver; availability check API exists (/api/calendar/availability). No caregiver-facing UI to set working hours/slots. |
+| Aide documents upload    | Aide      | Upload certifications (CPR, CNA, etc.)             | DONE   | Full credentials CRUD with presigned upload. APIs: /api/caregiver/credentials, /api/caregiver/credentials/upload-url, /api/caregiver/credentials/[id]; UI: /settings/credentials. |
+| Aide verification status | Admin     | Mark aide as verified / pending / rejected          | TODO   | Credential.isVerified fields exist, but no admin/RBAC endpoint to verify credentials or mark caregiver verified. |
+| Aide search list         | Operator  | Browse/search list of aides                         | DONE   | Marketplace caregiver list implemented. API: /api/marketplace/caregivers; UI: /marketplace (Caregivers tab/cards). |
+| Aide filters             | Operator  | Filter aides by location, skills, availability      | WIP    | Filters: q, city/state, radius, rate, experience, specialties, settings, careTypes implemented. No availability-based filter. |
+| Aide detail view         | Operator  | View aide profile, skills, docs, availability       | WIP    | Detail shows photo, bio, rate, experience, specialties, reviews, hire request. No availability calendar or docs listing surfaced. UI: /marketplace/caregivers/[id]. |
+| Operator → Aide contact  | Operator  | Send an initial contact / message to aide           | WIP    | Messaging system exists (/api/messages, /messages). New message picker lists employed caregivers; marketplace "Message" button doesn’t deep link to caregiver. |
+| Aide → Operator reply    | Aide      | Respond to operator (basic 2-way communication)     | DONE   | Two-way messaging works with SSE notifications. APIs: /api/messages, /api/messages/threads; UI: /messages. |
+| Aide visibility control  | Aide      | Set profile as active/paused in marketplace         | TODO   | No visibility toggle/field on Caregiver or UI to pause/hide from marketplace. |
+| Admin aide oversight     | Admin     | List/search aides; view profiles & status           | TODO   | No admin-facing list/search for caregivers; operator endpoints cover only employed caregivers. |
+
+Legend:
+
+- TODO = not validated / not implemented
+- WIP = partially working or needs polish
+- DONE = works and meets the Phase 1 definition of done


### PR DESCRIPTION
This PR updates docs/mvp_status_aides.md with an evidence-based status matrix (DONE/WIP/TODO) for 13 aide/caregiver marketplace capabilities.\n\nKey points:\n- Source-of-truth verified against code: APIs, UI routes, and prisma models\n- Clear classification with concrete gaps to close (skills UI, availability UI, admin verification/oversight, visibility toggle)\n\nValidation (local):\n- Lint: pass\n- Type-check: pass\n- Tests: 277 passed\n- Build: success (Next 14)\n\nChange scope:\n- docs/mvp_status_aides.md only\n\nTag: [Droid-assisted]