### PR TITLE
fix: user table overflow + switch-plan Stripe error handling

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -386,12 +386,12 @@ export default function AdminUsersPage() {
                         className="rounded border-neutral-300 text-[#3978FC] focus:ring-[#3978FC]"
                       />
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div>
-                        <div className="text-sm font-medium text-neutral-900">
+                    <td className="px-6 py-4 max-w-[260px]">
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium text-neutral-900 truncate">
                           {user.firstName && user.lastName ? `${user.firstName} ${user.lastName}` : user.email}
                         </div>
-                        <div className="text-sm text-neutral-500">{user.email}</div>
+                        <div className="text-sm text-neutral-500 truncate">{user.email}</div>
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">

--- a/src/app/api/operator/billing/switch-plan/route.ts
+++ b/src/app/api/operator/billing/switch-plan/route.ts
@@ -61,50 +61,49 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Find the active subscription on the Stripe customer
-  const subscriptions = await stripe.subscriptions.list({
-    customer: operator.stripeCustomerId,
-    status: 'all',
-    limit: 5,
-  });
+  try {
+    // Find the active subscription on the Stripe customer
+    const subscriptions = await stripe.subscriptions.list({
+      customer: operator.stripeCustomerId,
+      status: 'all',
+      limit: 5,
+    });
 
-  const activeSub = subscriptions.data.find(
-    (s) => s.status === 'active' || s.status === 'trialing'
-  );
-
-  if (!activeSub) {
-    return NextResponse.json(
-      { error: 'No active subscription found. Please subscribe first.' },
-      { status: 400 }
+    const activeSub = subscriptions.data.find(
+      (s) => s.status === 'active' || s.status === 'trialing'
     );
+
+    if (!activeSub) {
+      return NextResponse.json(
+        { error: 'No active subscription found. Please subscribe first.' },
+        { status: 400 }
+      );
+    }
+
+    if (plan === operator.subscriptionPlan) {
+      return NextResponse.json({ error: 'You are already on this plan.' }, { status: 400 });
+    }
+
+    const subscriptionItemId = activeSub.items.data[0]?.id;
+    if (!subscriptionItemId) {
+      return NextResponse.json({ error: 'Subscription item not found.' }, { status: 500 });
+    }
+
+    await stripe.subscriptions.update(activeSub.id, {
+      items: [{ id: subscriptionItemId, price: priceId }],
+      proration_behavior: 'create_prorations',
+      metadata: { plan },
+    });
+
+    await prisma.operator.update({
+      where: { id: operator.id },
+      data: { subscriptionPlan: plan as any },
+    });
+
+    return NextResponse.json({ success: true, plan, label: PLAN_LABEL[plan] });
+  } catch (err: any) {
+    console.error('[switch-plan] Stripe error:', err);
+    const message = err?.raw?.message || err?.message || 'Stripe error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  if (plan === operator.subscriptionPlan) {
-    return NextResponse.json({ error: 'You are already on this plan.' }, { status: 400 });
-  }
-
-  // Update the subscription with the new price
-  const subscriptionItemId = activeSub.items.data[0]?.id;
-  if (!subscriptionItemId) {
-    return NextResponse.json({ error: 'Subscription item not found.' }, { status: 500 });
-  }
-
-  await stripe.subscriptions.update(activeSub.id, {
-    items: [{ id: subscriptionItemId, price: priceId }],
-    proration_behavior: 'create_prorations',
-    metadata: { plan },
-  });
-
-  // Update operator record immediately (webhook will also fire but this ensures
-  // the UI reflects the change without waiting for the webhook round-trip)
-  await prisma.operator.update({
-    where: { id: operator.id },
-    data: { subscriptionPlan: plan as any },
-  });
-
-  return NextResponse.json({
-    success: true,
-    plan,
-    label: PLAN_LABEL[plan],
-  });
 }


### PR DESCRIPTION
- **User table**: Added `truncate` + `max-w-[260px]` to user cell — deleted-user emails were extremely long and pushing the Actions column off screen
- **switch-plan**: Wrapped all Stripe calls in try/catch so errors return JSON instead of HTML; UI now shows the actual Stripe error message instead of the generic fallback

https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ)_