### PR TITLE
feat: admin revenue dashboard + operator onboarding wizard

### DIFF
--- a/context/CARELINKAI_TECHNICAL_STATE.md
+++ b/context/CARELINKAI_TECHNICAL_STATE.md
@@ -2,7 +2,7 @@
 _Last updated: 2026-04-24_
 
 ## Active Branch
-`claude/review-carelink-docs-49Ycv` (Stripe subscription billing — ready to merge to main)
+`claude/review-carelink-docs-49Ycv` (admin revenue dashboard + operator onboarding wizard — ready to merge to main)
 
 ## Production URL
 https://carelinkai.onrender.com (also: https://getcarelinkai.com)
@@ -57,11 +57,13 @@ FAMILY, OPERATOR, CAREGIVER, ADMIN, STAFF, PROVIDER, AFFILIATE, DISCHARGE_PLANNE
 - Analytics: GA4, GTM, FB Pixel, Clarity
 - Anthropic Claude API: CareBot, inquiry responses, document classification, discharge planner search, match explanations, tour scheduling, home profile generation
 - Operator subscription billing: Checkout (14-day trial), Customer Portal, webhook lifecycle handlers, feature gating utility
+- **Admin revenue dashboard:** MRR, placement fees collected/pending, affiliate commissions owed, recent payments table, subscription breakdown by plan
+- **Operator onboarding wizard:** 3-step guided flow (company → first home → plan selection); new operators auto-redirected on first login
 
 ## Known Issues (as of 2026-04-24)
 1. 274 TypeScript strict mode errors — CI type-check step is disabled (non-blocking at runtime)
 2. 2 pre-existing test failures: `calendar.appointments.api` and `emergency.api`
-3. CareBot outputs raw markdown (`**bold**`) in chat widget (OL-013) — needs plain text prompt fix, same as inquiry response generator fix applied 2026-04-23
+3. ~~CareBot outputs raw markdown~~ — FIXED (OL-013 closed 2026-04-24)
 4. Stripe Products/Prices not yet created in Stripe dashboard — subscription checkout will fail until `STRIPE_PRICE_*` env vars are set
 
 ## Pending Deployment Actions (before subscription billing goes live)

--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -1,5 +1,5 @@
 # CareLinkAI — Tech Open Loops
-_Last updated: 2026-04-24_
+_Last updated: 2026-04-24 (session 2)_
 
 ## Format
 Each loop: what it is, why it matters, what done looks like.

--- a/context/DEV_SESSION_SUMMARIES.md
+++ b/context/DEV_SESSION_SUMMARIES.md
@@ -2,6 +2,40 @@
 
 ---
 
