### PR TITLE
feat: provider real-time new booking notification (OL-037)

### DIFF
--- a/context/CARELINKAI_TECHNICAL_STATE.md
+++ b/context/CARELINKAI_TECHNICAL_STATE.md
@@ -1,5 +1,5 @@
 # CareLinkAI — Technical State
-_Last updated: 2026-05-04_
+_Last updated: 2026-05-05_
 
 ## Active Branch
 `main` — all Transport Phase 2 work + landing page updates committed directly to main (auto-deploys to Render)
@@ -89,6 +89,12 @@ FAMILY, OPERATOR, CAREGIVER, ADMIN, STAFF, PROVIDER, AFFILIATE, DISCHARGE_PLANNE
 - **Pro Caregiver ($19/mo):** Stripe Checkout + Customer Portal at `/settings/billing`. `isPro=true` on ACTIVE/TRIALING. Pro caregivers rank first in all searches (`isPro: desc` orderBy). ★ Pro badge on CaregiverCard. `applicationCount` **fully enforced** — basic caregivers blocked at 10 apps/month with upsell banner; Pro caregivers uncapped. Monthly reset cron live (`0 0 1 * *`). Requires `STRIPE_PRICE_PRO_CAREGIVER` env var. ✅ Billing nav link added to DashboardLayout.
 - **Background check markup:** ENHANCED $34.99, MVR $19.99, PREMIUM $59.99.
 - **Admin MRR dashboard:** `/admin/page.tsx` now shows 5-tile Revenue Overview: Total MRR + per-stream breakdown (Operators, Providers, Pro Caregivers, Discharge Planners) with live counts.
+
+## Transport — Phase 4: NEMT Anti-Fraud + Reliability Score (as of 2026-05-05)
+- **Trip verification:** `actualPickupAt` / `actualDropoffAt` set server-side on status transitions (`/api/rides/[id]/start` + `/complete`). Driver cannot edit. Supports Medicaid claim data.
+- **No-show accountability:** `noShowCausedBy` on Ride (PROVIDER/RIDER/FACILITY/WEATHER/OTHER). Cancel modal collects cause when status is IN_PROGRESS. Stored via PATCH `/api/rides/[id]`.
+- **Recurring ride auto-scheduler:** Cron `GET /api/cron/recurring-rides` (`0 7 * * *`). Finds all seed rides (`isRecurring=true, recurringRootId=null`), spawns children 14 days ahead. Respects `recurringEndDate`. Return trip offset preserved.
+- **Provider reliability score:** `src/lib/rideStats.ts` — transport-only gate, weighted 60% completion + 40% on-time. `scoreLabel()` returns Excellent/Very Good/Good/Fair/Needs Work with color classes. Provider dashboard: 4th tile + Ride Dispatch quick action (PROVIDER+transport only). Marketplace detail: progress bars in Transport Capabilities block. API: `rideStats` field in `/api/marketplace/providers/[id]` response.
 
 ## Transport — Phase 3: Manifest, Shared Rides, Capacity (as of 2026-05-04)
 - **Provider manifest view:** `/rides` page redesigned for PROVIDER role — day-grouped cards showing time, passenger name, route, status badge, collapsible detail (contact, purpose, return/recurring, fare). PassengerNeedsRow shows NEMT tags (mobility level, door level, O₂, companion, cognition, service animal, wait time). Day-level CapacityBar (green→amber→red) vs `vehicleCapacity`.

--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -1,5 +1,5 @@
 # CareLinkAI — Tech Open Loops
-_Last updated: 2026-05-03_
+_Last updated: 2026-05-05_
 
 ## Format
 Each loop: what it is, why it matters, what done looks like.
@@ -83,29 +83,21 @@ Each loop: what it is, why it matters, what done looks like.
 - Flat-fee ($99-199) for Medicaid waiver, VA Aid & Attendance, LTC insurance claims navigation.
 
 ### OL-039: Add Render cron for recurring rides
