### PR TITLE
feat(admin): add Claim for operator button to home detail page

### DIFF
--- a/src/app/admin/homes/[id]/page.tsx
+++ b/src/app/admin/homes/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   FiShield,
   FiMail,
   FiPhone,
+  FiUserCheck,
 } from 'react-icons/fi';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -277,6 +278,39 @@ export default function AdminHomeDetailPage({ params }: { params: Promise<{ id: 
     }
   };
 
+  const handleClaim = async () => {
+    const operatorEmail = prompt(
+      "Enter the operator's account email to claim this listing for:"
+    );
+    if (!operatorEmail) return;
+
+    try {
+      const response = await fetch(
+        `/api/admin/homes/${resolvedParams.id}/claim`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ operatorEmail }),
+        }
+      );
+      const data = await response.json();
+      if (!response.ok) {
+        alert(`Failed to claim listing: ${data.error || 'Unknown error'}`);
+        return;
+      }
+      alert(data.message);
+      fetchHome();
+    } catch (error) {
+      console.error('Failed to claim listing:', error);
+      alert(
+        `Error claiming listing: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`
+      );
+    }
+  };
+
   const getStatusBadgeClass = (status: string) => {
     switch (status) {
       case 'ACTIVE':
@@ -367,7 +401,16 @@ export default function AdminHomeDetailPage({ params }: { params: Promise<{ id: 
             <div className="flex items-center gap-2">
               {!editing ? (
                 <>
-                  {home.status === 'PENDING_REVIEW' && (
+                  {home.status === 'DRAFT' && (
+                  <button
+                    onClick={handleClaim}
+                    className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700"
+                  >
+                    <FiUserCheck />
+                    Claim for operator
+                  </button>
+                )}
+                {home.status === 'PENDING_REVIEW' && (
                     <>
                       <button
                         onClick={() => handleVerify('APPROVE')}


### PR DESCRIPTION
Added a handleClaim function to allow claiming a home listing by entering an operator's email. Updated the UI to include a button for claiming the listing when the home status is 'DRAFT'.