### PR TITLE
fix: marketplace mock mode defaults OFF in production

### DIFF
--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -27,6 +27,11 @@ Each loop: what it is, why it matters, what done looks like.
 - **Status:** ✅ CLOSED (2026-05-03)
 - POST route blocks at 10 apps with 403 + `upgradeRequired: true`; `applicationCount` incremented on every submit; monthly reset cron at `/api/cron/reset-application-counts` (Render cron `0 0 1 * *` created); `ListingActions.tsx` shows Pro upsell banner with CTA to `/settings/billing`.
 
+### OL-036: Marketplace filter slug alignment for existing providers
+- **Status:** 🟡 OPEN — requires production action
+- **What:** Provider settings service type slugs changed from underscore to hyphen format (2026-05-04). Existing providers in production DB have old `personal_care`, `home_care` etc. stored. They need to re-save their settings page to update. Also: run `npx prisma db seed` in Render shell to populate new marketplace categories.
+- **Done when:** Demo provider re-saves settings, all new categories appear in marketplace filter.
+
 ### OL-032: Family subscription tier ($19/mo "CareLinkAI Plus")
 - **Status:** ✅ CLOSED (prior session — exact date unknown)
 - `plusStatus` + `isPlus` on Family model; `POST /api/family/billing/subscribe` (Stripe Checkout); `POST /api/family/billing/portal`; webhook syncs `plusStatus` on subscription events; billing UI at `/settings/family/billing` with feature list ($19/mo, 14-day trial); Plus nav item in sidebar with amber highlight; admin MRR tile shows `familyPlusMRR`. Requires `STRIPE_PRICE_FAMILY_PLUS` env var.

--- a/context/DEV_SESSION_SUMMARIES.md
+++ b/context/DEV_SESSION_SUMMARIES.md
@@ -2,6 +2,29 @@
 
 ---
 
