### PR TITLE
fix(tests): repair stale mocks in emergency and background_checks sui…

### DIFF
--- a/__tests__/background_checks.api.test.ts
+++ b/__tests__/background_checks.api.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit tests for Background Check API
- * 
+ *
  * Tests the endpoints:
  * - POST /api/caregiver/background-checks/start
  * - GET /api/caregiver/background-checks/status
@@ -18,6 +18,15 @@ const originalEnv = process.env;
 beforeEach(() => {
   jest.resetModules();
   process.env = { ...originalEnv };
+  // Set up default null returns for prisma models used in webhook route
+  (prisma.providerCredential.findUnique as jest.Mock).mockResolvedValue(null);
+  (prisma.backgroundCheckInvitation.findUnique as jest.Mock).mockResolvedValue(null);
+  (prisma.providerBackgroundCheckOrder.findUnique as jest.Mock).mockResolvedValue(null);
+  (prisma.backgroundCheckOrder.findUnique as jest.Mock).mockResolvedValue(null);
+  (prisma.backgroundCheckOrder.update as jest.Mock).mockResolvedValue({});
+  (prisma.backgroundCheckOrder.create as jest.Mock).mockResolvedValue({ id: 'order-default' });
+  (prisma.caregiver.update as jest.Mock).mockResolvedValue({});
+  (prisma.notification.create as jest.Mock).mockResolvedValue({});
 });
 
 afterEach(() => {
@@ -35,57 +44,86 @@ jest.mock('@/lib/auth', () => ({
   authOptions: {},
 }));
 
-// Mock Prisma
+// Mock Prisma — includes all models touched by the routes under test
 jest.mock('@/lib/prisma', () => {
   return {
     prisma: {
       caregiver: {
         findUnique: jest.fn(),
         update: jest.fn(),
-      }
-    }
+      },
+      backgroundCheckOrder: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        create: jest.fn(),
+      },
+      providerCredential: {
+        findUnique: jest.fn(),
+      },
+      backgroundCheckInvitation: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      providerBackgroundCheckOrder: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      notification: {
+        create: jest.fn(),
+      },
+    },
   };
 });
+
+// Mock Checkr API calls (external HTTP) — keep pure functions real
+jest.mock('@/lib/checkr', () => ({
+  ...jest.requireActual('@/lib/checkr'),
+  createCandidate: jest.fn(),
+  createReport: jest.fn(),
+}));
 
 // Import mocks after they're defined
 import { getServerSession } from 'next-auth';
 import { prisma } from '@/lib/prisma';
+import { createCandidate, createReport } from '@/lib/checkr';
 
 // Helper to create a mock NextRequest for POST
 function createMockRequest(body = {}, method = 'POST') {
   const url = new URL('https://example.com/api/caregiver/background-checks/start');
-  
+
   const request = {
     nextUrl: url,
     method,
     json: jest.fn().mockResolvedValue(body),
   } as unknown as NextRequest;
-  
+
   return request;
 }
 
 // Helper to create a mock NextRequest for GET
 function createMockGetRequest(method = 'GET') {
   const url = new URL('https://example.com/api/caregiver/background-checks/status');
-  
+
   const request = {
     nextUrl: url,
     method,
   } as unknown as NextRequest;
-  
+
   return request;
 }
 
 // Helper to create a mock NextRequest for webhook
 function createMockWebhookRequest(body = {}) {
   const url = new URL('https://example.com/api/webhooks/checkr');
-  
+
   const request = {
     nextUrl: url,
     method: 'POST',
     json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+    headers: { get: jest.fn().mockReturnValue('') },
   } as unknown as NextRequest;
-  
+
   return request;
 }
 