-- **Status:** 🟡 OPEN — cron endpoint built, not yet registered in Render
-- **What:** Add cron job in Render dashboard: `0 7 * * *` → `GET https://getcarelinkai.com/api/cron/recurring-rides?secret=CRON_SECRET` (or via `x-cron-secret` header). Spawns next 14-day occurrences of all active recurring ride series.
-- **Done when:** Cron registered + first successful run in Render logs.
+- **Status:** ✅ CLOSED (2026-05-04) — Chris registered cron in Render dashboard: `0 7 * * *` → `/api/cron/recurring-rides`. Endpoint live.
 
 ### OL-040: Transport migration 20260504000006 deploy
-- **Status:** 🟡 OPEN — needs `npx prisma migrate deploy` after next merge
-- **What:** Adds actualPickupAt, actualDropoffAt, noShowCausedBy, recurringRootId to Ride. All nullable — no data risk.
-- **Done when:** Migration runs cleanly.
+- **Status:** ✅ CLOSED (2026-05-04) — PR #512 squash-merged to main. Migration auto-runs via `start` script (`npm run migrate:deploy && node .next/standalone/server.js`). No manual Render shell step needed.
 
 ### OL-041: Provider reliability score dashboard
-- **Status:** 🟡 OPEN — data now being collected (noShowCausedBy, actualPickupAt, actualDropoffAt)
-- **What:** Build a reliability summary per provider: on-time pickup %, ride completion rate, no-show cause breakdown. Show in provider dashboard + marketplace listing. Critical for payer contract pitches ("we reduce missed appointments by X%").
-- **Done when:** Provider dashboard tile shows reliability score; marketplace card shows it.
+- **Status:** ✅ CLOSED (2026-05-04) — Built in full: `src/lib/rideStats.ts` (transport-only gate, weighted score 60% completion + 40% on-time), provider dashboard 4th tile + Ride Dispatch quick action, marketplace provider detail reliability section with progress bars, API route returns `rideStats`. PR #512 merged.
 
 ### OL-038: Transport migration 20260504000005 deploy
-- **Status:** 🟡 OPEN — needs `npx prisma migrate deploy` in Render shell after next merge
-- **What:** Adds `isSharedRide`, `sharedRideGroupId` to Ride + `vehicleCapacity` to Provider. All columns have safe defaults.
-- **Done when:** Migration runs without error; `vehicleCapacity` appears in provider settings.
+- **Status:** ✅ CLOSED (2026-05-04) — PR #512 squash-merged to main. Migration auto-runs via `start` script. `vehicleCapacity` and shared ride fields live in production.
 
 ### OL-037: Provider real-time new booking notification
-- **Status:** 🟡 OPEN — providers currently must refresh /rides to see new bookings
-- **What:** SSE push or polling to alert provider in real-time when a new REQUESTED ride appears. Could use existing SSE infrastructure or a simple long-poll interval.
-- **Done when:** Provider sees a toast/notification within seconds of a family booking without refreshing.
+- **Status:** 🟡 IN PROGRESS — building polling-based toast notification for new REQUESTED rides
+- **What:** 30-second poll on `/rides` page; compares `latestRequestedRideId` from API; shows toast when new REQUESTED ride arrives. No new infra required.
+- **Done when:** Provider sees a toast/notification within 30 seconds of a family booking without refreshing.
 
 ### OL-026: Transport Phase 2 — ride booking + dispatch
 - **Status:** ✅ CLOSED (2026-05-04)
@@ -303,3 +295,7 @@ Each loop: what it is, why it matters, what done looks like.
 | Landing page freemium inaccuracy | Updated 5 "always free" references to reflect free-to-join + Pro $19/mo optional model | 2026-05-03 |
 | Admin MRR visibility | Admin dashboard now shows 5-tile MRR breakdown across all 4 revenue streams | 2026-05-03 |
 | OL-031: Application cap enforcement | Full enforcement built: block at 10, increment on submit, reset cron, upsell banner | 2026-05-03 |
+| OL-038: Transport migration 20260504000005 | Auto-deployed via PR #512 merge → Render start script | 2026-05-04 |
+| OL-039: Recurring rides cron | Chris registered Render cron `0 7 * * *` → `/api/cron/recurring-rides` | 2026-05-04 |
+| OL-040: Transport migration 20260504000006 | Auto-deployed via PR #512 merge → Render start script | 2026-05-04 |
+| OL-041: Provider reliability score | `rideStats.ts` + dashboard tile + marketplace section + API; transport-only gate | 2026-05-04 |