+### 2026-04-24 — Admin Revenue Dashboard + Operator Onboarding Wizard
+
+- **Objective:** Build admin revenue visibility (MRR, placement fees, affiliate commissions) and guided first-time operator onboarding.
+
+- **Work completed:**
+  1. **Admin analytics API rewrite** (`/api/admin/analytics`): Added revenue block with MRR calc (active/trialing operators × plan price), placement fees collected/pending aggregates, affiliate commissions owed, recent 15 payments with user info, subscription breakdown by plan+status.
+  2. **Admin analytics page revenue UI**: Added Revenue section above existing KPI cards — 4 stat cards (MRR, Placement Fees Collected, Placement Fees Pending, Affiliate Commissions Owed), subscription plan breakdown grid, recent payments table with type/amount/status/user/date columns.
+  3. **Operator onboarding wizard** (`/operator/onboarding`): 3-step client wizard — Step 1 company/phone, Step 2 first home (with care-level checkboxes), Step 3 plan selection (Starter/Professional/Growth) with FOUNDERS49 reminder + "Skip for now". No schema changes needed; uses `homes === 0` as onboarding signal.
+  4. **Operator dashboard redirect**: Added `homes === 0` check after dashboard data loads; new operators are immediately redirected to `/operator/onboarding`.
+  5. **Stripe setup runbook** (`context/STRIPE_SETUP_RUNBOOK.md`): CoWork-ready 6-step guide for creating Products/Prices, webhook, Customer Portal, env vars — reusable when Chris swaps Stripe accounts.
+  6. **Affiliate nav item**: Added "Affiliate Dashboard" to sidebar (AFFILIATE + ADMIN roles only).
+  7. **PR #497 merge**: Rebased and squash-merged to main after 3 rounds of conflict resolution on `.env.example`, `DashboardLayout.tsx`, `CARELINKAI_TECH_OPEN_LOOPS.md`.
+  8. **Analytics crash fix** (`/operator/analytics`): Extracted chart.js renders to `"use client"` `AnalyticsCharts.tsx` component; created proper export API route.
+
+- **Files changed:**
+  - `src/app/api/admin/analytics/route.ts` — revenue queries + MRR calc
+  - `src/app/admin/analytics/page.tsx` — revenue section UI
+  - `src/app/operator/onboarding/page.tsx` — new 3-step wizard
+  - `src/components/operator/OperatorDashboardPage.tsx` — redirect on homes === 0
+  - `src/app/operator/analytics/AnalyticsCharts.tsx` — new client chart component
+  - `src/app/operator/analytics/page.tsx` — server component with chart props
+  - `src/app/api/operator/analytics/export/route.ts` — new CSV export route
+  - `src/components/layout/DashboardLayout.tsx` — affiliate nav item
+  - `.env.example` — DEFAULT_AFFILIATE_COMMISSION_PCT, CRON_SECRET
+  - `context/STRIPE_SETUP_RUNBOOK.md` — new CoWork runbook
+
+- **Commands run:** `git rebase origin/main`, `git push --force-with-lease`, `npx tsc --noEmit` (0 errors on analytics files)
+- **Tests/build status:** TypeScript clean on changed files; CI type-check step still disabled (OL-005/OL-006)
+- **Deployment impact:** Admin analytics page now includes revenue section; operator onboarding wizard is live on branch. Needs merge to main to deploy.
+- **New risks/blockers:** None new. Revenue data will show $0 until Stripe is live (OL-004).
+- **Recommended next step:** Merge `claude/review-carelink-docs-49Ycv` to main so revenue dashboard and onboarding wizard deploy to production. Then work OL-005 (TypeScript strict errors) to re-enable CI type-check.
+
+---
+
 ### 2026-04-24 — Revenue Streams: Billing Switch, SMS, Care Wallet, Affiliate Commission
 
 - **Objective:** Close 5 revenue and notification features: placement fee billing model switch, FOUNDERS49 promo code, Twilio SMS (OL-009), Care Wallet spending, and affiliate commission auto-trigger.

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -25,6 +25,9 @@ import {
   FiActivity,
   FiPercent,
   FiRefreshCw,
+  FiDollarSign,
+  FiCreditCard,
+  FiLink,
 } from 'react-icons/fi';
 
 interface KPIs {
@@ -50,8 +53,38 @@ interface GrowthData {
   count: number;
 }
 
+interface RevenuePayment {
+  id: string;
+  amount: number;
+  type: string;
+  status: string;
+  description: string | null;
+  createdAt: string;
+  user: { firstName: string | null; lastName: string | null; email: string } | null;
+}
+
+interface SubscriptionBreakdownItem {
+  plan: string | null;
+  status: string | null;
+  count: number;
+}
+
+interface Revenue {
+  mrr: number;
+  activeSubscribers: number;
+  planCounts: Record<string, number>;
+  placementFeesCollected: number;
+  placementFeesPending: number;
+  placementFeesCollectedCount: number;
+  affiliateCommissionsOwed: number;
+  affiliateCommissionsOwedCount: number;
+  recentPayments: RevenuePayment[];
+  subscriptionBreakdown: SubscriptionBreakdownItem[];
+}
+
 interface AnalyticsData {
   kpis: KPIs;
+  revenue: Revenue;
   charts: {
     userRoleDistribution: ChartData[];
     userStatusDistribution: ChartData[];
@@ -169,7 +202,31 @@ export default function AnalyticsPage() {
 
   if (!data) return null;
 
-  const { kpis, charts } = data;
+  const { kpis, revenue, charts } = data;
+
+  const fmt$ = (n: number) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(n);
+
+  const PLAN_ORDER = ['STARTER', 'PROFESSIONAL', 'GROWTH', 'ENTERPRISE'];
+  const PLAN_COLORS: Record<string, string> = {
+    STARTER: 'bg-blue-100 text-blue-800',
+    PROFESSIONAL: 'bg-purple-100 text-purple-800',
+    GROWTH: 'bg-emerald-100 text-emerald-800',
+    ENTERPRISE: 'bg-amber-100 text-amber-800',
+  };
+  const PAYMENT_TYPE_LABELS: Record<string, string> = {
+    PLACEMENT_FEE: 'Placement Fee',
+    AFFILIATE_COMMISSION: 'Affiliate Commission',
+    DEPOSIT: 'Deposit',
+    MONTHLY_FEE: 'Monthly Fee',
+  };
+  const PAYMENT_STATUS_COLORS: Record<string, string> = {
+    COMPLETED: 'text-emerald-700 bg-emerald-50',
+    PENDING: 'text-amber-700 bg-amber-50',
+    PROCESSING: 'text-blue-700 bg-blue-50',
+    FAILED: 'text-red-700 bg-red-50',
+    REFUNDED: 'text-gray-700 bg-gray-100',
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 p-6">
@@ -232,6 +289,118 @@ export default function AnalyticsPage() {
             icon={FiPercent}
             color="bg-amber-500"
           />
+        </div>
+
+        {/* Revenue Section */}
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+            <FiDollarSign className="text-emerald-500" />
+            Revenue
+          </h2>
+
+          {/* Revenue KPI Cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+            <KPICard
+              title="Monthly Recurring Revenue"
+              value={fmt$(revenue.mrr)}
+              subValue={`${revenue.activeSubscribers} active subscribers`}
+              icon={FiDollarSign}
+              color="bg-emerald-500"
+            />
+            <KPICard
+              title="Placement Fees Collected"
+              value={fmt$(revenue.placementFeesCollected)}
+              subValue={`${revenue.placementFeesCollectedCount} completed`}
+              icon={FiCreditCard}
+              color="bg-blue-500"
+            />
+            <KPICard
+              title="Placement Fees Pending"
+              value={fmt$(revenue.placementFeesPending)}
+              subValue="In processing"
+              icon={FiCreditCard}
+              color="bg-amber-500"
+            />
+            <KPICard
+              title="Affiliate Commissions Owed"
+              value={fmt$(revenue.affiliateCommissionsOwed)}
+              subValue={`${revenue.affiliateCommissionsOwedCount} pending payouts`}
+              icon={FiLink}
+              color="bg-purple-500"
+            />
+          </div>
+
+          {/* Subscription plan breakdown + recent payments */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            {/* Plan breakdown */}
+            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+              <h3 className="text-base font-semibold text-gray-900 mb-4">Subscriptions by Plan</h3>
+              <div className="space-y-3">
+                {PLAN_ORDER.map((plan) => {
+                  const count = revenue.planCounts[plan] || 0;
+                  return (
+                    <div key={plan} className="flex items-center justify-between">
+                      <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${PLAN_COLORS[plan] || 'bg-gray-100 text-gray-700'}`}>
+                        {plan}
+                      </span>
+                      <span className="text-sm font-semibold text-gray-900">{count}</span>
+                    </div>
+                  );
+                })}
+                {revenue.subscriptionBreakdown
+                  .filter(r => r.status === 'TRIALING')
+                  .map(r => (
+                    <div key={`trial-${r.plan}`} className="flex items-center justify-between text-gray-500">
+                      <span className="text-xs">{r.plan} (trial)</span>
+                      <span className="text-sm font-medium">{r.count}</span>
+                    </div>
+                  ))}
+              </div>
+            </div>
+
+            {/* Recent payments table */}
+            <div className="lg:col-span-2 bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+              <h3 className="text-base font-semibold text-gray-900 mb-4">Recent Payments</h3>
+              {revenue.recentPayments.length === 0 ? (
+                <p className="text-sm text-gray-500 text-center py-8">No payments recorded yet</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-gray-500 border-b border-gray-100">
+                        <th className="pb-2 font-medium">Type</th>
+                        <th className="pb-2 font-medium">Amount</th>
+                        <th className="pb-2 font-medium">Status</th>
+                        <th className="pb-2 font-medium">User</th>
+                        <th className="pb-2 font-medium">Date</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-50">
+                      {revenue.recentPayments.map((p) => (
+                        <tr key={p.id} className="hover:bg-gray-50">
+                          <td className="py-2 text-gray-700">
+                            {PAYMENT_TYPE_LABELS[p.type] || p.type}
+                          </td>
+                          <td className="py-2 font-medium text-gray-900">{fmt$(p.amount)}</td>
+                          <td className="py-2">
+                            <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${PAYMENT_STATUS_COLORS[p.status] || 'bg-gray-100 text-gray-700'}`}>
+                              {p.status}
+                            </span>
+                          </td>
+                          <td className="py-2 text-gray-600 truncate max-w-[120px]">
+                            {p.user ? `${p.user.firstName || ''} ${p.user.lastName || ''}`.trim() || p.user.email : '—'}
+                          </td>
+                          <td className="py-2 text-gray-500">
+                            {new Date(p.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
 
         {/* Charts Row 1 */}

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -5,233 +5,165 @@ import { prisma } from '@/lib/prisma';
 
 export const dynamic = 'force-dynamic';
 
+const PLAN_PRICES: Record<string, number> = {
+  STARTER: 99,
+  PROFESSIONAL: 249,
+  GROWTH: 499,
+  ENTERPRISE: 999,
+};
+
 export async function GET(request: NextRequest) {
   console.log('[Analytics API] GET request received');
   try {
     const session = await getServerSession(authOptions);
-    console.log('[Analytics API] Session:', session ? `User: ${session.user?.email}, Role: ${session.user?.role}` : 'No session');
-    
     if (!session?.user || session.user.role !== 'ADMIN') {
-      console.log('[Analytics API] Unauthorized access attempt');
-      return NextResponse.json(
-        { error: 'Unauthorized - Admin access required' },
-        { status: 403 }
-      );
+      return NextResponse.json({ error: 'Unauthorized - Admin access required' }, { status: 403 });
     }
 
     const searchParams = request.nextUrl.searchParams;
-    const timeRange = searchParams.get('timeRange') || '30'; // days
+    const timeRange = searchParams.get('timeRange') || '30';
     const days = parseInt(timeRange);
-    
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - days);
 
-    // Parallel queries for all analytics data
     const [
-      // User metrics
-      totalUsers,
-      usersByRole,
-      usersByStatus,
-      newUsersInPeriod,
-      userGrowthData,
-      
-      // Inquiry metrics
-      totalInquiries,
-      inquiriesByStatus,
-      newInquiriesInPeriod,
-      inquiryGrowthData,
-      convertedInquiries,
-      
-      // Home metrics
-      totalHomes,
-      homesByStatus,
-      totalCapacity,
-      totalOccupancy,
-      
-      // Activity metrics
-      recentLogins,
-      auditLogsByAction,
+      totalUsers, usersByRole, usersByStatus, newUsersInPeriod, userGrowthData,
+      totalInquiries, inquiriesByStatus, newInquiriesInPeriod, inquiryGrowthData, convertedInquiries,
+      totalHomes, homesByStatus, totalCapacity, totalOccupancy,
+      recentLogins, auditLogsByAction,
+      // Revenue queries
+      activeOperators,
+      placementFeesCompleted,
+      placementFeesPending,
+      affiliateCommissionsOwed,
+      recentPayments,
+      subscriptionBreakdown,
     ] = await Promise.all([
-      // Total users
       prisma.user.count(),
-      
-      // Users by role
-      prisma.user.groupBy({
-        by: ['role'],
-        _count: { id: true },
-      }),
-      
-      // Users by status
-      prisma.user.groupBy({
-        by: ['status'],
-        _count: { id: true },
-      }),
-      
-      // New users in period
-      prisma.user.count({
-        where: {
-          createdAt: { gte: startDate },
-        },
-      }),
-      
-      // User growth over time (daily counts)
+      prisma.user.groupBy({ by: ['role'], _count: { id: true } }),
+      prisma.user.groupBy({ by: ['status'], _count: { id: true } }),
+      prisma.user.count({ where: { createdAt: { gte: startDate } } }),
       prisma.$queryRaw`
-        SELECT 
-          DATE("createdAt") as date,
-          COUNT(*)::int as count
-        FROM "User"
-        WHERE "createdAt" >= ${startDate}
-        GROUP BY DATE("createdAt")
-        ORDER BY date ASC
+        SELECT DATE("createdAt") as date, COUNT(*)::int as count
+        FROM "User" WHERE "createdAt" >= ${startDate}
+        GROUP BY DATE("createdAt") ORDER BY date ASC
       `,
-      
-      // Total inquiries
       prisma.inquiry.count(),
-      
-      // Inquiries by status
-      prisma.inquiry.groupBy({
-        by: ['status'],
-        _count: { id: true },
-      }),
-      
-      // New inquiries in period
-      prisma.inquiry.count({
-        where: {
-          createdAt: { gte: startDate },
-        },
-      }),
-      
-      // Inquiry growth over time
+      prisma.inquiry.groupBy({ by: ['status'], _count: { id: true } }),
+      prisma.inquiry.count({ where: { createdAt: { gte: startDate } } }),
       prisma.$queryRaw`
-        SELECT 
-          DATE("createdAt") as date,
-          COUNT(*)::int as count
-        FROM "Inquiry"
-        WHERE "createdAt" >= ${startDate}
-        GROUP BY DATE("createdAt")
-        ORDER BY date ASC
+        SELECT DATE("createdAt") as date, COUNT(*)::int as count
+        FROM "Inquiry" WHERE "createdAt" >= ${startDate}
+        GROUP BY DATE("createdAt") ORDER BY date ASC
       `,
-      
-      // Converted inquiries (those with conversionDate)
-      prisma.inquiry.count({
-        where: {
-          conversionDate: { not: null },
-        },
-      }),
-      
-      // Total homes
+      prisma.inquiry.count({ where: { conversionDate: { not: null } } }),
       prisma.assistedLivingHome.count(),
-      
-      // Homes by status
-      prisma.assistedLivingHome.groupBy({
-        by: ['status'],
+      prisma.assistedLivingHome.groupBy({ by: ['status'], _count: { id: true } }),
+      prisma.assistedLivingHome.aggregate({ _sum: { capacity: true } }),
+      prisma.assistedLivingHome.aggregate({ _sum: { currentOccupancy: true } }),
+      prisma.auditLog.count({ where: { action: 'LOGIN', createdAt: { gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) } } }),
+      prisma.auditLog.groupBy({ by: ['action'], _count: { id: true }, where: { createdAt: { gte: startDate } } }),
+      // Active/trialing operators with their plan
+      prisma.operator.findMany({
+        where: { subscriptionStatus: { in: ['ACTIVE', 'TRIALING'] }, subscriptionPlan: { not: null } },
+        select: { subscriptionPlan: true, subscriptionStatus: true },
+      }),
+      // Completed placement fees (total collected)
+      prisma.payment.aggregate({
+        where: { type: 'PLACEMENT_FEE', status: 'COMPLETED' },
+        _sum: { amount: true },
         _count: { id: true },
       }),
-      
-      // Total capacity
-      prisma.assistedLivingHome.aggregate({
-        _sum: { capacity: true },
-      }),
-      
-      // Total current occupancy
-      prisma.assistedLivingHome.aggregate({
-        _sum: { currentOccupancy: true },
-      }),
-      
-      // Recent logins (last 7 days)
-      prisma.auditLog.count({
-        where: {
-          action: 'LOGIN',
-          createdAt: {
-            gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
-          },
-        },
-      }),
-      
-      // Audit logs by action type (for activity chart)
-      prisma.auditLog.groupBy({
-        by: ['action'],
+      // Pending/processing placement fees
+      prisma.payment.aggregate({
+        where: { type: 'PLACEMENT_FEE', status: { in: ['PENDING', 'PROCESSING'] } },
+        _sum: { amount: true },
         _count: { id: true },
-        where: {
-          createdAt: { gte: startDate },
+      }),
+      // Affiliate commissions owed (pending)
+      prisma.payment.aggregate({
+        where: { type: 'AFFILIATE_COMMISSION', status: 'PENDING' },
+        _sum: { amount: true },
+        _count: { id: true },
+      }),
+      // Recent revenue payments
+      prisma.payment.findMany({
+        where: { type: { in: ['PLACEMENT_FEE', 'AFFILIATE_COMMISSION', 'DEPOSIT', 'MONTHLY_FEE'] } },
+        orderBy: { createdAt: 'desc' },
+        take: 15,
+        select: {
+          id: true, amount: true, type: true, status: true, description: true, createdAt: true,
+          user: { select: { firstName: true, lastName: true, email: true } },
         },
+      }),
+      // Subscription counts by plan and status
+      prisma.operator.groupBy({
+        by: ['subscriptionPlan', 'subscriptionStatus'],
+        where: { subscriptionPlan: { not: null } },
+        _count: { id: true },
       }),
     ]);
 
-    // Calculate KPIs
+    // ── Revenue calculations ────────────────────────────────────────────────
+    let mrr = 0;
+    const planCounts: Record<string, number> = {};
+    for (const op of activeOperators) {
+      const plan = op.subscriptionPlan as string;
+      const price = PLAN_PRICES[plan] ?? 0;
+      mrr += price;
+      planCounts[plan] = (planCounts[plan] || 0) + 1;
+    }
+
     const capacity = totalCapacity._sum.capacity || 0;
     const occupancy = totalOccupancy._sum.currentOccupancy || 0;
     const occupancyRate = capacity > 0 ? ((occupancy / capacity) * 100).toFixed(1) : 0;
-    const conversionRate = totalInquiries > 0 
-      ? ((convertedInquiries / totalInquiries) * 100).toFixed(1) 
-      : 0;
+    const conversionRate = totalInquiries > 0 ? ((convertedInquiries / totalInquiries) * 100).toFixed(1) : 0;
 
-    // Format data for charts
-    const userRoleDistribution = usersByRole.map(item => ({
-      name: item.role,
-      value: item._count.id,
-    }));
-
-    const userStatusDistribution = usersByStatus.map(item => ({
-      name: item.status,
-      value: item._count.id,
-    }));
-
-    const inquiryStatusDistribution = inquiriesByStatus.map(item => ({
-      name: item.status,
-      value: item._count.id,
-    }));
-
-    const homeStatusDistribution = homesByStatus.map(item => ({
-      name: item.status,
-      value: item._count.id,
-    }));
-
-    const activityByType = auditLogsByAction.map(item => ({
-      name: item.action,
-      value: item._count.id,
-    })).sort((a, b) => b.value - a.value).slice(0, 10);
-
-    // Format growth data
-    const formatGrowthData = (data: any[]) => {
-      return data.map(item => ({
+    const formatGrowthData = (data: any[]) =>
+      data.map((item) => ({
         date: new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
         count: item.count,
       }));
-    };
 
     return NextResponse.json({
+      revenue: {
+        mrr,
+        activeSubscribers: activeOperators.length,
+        planCounts,
+        placementFeesCollected: Number(placementFeesCompleted._sum.amount ?? 0),
+        placementFeesPending: Number(placementFeesPending._sum.amount ?? 0),
+        placementFeesCollectedCount: placementFeesCompleted._count.id,
+        affiliateCommissionsOwed: Number(affiliateCommissionsOwed._sum.amount ?? 0),
+        affiliateCommissionsOwedCount: affiliateCommissionsOwed._count.id,
+        recentPayments: recentPayments.map((p) => ({
+          ...p,
+          amount: Number(p.amount),
+          createdAt: p.createdAt.toISOString(),
+        })),
+        subscriptionBreakdown: subscriptionBreakdown.map((r) => ({
+          plan: r.subscriptionPlan,
+          status: r.subscriptionStatus,
+          count: r._count.id,
+        })),
+      },
       kpis: {
-        totalUsers,
-        newUsersInPeriod,
-        totalInquiries,
-        newInquiriesInPeriod,
-        totalHomes,
-        occupancyRate: Number(occupancyRate),
-        conversionRate: Number(conversionRate),
-        recentLogins,
-        capacity,
-        occupancy,
+        totalUsers, newUsersInPeriod, totalInquiries, newInquiriesInPeriod,
+        totalHomes, occupancyRate: Number(occupancyRate), conversionRate: Number(conversionRate),
+        recentLogins, capacity, occupancy,
       },
       charts: {
-        userRoleDistribution,
-        userStatusDistribution,
-        inquiryStatusDistribution,
-        homeStatusDistribution,
+        userRoleDistribution: usersByRole.map((i) => ({ name: i.role, value: i._count.id })),
+        userStatusDistribution: usersByStatus.map((i) => ({ name: i.status, value: i._count.id })),
+        inquiryStatusDistribution: inquiriesByStatus.map((i) => ({ name: i.status, value: i._count.id })),
+        homeStatusDistribution: homesByStatus.map((i) => ({ name: i.status, value: i._count.id })),
         userGrowthData: formatGrowthData(userGrowthData as any[]),
         inquiryGrowthData: formatGrowthData(inquiryGrowthData as any[]),
-        activityByType,
+        activityByType: auditLogsByAction.map((i) => ({ name: i.action, value: i._count.id })).sort((a, b) => b.value - a.value).slice(0, 10),
       },
       timeRange: days,
     });
   } catch (error) {
     console.error('[Analytics API] Error:', error);
-    return NextResponse.json(
-      { 
-        error: 'Failed to fetch analytics data', 
-        details: error instanceof Error ? error.message : 'Unknown error' 
-      },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to fetch analytics data', details: error instanceof Error ? error.message : 'Unknown error' }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- **Admin revenue dashboard**: Analytics page now includes MRR (from active subscriptions × plan price), placement fees collected/pending, affiliate commissions owed, recent payments table, and subscription breakdown by plan
- **Operator onboarding wizard**: 3-step guided flow (company info → first home → plan selection) with FOUNDERS49 reminder; new operators auto-redirected on first login when they have 0 homes
- **Analytics API cleanup**: Removed duplicate orphaned function body from `/api/admin/analytics`; revenue data added to API response

## Files changed
- `src/app/api/admin/analytics/route.ts` — revenue queries + MRR calculation
- `src/app/admin/analytics/page.tsx` — revenue section UI (4 KPI cards + plan breakdown + payments table)
- `src/app/operator/onboarding/page.tsx` — new 3-step wizard
- `src/components/operator/OperatorDashboardPage.tsx` — redirect to onboarding when homes === 0

## Deployment notes
- No schema migration needed
- Revenue cards will show $0 until Stripe is live (OL-004)

https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ)_