@@ -96,253 +134,249 @@ describe('Background Check API', () => {
     email: 'caregiver@example.com',
     name: 'Caregiver User',
   };
-  
+
   const mockCaregiverId = 'caregiver-123';
-  
+
   const mockCaregiver = {
     id: mockCaregiverId,
     userId: mockUser.id,
+    checkrCandidateId: null,
     backgroundCheckStatus: 'NOT_STARTED',
     backgroundCheckProvider: null,
     backgroundCheckReportUrl: null,
+    user: { firstName: 'Test', lastName: 'User', email: 'test@example.com' },
   };
-  
+
   describe('POST /api/caregiver/background-checks/start', () => {
     test('returns 401 when user is not authenticated', async () => {
       (getServerSession as jest.Mock).mockResolvedValueOnce(null);
-      
+
       const request = createMockRequest();
       const response = await startBackgroundCheck(request);
-      
+
       expect(response.status).toBe(401);
       expect(await response.json()).toEqual({ error: "Unauthorized" });
     });
-    
+
     test('returns 403 when user is not a caregiver', async () => {
       (getServerSession as jest.Mock).mockResolvedValueOnce({
         user: mockUser,
       });
-      
+
       (prisma.caregiver.findUnique as jest.Mock).mockResolvedValueOnce(null);
-      
+
       const request = createMockRequest();
       const response = await startBackgroundCheck(request);
-      
+
       expect(response.status).toBe(403);
-      expect(await response.json()).toEqual({ error: "User is not registered as a caregiver" });
+      expect(await response.json()).toEqual({ error: "Not registered as a caregiver" });
     });
-    
+
     test('successfully initiates a background check with default provider', async () => {
-      (getServerSession as jest.Mock).mockResolvedValueOnce({
-        user: mockUser,
-      });
-      
+      (getServerSession as jest.Mock).mockResolvedValueOnce({ user: mockUser });
       (prisma.caregiver.findUnique as jest.Mock).mockResolvedValueOnce(mockCaregiver);
-      
-      const updatedCaregiver = {
-        ...mockCaregiver,
-        backgroundCheckStatus: 'PENDING',
-        backgroundCheckProvider: 'CHECKR',
-      };
-      
-      (prisma.caregiver.update as jest.Mock).mockResolvedValueOnce(updatedCaregiver);
-      
+      (createCandidate as jest.Mock).mockResolvedValueOnce({ id: 'candidate-123' });
+      (prisma.caregiver.update as jest.Mock).mockResolvedValueOnce({}); // checkrCandidateId update
+      (createReport as jest.Mock).mockResolvedValueOnce({ id: 'report-123' });
+      (prisma.backgroundCheckOrder.create as jest.Mock).mockResolvedValueOnce({ id: 'order-123' });
+      (prisma.caregiver.update as jest.Mock).mockResolvedValueOnce({}); // status update
+
       const request = createMockRequest({});
       const response = await startBackgroundCheck(request);
-      
+
       expect(response.status).toBe(200);
-      
+
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.status).toBe('PENDING');
-      expect(data.provider).toBe('CHECKR');
-      
-      // Verify update was called with correct data
-      expect(prisma.caregiver.update).toHaveBeenCalledWith({
-        where: { id: mockCaregiverId },
-        data: {
-          backgroundCheckStatus: 'PENDING',
-          backgroundCheckProvider: 'CHECKR',
-          backgroundCheckReportUrl: null,
-        },
-        select: expect.any(Object),
-      });
+      expect(data.orderId).toBe('order-123');
+      expect(data.reportId).toBe('report-123');
     });
-    
-    test('successfully initiates a background check with custom provider', async () => {
-      (getServerSession as jest.Mock).mockResolvedValueOnce({
-        user: mockUser,
-      });
-      
+
+    test('successfully initiates a background check (request body is ignored by route)', async () => {
+      (getServerSession as jest.Mock).mockResolvedValueOnce({ user: mockUser });
       (prisma.caregiver.findUnique as jest.Mock).mockResolvedValueOnce(mockCaregiver);
-      
-      const updatedCaregiver = {
-        ...mockCaregiver,
-        backgroundCheckStatus: 'PENDING',
-        backgroundCheckProvider: 'CUSTOM_PROVIDER',
-      };
-      
-      (prisma.caregiver.update as jest.Mock).mockResolvedValueOnce(updatedCaregiver);
-      
-      const request = createMockRequest({ provider: 'CUSTOM_PROVIDER' });
+      (createCandidate as jest.Mock).mockResolvedValueOnce({ id: 'candidate-456' });
+      (prisma.caregiver.update as jest.Mock).mockResolvedValueOnce({});
+      (createReport as jest.Mock).mockResolvedValueOnce({ id: 'report-456' });
+      (prisma.backgroundCheckOrder.create as jest.Mock).mockResolvedValueOnce({ id: 'order-456' });
+      (prisma.caregiver.update as jest.Mock).mockResolvedValueOnce({});
+
+      const request = createMockRequest({ provider: 'MANUAL' });
       const response = await startBackgroundCheck(request);
-      
+
       expect(response.status).toBe(200);
-      
+
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.status).toBe('PENDING');
-      expect(data.provider).toBe('CUSTOM_PROVIDER');
-      
-      // Verify update was called with correct data
-      expect(prisma.caregiver.update).toHaveBeenCalledWith({
-        where: { id: mockCaregiverId },
-        data: {
-          backgroundCheckStatus: 'PENDING',
-          backgroundCheckProvider: 'CUSTOM_PROVIDER',
-          backgroundCheckReportUrl: null,
-        },
-        select: expect.any(Object),
-      });
+      expect(data.orderId).toBe('order-456');
+      expect(data.reportId).toBe('report-456');
     });
   });
-  
+
   describe('GET /api/caregiver/background-checks/status', () => {
     test('returns 401 when user is not authenticated', async () => {
       (getServerSession as jest.Mock).mockResolvedValueOnce(null);
-      
+
       const request = createMockGetRequest();
       const response = await getBackgroundCheckStatus(request);
-      
+
       expect(response.status).toBe(401);
       expect(await response.json()).toEqual({ error: "Unauthorized" });
     });
-    
+
     test('returns 403 when user is not a caregiver', async () => {
       (getServerSession as jest.Mock).mockResolvedValueOnce({
         user: mockUser,
       });
-      
+
       (prisma.caregiver.findUnique as jest.Mock).mockResolvedValueOnce(null);
-      
+
       const request = createMockGetRequest();
       const response = await getBackgroundCheckStatus(request);
-      
+
       expect(response.status).toBe(403);
       expect(await response.json()).toEqual({ error: "User is not registered as a caregiver" });
     });
-    
+
     test('successfully returns background check status', async () => {
       (getServerSession as jest.Mock).mockResolvedValueOnce({
         user: mockUser,
       });
-      
+
       const caregiverWithStatus = {
         ...mockCaregiver,
         backgroundCheckStatus: 'CLEAR',
         backgroundCheckProvider: 'CHECKR',
         backgroundCheckReportUrl: 'https://example.com/report',
       };
-      
+
       (prisma.caregiver.findUnique as jest.Mock).mockResolvedValueOnce(caregiverWithStatus);
-      
+
       const request = createMockGetRequest();
       const response = await getBackgroundCheckStatus(request);
-      
+
       expect(response.status).toBe(200);
-      
+
       const data = await response.json();
       expect(data.status).toBe('CLEAR');
       expect(data.provider).toBe('CHECKR');
       expect(data.reportUrl).toBe('https://example.com/report');
     });
   });
-  
+
   describe('POST /api/webhooks/checkr', () => {
-    test('returns 400 when payload is invalid', async () => {
+    // The webhook route returns 200 { received: true } for all non-error paths,
+    // including unrecognized event types (Checkr best practice: always ACK).
+
+    test('returns 200 for payload with no recognized event type', async () => {
       const request = createMockWebhookRequest({
-        // Missing caregiverId
+        // No 'type' field — treated as unrecognized event
         status: 'CLEAR',
       });
-      
+
       const response = await webhookCheckr(request);
-      
-      expect(response.status).toBe(400);
-      expect(await response.json()).toHaveProperty('error', 'Invalid webhook payload');
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ received: true });
     });
-    
-    test('returns 400 when status is invalid', async () => {
+
+    test('returns 200 for payload with non-report event type', async () => {
       const request = createMockWebhookRequest({
-        caregiverId: mockCaregiverId,
-        status: 'INVALID_STATUS', // Invalid status
+        type: 'candidate.created',
+        data: { object: { id: 'cand-123' } },
       });
-      
+
       const response = await webhookCheckr(request);
-      
-      expect(response.status).toBe(400);
-      expect(await response.json()).toHaveProperty('error', 'Invalid webhook payload');
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ received: true });
     });
-    
-    test('returns 404 when caregiver not found', async () => {
+
+    test('returns 200 when report id is not found in any order table', async () => {
+      // All findUnique mocks return null (set in beforeEach)
+      // Fallback candidateId lookup also returns null
       (prisma.caregiver.findUnique as jest.Mock).mockResolvedValueOnce(null);
-      
+
       const request = createMockWebhookRequest({
-        caregiverId: 'non-existent',
-        status: 'CLEAR',
+        type: 'report.completed',
+        data: { object: { id: 'unknown-report', status: 'clear', candidate_id: 'unknown-cand' } },
       });
-      
+
       const response = await webhookCheckr(request);
-      
-      expect(response.status).toBe(404);
-      expect(await response.json()).toEqual({ error: "Caregiver not found" });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ received: true });
     });
-    
+
     test('successfully updates background check status', async () => {
-      (prisma.caregiver.findUnique as jest.Mock).mockResolvedValueOnce(mockCaregiver);
-      
-      const webhookData = {
+      const reportId = 'report-checkr-123';
+      (prisma.backgroundCheckOrder.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: 'order-123',
         caregiverId: mockCaregiverId,
-        status: 'CLEAR',
-        reportUrl: 'https://example.com/report',
+      });
+      // caregiver.findUnique for notification (status CLEAR triggers notification)
+      (prisma.caregiver.findUnique as jest.Mock).mockResolvedValueOnce({ userId: mockUser.id });
+
+      const webhookData = {
+        type: 'report.completed',
+        data: {
+          object: {
+            id: reportId,
+            status: 'clear',
+            candidate_id: 'cand-123',
+            report_url: 'https://example.com/report',
+          },
+        },
       };
-      
+
       const request = createMockWebhookRequest(webhookData);
       const response = await webhookCheckr(request);
-      
+
       expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ success: true });
-      
-      // Verify update was called with correct data
+      expect(await response.json()).toEqual({ received: true });
+
       expect(prisma.caregiver.update).toHaveBeenCalledWith({
         where: { id: mockCaregiverId },
         data: {
           backgroundCheckStatus: 'CLEAR',
           backgroundCheckReportUrl: 'https://example.com/report',
-        }
+        },
       });
     });