+### 2026-05-04 — Marketplace Filter End-to-End Fix (Providers, Jobs, Categories)
+
+- **Objective:** Fix marketplace filters so transportation and other service type filters actually work for providers, jobs, and caregivers tabs.
+- **Work completed:**
+  1. **Root cause analysis** — Identified 3 provider API bugs: (a) `NOT IN` with NULL listingStatus incorrectly excluded providers without a Stripe subscription; (b) serviceTypes filter only used first value from CSV; (c) `verified` filter applied on empty string. Also identified slug format mismatches between provider settings (underscore) and marketplace categories (hyphen).
+  2. **Provider API fix** — `src/app/api/marketplace/providers/route.ts`: replaced `NOT: { listingStatus: { in: [...] } }` with `OR: [null, notIn([...])]` in AND block to correctly handle NULL. Changed serviceTypes filter from `has: first` to `hasSome: all`. Fixed `verified` to only apply on explicit 'true'/'false'.
+  3. **Provider settings slugs** — `src/app/settings/provider/page.tsx`: changed all underscore service type values to hyphen format (`home_care` → `home-care`, `personal_care` → `personal-care`, etc.) to match marketplace category slug format.
+  4. **Seed categories expanded** — `prisma/seed.ts`: SERVICE categories now include all provider service types + job service types. SETTING, CARE_TYPE, SPECIALTY expanded. All slugs verified globally unique across types.
+  5. **Job listing form** — `src/app/marketplace/listings/new/page.tsx`: SETTINGS/CARE_TYPES/SERVICES/SPECIALTIES constants converted from display strings to `{value: slug, label: displayName}` format. CheckGroup updated to handle new format. New listings now store slugs → filterable by marketplace filter.
+- **Files changed:**
+  - `src/app/api/marketplace/providers/route.ts` — 3 filter bugs fixed
+  - `src/app/settings/provider/page.tsx` — underscore → hyphen service type slugs
+  - `src/app/marketplace/listings/new/page.tsx` — slug-based form values
+  - `prisma/seed.ts` — expanded categories
+  - `context/DEV_SESSION_SUMMARIES.md`, `context/CARELINKAI_TECH_OPEN_LOOPS.md`
+- **Commands run:** `npx tsc --noEmit` (0 errors), `git commit`, `git push origin claude/review-carelink-docs-49Ycv`
+- **Tests/build status:** TypeScript 0 errors.
+- **Deployment impact:** No schema changes. Run `npx prisma db seed` in production to populate new categories. Existing providers with underscore serviceTypes in DB need to re-save their settings page to update to new hyphen slugs.
+- **New risks/blockers:** Existing providers in production DB have old underscore slugs (e.g., `personal_care`). These won't match marketplace filter until provider re-saves settings. Chris needs to log in as demo.provider and re-save `/settings/provider` after seed runs.
+- **Recommended next step:** (1) Merge to main and let Render deploy. (2) Run `npx prisma db seed` in Render shell to add new marketplace categories. (3) Log in as demo.provider → `/settings/provider` → save to update serviceTypes to new slug format. (4) Test transportation filter end-to-end. (5) Switch Stripe to live mode.
+
+---
+
 ### 2026-05-04 — Transport Phase 2 (Full Ride Booking) + Landing Page Transport Update
 
 - **Objective:** Build end-to-end transport ride booking (Phase 2) — real bookings with Stripe payment, full lifecycle management, operator booking for residents, and update the landing page to reflect the new capability.

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -13,19 +13,27 @@ async function seedMarketplaceTaxonomy() {
   const groups: { type: CategoryType; names: string[] }[] = [
     {
       type: 'SETTING',
-      names: ['In-home','Assisted Living','Independent Living','Memory Care','Senior Living Community'],
+      // slug = lowercase-hyphen; must be globally unique across all category types
+      names: ['In-home','Assisted Living','Independent Living','Memory Care','Senior Living Community','Skilled Nursing','Hospice'],
     },
     {
       type: 'CARE_TYPE',
-      names: ['Companion Care','Personal Care',"Dementia/Alzheimer's",'Hospice Support','Post-Surgery Support','Special Needs Adult Care','Respite Care'],
+      // avoid apostrophes so slugs stay clean; avoid slugs already used in SETTING/SPECIALTY
+      // 'Dementia Care' excluded here — its slug (dementia-care) already exists in SPECIALTY
+      names: ['Senior Care','Alzheimers Care','Parkinsons Care','Post-Surgery Care','Disability Care','Overnight Care','Live-In Care','Respite Care','Companion Care','Hospice Support','Special Needs Adult Care','Personal Care'],
     },
     {
       type: 'SERVICE',
-      names: ['Transportation','Errands','Household Tasks','Medication Prompting','Mobility Assistance'],
+      // slugs must not conflict with SETTING/CARE_TYPE/SPECIALTY slugs above;
+      // personal-care/companionship/memory-care/skilled-nursing/hospice are excluded here
+      // because they already exist in other types (globally unique slug constraint).
+      // Provider filter still works via hasSome query even if they aren't in SERVICE type.
+      names: ['Transportation','Home Care','Adult Day','Medication Management','Meal Preparation','Light Housekeeping','Wound Care','Bathing Grooming','Incontinence Care','Mobility Assistance','Errands','Household Tasks','Medication Prompting'],
     },
     {
       type: 'SPECIALTY',
-      names: ['Companionship','Dementia Care'],
+      // avoid slugs used in other types; companionship/dementia-care are kept here from original
+      names: ['Companionship','Dementia Alzheimers','Parkinsons','Stroke Recovery','Diabetes Management','Hospice End Of Life','Autism Support','Veteran Care','Pediatric Special Needs','Behavioral Health'],
     },
   ];
 

--- a/src/app/api/marketplace/providers/[id]/route.ts
+++ b/src/app/api/marketplace/providers/[id]/route.ts
@@ -71,11 +71,17 @@ export async function GET(
         licenseNumber: mockProvider.licenseNumber,
         yearsInBusiness: mockProvider.yearsInBusiness,
         isVerified: mockProvider.isVerified,
+        isActive: true,
         serviceTypes: mockProvider.serviceTypes,
         coverageArea: mockProvider.coverageArea,
         photoUrl: mockProvider.photoUrl,
         credentials: mockProvider.credentials,
         memberSince: mockProvider.memberSince,
+        rideTypes: (mockProvider as any).rideTypes ?? [],
+        wheelchairAccessible: (mockProvider as any).wheelchairAccessible ?? false,
+        acceptsMedicaid: (mockProvider as any).acceptsMedicaid ?? false,
+        serviceRadius: (mockProvider as any).serviceRadius ?? null,
+        allowsRecurring: (mockProvider as any).allowsRecurring ?? false,
       };
       
       return NextResponse.json(

--- a/src/app/api/marketplace/providers/route.ts
+++ b/src/app/api/marketplace/providers/route.ts
@@ -82,8 +82,12 @@ export async function GET(request: Request) {
     const idsParam = searchParams.get('ids');
     const ids = idsParam ? idsParam.split(',').map((s) => s.trim()).filter(Boolean) : null;
     const q = searchParams.get('q');
-    // Accept both 'serviceType' (single, from direct links) and 'services' (csv, from marketplace filter UI)
-    const serviceType = searchParams.get('serviceType') || searchParams.get('services')?.split(',')[0] || null;
+    // Accept both 'serviceType' (single) and 'services' (csv) — normalize to lowercase array
+    const serviceTypeSingle = searchParams.get('serviceType');
+    const serviceTypesRaw = serviceTypeSingle
+      ? [serviceTypeSingle]
+      : (searchParams.get('services')?.split(',').filter(Boolean) || []);
+    const serviceTypeFilters = serviceTypesRaw.map((s) => s.toLowerCase()).filter(Boolean);
     const city = searchParams.get('city');
     const state = searchParams.get('state');
     const verified = searchParams.get('verified');
@@ -172,13 +176,21 @@ export async function GET(request: Request) {
     }
 
     // Build where clause for filtering
-    // Gate: only show providers with an active/trialing listing subscription (or no subscription yet during grace period)
-    // Providers with CANCELED or PAST_DUE status are hidden
+    // NULL listingStatus = no subscription yet (grace period) — must be explicitly included
+    // because Postgres NULL NOT IN (...) evaluates to NULL (falsy), which would wrongly exclude them.
     const where: any = {
       isActive: true,
-      NOT: { listingStatus: { in: ['CANCELED', 'PAST_DUE', 'INCOMPLETE', 'INCOMPLETE_EXPIRED'] } },
+      AND: [
+        {
+          OR: [
+            { listingStatus: null },
+            { listingStatus: { notIn: ['CANCELED', 'PAST_DUE', 'INCOMPLETE', 'INCOMPLETE_EXPIRED'] } },
+          ],
+        },
+      ],
     };
-    
+
+
     // Text search in bio, business name, or contact name
     if (q) {
       where.OR = [
@@ -187,16 +199,16 @@ export async function GET(request: Request) {
         { contactName: { contains: q, mode: 'insensitive' } }
       ];
     }
-    
-    // Service type filter (case-insensitive: normalize to lowercase)
-    if (serviceType) {
-      where.serviceTypes = {
-        has: serviceType.toLowerCase()
-      };
+
+    // Service type filter — supports multiple selected services (any match)
+    if (serviceTypeFilters.length === 1) {
+      where.serviceTypes = { has: serviceTypeFilters[0] };
+    } else if (serviceTypeFilters.length > 1) {
+      where.serviceTypes = { hasSome: serviceTypeFilters };
     }
-    
-    // Verified filter
-    if (verified !== null) {
+
+    // Verified filter — only apply when explicitly set to "true" or "false"
+    if (verified === 'true' || verified === 'false') {
       where.isVerified = verified === 'true';
     }
 

--- a/src/app/api/runtime/mocks/route.ts
+++ b/src/app/api/runtime/mocks/route.ts
@@ -6,66 +6,48 @@ import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
   const isProduction = process.env.NODE_ENV === 'production';
-  
-  // PRODUCTION: Mock mode is OFF by default for homes, but ON for marketplace
-  // This allows real homes data while marketplace shows mock caregivers/jobs/providers
-  
+
   // 1) Check cookie first (admin runtime toggle)
   const cookieRaw = req.cookies.get("carelink_mock_mode")?.value?.toString().trim().toLowerCase() || "";
   const cookieOn = ["1", "true", "yes", "on"].includes(cookieRaw);
   const cookieOff = ["0", "false", "no", "off"].includes(cookieRaw);
-  
+
   // Marketplace-specific cookie
   const marketplaceCookieRaw = req.cookies.get("carelink_marketplace_mock")?.value?.toString().trim().toLowerCase() || "";
   const marketplaceCookieOn = ["1", "true", "yes", "on"].includes(marketplaceCookieRaw);
   const marketplaceCookieOff = ["0", "false", "no", "off"].includes(marketplaceCookieRaw);
-  
+
   // Check environment variables
   const envValue = (process.env["SHOW_SITE_MOCKS"] ?? "").toString().trim().toLowerCase();
   const envEnabled = ["1", "true", "yes", "on"].includes(envValue);
-  
-  // Marketplace mock mode: defaults to TRUE in production (since we don't have real caregivers yet)
-  // Can be explicitly disabled via SHOW_MARKETPLACE_MOCKS=0 or cookie
+
   const marketplaceEnvValue = (process.env["SHOW_MARKETPLACE_MOCKS"] ?? "").toString().trim().toLowerCase();
-  const marketplaceEnvExplicitlyDisabled = ["0", "false", "no", "off"].includes(marketplaceEnvValue);
-  
+  const marketplaceEnvEnabled = ["1", "true", "yes", "on"].includes(marketplaceEnvValue);
+
   // Determine marketplace mock mode:
-  // Priority: Cookie > Env var > Default (true for marketplace)
+  // Priority: general cookie > marketplace cookie > env var > default (OFF in production, ON in dev)
   let showMarketplace: boolean;
-  if (marketplaceCookieOn) {
+  if (cookieOn) {
+    showMarketplace = true;
+  } else if (cookieOff) {
+    // Admin explicitly disabled — also kills marketplace mocks
+    showMarketplace = false;
+  } else if (marketplaceCookieOn) {
     showMarketplace = true;
   } else if (marketplaceCookieOff) {
     showMarketplace = false;
-  } else if (marketplaceEnvExplicitlyDisabled) {
-    showMarketplace = false;
-  } else {
-    // Default: marketplace mocks are ON (since we don't have real caregivers/jobs/providers yet)
+  } else if (marketplaceEnvEnabled) {
     showMarketplace = true;
-  }
-  
-  // If cookie explicitly sets general mock state, use that
-  if (cookieOn) {
-    console.log('[Mock Mode] Enabled via cookie (all)');
-    return new NextResponse(JSON.stringify({ show: true, showMarketplace: true, source: 'cookie' }), {
-      status: 200,
-      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
-    });
-  }
-  
-  if (cookieOff) {
-    console.log('[Mock Mode] Disabled via cookie (homes only, marketplace may still use mocks)');
-    return new NextResponse(JSON.stringify({ show: false, showMarketplace, source: 'cookie' }), {
-      status: 200,
-      headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
-    });
+  } else {
+    // Default: OFF in production (real data is live), ON in development
+    showMarketplace = !isProduction;
   }
 
-  // In production, default to FALSE for homes unless explicitly enabled
-  const show = isProduction ? envEnabled : envEnabled;
-  
+  const show = cookieOn ? true : cookieOff ? false : envEnabled;
+
   console.log(`[Mock Mode] show=${show}, showMarketplace=${showMarketplace} (env=${envValue}, prod=${isProduction})`);
-  
-  return new NextResponse(JSON.stringify({ show, showMarketplace, source: 'env', isProduction }), {
+
+  return new NextResponse(JSON.stringify({ show, showMarketplace, source: cookieOn || cookieOff ? 'cookie' : 'env', isProduction }), {
     status: 200,
     headers: {
       "Content-Type": "application/json",

--- a/src/app/marketplace/listings/new/page.tsx
+++ b/src/app/marketplace/listings/new/page.tsx
@@ -8,30 +8,54 @@ import {
   FiMapPin, FiCalendar, FiFileText, FiBriefcase,
 } from "react-icons/fi";
 
-// ─── static option lists ───────────────────────────────────────────────────
+// ─── static option lists (value = slug stored in DB, label = display text) ─
 
-const SETTINGS = [
-  "In-Home", "Assisted Living", "Memory Care",
-  "Independent Living", "Skilled Nursing", "Hospice",
+const SETTINGS: { value: string; label: string }[] = [
+  { value: 'in-home', label: 'In-Home' },
+  { value: 'assisted-living', label: 'Assisted Living' },
+  { value: 'memory-care', label: 'Memory Care' },
+  { value: 'independent-living', label: 'Independent Living' },
+  { value: 'skilled-nursing', label: 'Skilled Nursing' },
+  { value: 'hospice', label: 'Hospice' },
+  { value: 'senior-living-community', label: 'Senior Living' },
 ];
 
-const CARE_TYPES = [
-  "Senior Care", "Dementia Care", "Alzheimer's Care", "Parkinson's Care",
-  "Post-Surgery Care", "Disability Care", "Pediatric Care",
-  "Overnight Care", "Live-In Care", "Respite Care",
+const CARE_TYPES: { value: string; label: string }[] = [
+  { value: 'senior-care', label: 'Senior Care' },
+  { value: 'dementia-care', label: 'Dementia Care' },
+  { value: 'alzheimers-care', label: "Alzheimer's Care" },
+  { value: 'parkinsons-care', label: "Parkinson's Care" },
+  { value: 'post-surgery-care', label: 'Post-Surgery Care' },
+  { value: 'disability-care', label: 'Disability Care' },
+  { value: 'overnight-care', label: 'Overnight Care' },
+  { value: 'live-in-care', label: 'Live-In Care' },
+  { value: 'respite-care', label: 'Respite Care' },
+  { value: 'companion-care', label: 'Companion Care' },
 ];
 
-const SERVICES = [
-  "Personal Care / ADLs", "Medication Management", "Meal Preparation",
-  "Light Housekeeping", "Transportation", "Companionship",
-  "Physical Therapy Assistance", "Wound Care", "Bathing & Grooming",
-  "Incontinence Care", "Mobility Assistance",
+const SERVICES: { value: string; label: string }[] = [
+  { value: 'personal-care', label: 'Personal Care / ADLs' },
+  { value: 'medication-management', label: 'Medication Management' },
+  { value: 'meal-preparation', label: 'Meal Preparation' },
+  { value: 'light-housekeeping', label: 'Light Housekeeping' },
+  { value: 'transportation', label: 'Transportation' },
+  { value: 'companionship', label: 'Companionship' },
+  { value: 'wound-care', label: 'Wound Care' },
+  { value: 'bathing-grooming', label: 'Bathing & Grooming' },
+  { value: 'incontinence-care', label: 'Incontinence Care' },
+  { value: 'mobility-assistance', label: 'Mobility Assistance' },
 ];
 
-const SPECIALTIES = [
-  "Dementia / Alzheimer's", "Parkinson's Disease", "Stroke Recovery",
-  "Diabetes Management", "Hospice / End of Life", "Autism Support",
-  "Veteran Care", "Pediatric Special Needs", "Behavioral Health",
+const SPECIALTIES: { value: string; label: string }[] = [
+  { value: 'dementia-alzheimers', label: "Dementia / Alzheimer's" },
+  { value: 'parkinsons', label: "Parkinson's Disease" },
+  { value: 'stroke-recovery', label: 'Stroke Recovery' },
+  { value: 'diabetes-management', label: 'Diabetes Management' },
+  { value: 'hospice-end-of-life', label: 'Hospice / End of Life' },
+  { value: 'autism-support', label: 'Autism Support' },
+  { value: 'veteran-care', label: 'Veteran Care' },
+  { value: 'pediatric-special-needs', label: 'Pediatric Special Needs' },
+  { value: 'behavioral-health', label: 'Behavioral Health' },
 ];
 
 const US_STATES = [
@@ -50,19 +74,22 @@ function toggle(arr: string[], val: string): string[] {
 function CheckGroup({
   label, options, selected, onChange,
 }: {
-  label: string; options: string[]; selected: string[]; onChange: (v: string[]) => void;
+  label: string;
+  options: { value: string; label: string }[];
+  selected: string[];
+  onChange: (v: string[]) => void;
 }) {
   return (
     <div>
       <p className="text-xs font-semibold text-neutral-500 uppercase tracking-wide mb-3">{label}</p>
       <div className="flex flex-wrap gap-2">
         {options.map((opt) => {
-          const active = selected.includes(opt);
+          const active = selected.includes(opt.value);
           return (
             <button
-              key={opt}
+              key={opt.value}
               type="button"
-              onClick={() => onChange(toggle(selected, opt))}
+              onClick={() => onChange(toggle(selected, opt.value))}
               className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-all ${
                 active
                   ? "bg-primary-500 border-primary-500 text-white"
@@ -70,7 +97,7 @@ function CheckGroup({
               }`}
             >
               {active && <FiCheck className="h-3 w-3" />}
-              {opt}
+              {opt.label}
             </button>
           );
         })}
@@ -271,16 +298,16 @@ export default function NewListingPage() {
             <div className="flex flex-wrap gap-2">
               {SETTINGS.map((s) => (
                 <button
-                  key={s}
+                  key={s.value}
                   type="button"
-                  onClick={() => setSetting(setting === s ? "" : s)}
+                  onClick={() => setSetting(setting === s.value ? "" : s.value)}
                   className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-all ${
-                    setting === s
+                    setting === s.value
                       ? "bg-primary-500 border-primary-500 text-white"
                       : "bg-white border-neutral-200 text-neutral-600 hover:border-primary-300 hover:text-primary-600"
                   }`}
                 >
-                  {s}
+                  {s.label}
                 </button>
               ))}
             </div>

--- a/src/app/marketplace/providers/[id]/page.tsx
+++ b/src/app/marketplace/providers/[id]/page.tsx
@@ -422,7 +422,7 @@ export default function ProviderDetailPage() {
                     </div>
                   )}
                 </div>
-                {provider.rideTypes.length > 0 && (
+                {(provider.rideTypes ?? []).length > 0 && (
                   <div className="mt-4">
                     <h3 className="text-sm font-medium text-neutral-700 mb-2">Ride Types</h3>
                     <div className="flex flex-wrap gap-2">

--- a/src/app/settings/provider/page.tsx
+++ b/src/app/settings/provider/page.tsx
@@ -16,14 +16,14 @@ const RIDE_TYPE_OPTIONS = [
 ];
 
 const SERVICE_TYPE_OPTIONS = [
-  { value: "home_care", label: "Home Care" },
-  { value: "personal_care", label: "Personal Care" },
+  { value: "home-care", label: "Home Care" },
+  { value: "personal-care", label: "Personal Care" },
   { value: "companionship", label: "Companionship" },
-  { value: "skilled_nursing", label: "Skilled Nursing" },
+  { value: "skilled-nursing", label: "Skilled Nursing" },
   { value: "transportation", label: "Transportation / NEMT" },
   { value: "hospice", label: "Hospice Support" },
-  { value: "memory_care", label: "Memory Care" },
-  { value: "adult_day", label: "Adult Day Services" },
+  { value: "memory-care", label: "Memory Care" },
+  { value: "adult-day", label: "Adult Day Services" },
 ];
 
 type ProviderForm = {


### PR DESCRIPTION
## Summary
- `showMarketplace` in `/api/runtime/mocks` was hardcoded `true` by default — marketplace always showed fake Seattle providers even with admin mock mode disabled
- Now defaults to `false` in production, `true` in development
- Admin Disable toggle now correctly kills marketplace mocks (cookieOff propagates to `showMarketplace = false`)

## Effect
After this deploy, the marketplace providers/caregivers/jobs tabs will hit the real database. The admin Enable button still works to turn on demo data for walkthroughs.

https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ)_