--- a/src/app/rides/page.tsx
+++ b/src/app/rides/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
 import DashboardLayout from "@/components/layout/DashboardLayout";
@@ -396,20 +396,60 @@ export default function RidesPage() {
   const isProvider = role === "PROVIDER";
   const isOperator = role === "OPERATOR" || role === "STAFF";
 
+  // Track REQUESTED ride IDs seen so far; used for new-booking notifications
+  const knownRequestedIds = useRef<Set<string>>(new Set());
+  const pollingInitialized = useRef(false);
+
   const fetchRides = useCallback(async () => {
     setLoading(true);
     try {
       const res = await fetch("/api/rides");
       if (res.ok) {
         const data = await res.json();
-        setRides(data.rides ?? []);
+        const incoming: Ride[] = data.rides ?? [];
+        setRides(incoming);
         if (data.vehicleCapacity) setVehicleCapacity(data.vehicleCapacity);
+        // Seed the known set on first load so we don't false-alarm
+        const requestedIds = incoming
+          .filter((r) => r.status === "REQUESTED")
+          .map((r) => r.id);
+        requestedIds.forEach((id) => knownRequestedIds.current.add(id));
+        pollingInitialized.current = true;
       }
     } catch { toast.error("Failed to load rides"); }
     finally { setLoading(false); }
   }, []);
 
+  // Silent background poll every 30 s — providers only
+  const pollRides = useCallback(async () => {
+    if (!pollingInitialized.current) return;
+    try {
+      const res = await fetch("/api/rides");
+      if (!res.ok) return;
+      const data = await res.json();
+      const incoming: Ride[] = data.rides ?? [];
+      const newRequested = incoming.filter(
+        (r) => r.status === "REQUESTED" && !knownRequestedIds.current.has(r.id)
+      );
+      if (newRequested.length > 0) {
+        newRequested.forEach((r) => knownRequestedIds.current.add(r.id));
+        const msg = newRequested.length === 1
+          ? "New ride request — tap to view"
+          : `${newRequested.length} new ride requests`;
+        toast(msg, { icon: "🚗", duration: 6000 });
+        setRides(incoming);
+        if (data.vehicleCapacity) setVehicleCapacity(data.vehicleCapacity);
+      }
+    } catch { /* silent — no error toast on background poll */ }
+  }, []);
+
   useEffect(() => { if (session?.user) fetchRides(); }, [session, fetchRides]);
+
+  useEffect(() => {
+    if (!isProvider) return;
+    const interval = setInterval(pollRides, 30_000);
+    return () => clearInterval(interval);
+  }, [isProvider, pollRides]);
 
   useEffect(() => {
     if (paymentResult === "success") toast.success("Payment complete! Your ride is confirmed.");


### PR DESCRIPTION
## Summary

- Providers now receive a 🚗 toast within 30 seconds when a family books a new ride — no manual refresh required
- Background poll every 30s hits the existing `/api/rides` endpoint (provider-only, silent — no error toast on failure)
- Initial load seeds a known-IDs set so no false alarms fire on page open
- Single vs. plural message: "New ride request — tap to view" / "N new ride requests"
- Ride list updates in-place so the new card appears immediately

Also closes four open loops in context files:
- **OL-038** — migration 20260504000005 auto-deployed via PR #512 start script
- **OL-039** — recurring rides cron registered by Chris in Render dashboard
- **OL-040** — migration 20260504000006 auto-deployed via PR #512 start script
- **OL-041** — provider reliability score (rideStats.ts, dashboard tile, marketplace section)

No new infrastructure, no schema changes, no migrations needed.

## Test plan

- [ ] Log in as `demo.provider@carelinkai.test`, open `/rides`
- [ ] In a second browser/tab, log in as `demo.family@carelinkai.test` and book a ride with the demo provider
- [ ] Within ~30 seconds the provider tab shows a 🚗 toast without refreshing
- [ ] Verify no false-alarm toast fires on initial page load
- [ ] Verify non-provider roles (family, operator) do NOT poll (no interval registered)

https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ)_