### PR TITLE
Add Healthcare + Affiliate demo accounts, gitignore Playwright artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ out
 .deploy
 .logs
 *.tsbuildinfo
+
+# Playwright test artifacts
+test-results/
+playwright-report/

--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -16,10 +16,9 @@ Each loop: what it is, why it matters, what done looks like.
 - **Accounts:** demo.admin / demo.operator / demo.family / demo.aide / demo.provider @ carelinkai.test / DemoUser123!
 
 ### OL-002: ANTHROPIC_API_KEY not set in Render
-- **Status:** Open (was OPENAI_API_KEY + ABACUSAI_API_KEY — both replaced by single Anthropic key)
-- **Impact:** All AI features fail: CareBot, inquiry responses, document classification, discharge planner search, match explanations, tour scheduling, home profile generation
-- **Fix:** Set `ANTHROPIC_API_KEY` in Render dashboard > Environment. Get key from console.anthropic.com.
-- **Done when:** CareBot responds and `/api/inquiries/[id]/generate-response` returns AI text in production
+- **Status:** ✅ FIXED (2026-04-22) — Chris confirmed key is set in Render dashboard
+- **Impact was:** All AI features failing in production
+- **Done:** CareBot, inquiry AI, document classification, discharge planner, match explainer all live
 
 ### OL-004: Revenue model not finalized
 - **Status:** Open
@@ -94,3 +93,4 @@ Each loop: what it is, why it matters, what done looks like.
 | Migration failure (20251218) | Resolved with resolve script | 2025-12-19 |
 | CareBot implementation | Built and deployed | 2025-12-30 |
 | AI provider consolidation | Migrated all AI from OpenAI+AbacusAI → Anthropic Claude API | 2026-04-21 |
+| OL-002: ANTHROPIC_API_KEY | Set in Render dashboard by Chris | 2026-04-22 |

--- a/prisma/seed-demo.ts
+++ b/prisma/seed-demo.ts
@@ -183,7 +183,53 @@ async function main() {
       emailVerified: new Date(),
     },
   });
-  console.log('  ✓ Admin account created: demo.admin@carelinkai.test\n');
+  console.log('  ✓ Admin account created: demo.admin@carelinkai.test');
+
+  // 6. Demo Healthcare Professional / Discharge Planner Account
+  await prisma.user.upsert({
+    where: { email: 'demo.healthcare@carelinkai.test' },
+    update: {},
+    create: {
+      email: 'demo.healthcare@carelinkai.test',
+      passwordHash: hashedPassword,
+      firstName: 'Dr. Angela',
+      lastName: 'Foster',
+      phone: '(555) 678-9012',
+      role: UserRole.DISCHARGE_PLANNER,
+      status: 'ACTIVE',
+      emailVerified: new Date(),
+    },
+  });
+  console.log('  ✓ Healthcare Professional account created: demo.healthcare@carelinkai.test');
+
+  // 7. Demo Affiliate Partner Account
+  await prisma.user.upsert({
+    where: { email: 'demo.affiliate@carelinkai.test' },
+    update: {},
+    create: {
+      email: 'demo.affiliate@carelinkai.test',
+      passwordHash: hashedPassword,
+      firstName: 'Marcus',
+      lastName: 'Reed',
+      phone: '(555) 789-0123',
+      role: UserRole.AFFILIATE,
+      status: 'ACTIVE',
+      emailVerified: new Date(),
+      affiliate: {
+        create: {
+          affiliateCode: 'DEMO-AFF-001',
+          organization: 'Senior Care Referral Partners',
+          commissionRate: 15.00,
+          paymentDetails: {
+            method: 'ACH',
+            bankName: 'Demo Bank',
+            accountType: 'checking',
+          },
+        },
+      },
+    },
+  });
+  console.log('  ✓ Affiliate Partner account created: demo.affiliate@carelinkai.test\n');
 
   // ==================== ADDITIONAL CAREGIVERS ====================
   
@@ -655,14 +701,16 @@ async function main() {
   console.log('═══════════════════════════════════════════════════════════');
   console.log('📧 DEMO ACCOUNTS (Password: DemoUser123!)');
   console.log('═══════════════════════════════════════════════════════════');
-  console.log('1. Family:   demo.family@carelinkai.test');
-  console.log('2. Operator: demo.operator@carelinkai.test');
-  console.log('3. Aide:     demo.aide@carelinkai.test');
-  console.log('4. Provider: demo.provider@carelinkai.test');
-  console.log('5. Admin:    demo.admin@carelinkai.test');
+  console.log('1. Family:        demo.family@carelinkai.test');
+  console.log('2. Operator:      demo.operator@carelinkai.test');
+  console.log('3. Caregiver:     demo.aide@carelinkai.test');
+  console.log('4. Provider:      demo.provider@carelinkai.test');
+  console.log('5. Admin:         demo.admin@carelinkai.test');
+  console.log('6. Healthcare:    demo.healthcare@carelinkai.test');
+  console.log('7. Affiliate:     demo.affiliate@carelinkai.test');
   console.log('═══════════════════════════════════════════════════════════');
   console.log(`\n📊 Created:`);
-  console.log(`   • 5 demo accounts with realistic profiles`);
+  console.log(`   • 7 demo accounts with realistic profiles`);
   console.log(`   • 6 additional caregivers (various cities)`);
   console.log(`   • 5 additional providers (various cities)`);
   console.log(`   • 4 leads (various statuses)`);


### PR DESCRIPTION
## Summary
- Adds `demo.healthcare@carelinkai.test` (DISCHARGE_PLANNER role) and `demo.affiliate@carelinkai.test` (AFFILIATE role) to `seed-demo.ts` for full coverage of all 6 registration types
- Adds `test-results/` and `playwright-report/` to `.gitignore` (Playwright artifacts)
- Marks OL-002 (ANTHROPIC_API_KEY) as closed in open loops context file

## After merging
Run `npm run seed:demo` in the Render shell to create the 2 missing demo accounts (safe to re-run — uses upsert, won't duplicate existing accounts).