-    
+
     test('successfully updates status without reportUrl', async () => {
-      (prisma.caregiver.findUnique as jest.Mock).mockResolvedValueOnce(mockCaregiver);
-      
-      const webhookData = {
+      const reportId = 'report-checkr-456';
+      (prisma.backgroundCheckOrder.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: 'order-456',
         caregiverId: mockCaregiverId,
-        status: 'PENDING',
+      });
+      // status 'pending' → PENDING — no notification created, no caregiver.findUnique needed
+
+      const webhookData = {
+        type: 'report.completed',
+        data: {
+          object: {
+            id: reportId,
+            status: 'pending',
+            candidate_id: 'cand-123',
+          },
+        },
       };
-      
+
       const request = createMockWebhookRequest(webhookData);
       const response = await webhookCheckr(request);
-      
+
       expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ success: true });
-      
-      // Verify update was called with correct data
+      expect(await response.json()).toEqual({ received: true });
+
       expect(prisma.caregiver.update).toHaveBeenCalledWith({
         where: { id: mockCaregiverId },
         data: {
           backgroundCheckStatus: 'PENDING',
           backgroundCheckReportUrl: undefined,
-        }
+        },
       });
     });
   });

--- a/__tests__/emergency.api.test.ts
+++ b/__tests__/emergency.api.test.ts
@@ -52,6 +52,9 @@ jest.mock('@/lib/prisma', () => {
         update: jest.fn(),
         create: jest.fn(),
       },
+      activityFeedItem: {
+        create: jest.fn().mockResolvedValue({}),
+      },
     },
   };
 });


### PR DESCRIPTION
…tes — add activityFeedItem prisma mock, user object on mockCaregiver, text+headers methods on mockWebhookRequest [skip render]

emergency.api.test.ts:
- Add activityFeedItem.create mock (route added activity feed logging after tests were written)
- Use mockResolvedValue({}) so .catch() chaining on the create call doesn't throw

background_checks.api.test.ts:
- Expand prisma mock: add backgroundCheckOrder, providerCredential, backgroundCheckInvitation, providerBackgroundCheckOrder, notification
- Add jest.mock(@/lib/checkr) for createCandidate and createReport
- Add checkrCandidateId: null and user object to mockCaregiver
- Add text() and headers.get() to createMockWebhookRequest
- Fix stale error string: "User is not registered" → "Not registered as a caregiver"
- Rewrite 2 start route success tests to match new route contract (creates BackgroundCheckOrder, returns orderId/reportId, no longer returns provider)
- Rewrite 5 webhook tests to match rewritten webhook handler (Checkr-format payload, always returns {received:true}, no 400/404 paths)

https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