### PR TITLE
feat(seo): LodgingBusiness JSON-LD + SSR metadata for /homes/[id]

### DIFF
--- a/src/app/homes/[id]/layout.tsx
+++ b/src/app/homes/[id]/layout.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from 'next';
+import { prisma } from '@/lib/prisma';
+import { buildHomeJsonLd, type HomeForJsonLd } from '@/lib/seo/homeJsonLd';
+
+/**
+ * Server layout for /homes/[id].
+ *
+ * The page itself (page.tsx) is a large client component that fetches its
+ * data via the browser. That's fine for the UI, but Google indexes the
+ * initial HTML — so without server-rendered metadata + JSON-LD, facility
+ * pages have no SEO surface area.
+ *
+ * This layout sits in front of the client page:
+ *   1. Fetches the home server-side (one query per page load).
+ *   2. Exports generateMetadata() so the page ships proper <title>, meta
+ *      description, canonical URL, and OpenGraph tags in the SSR HTML.
+ *   3. Emits a LodgingBusiness JSON-LD script in the SSR HTML.
+ *   4. Renders {children} — the existing client page is untouched.
+ *
+ * Only ACTIVE listings get structured data and indexable metadata. DRAFT,
+ * PENDING_REVIEW, SUSPENDED, and INACTIVE listings get a minimal noindex
+ * metadata block — they shouldn't show up in search results until claimed
+ * and approved.
+ */
+
+const SITE_URL = 'https://getcarelinkai.com';
+
+type HomeRecord = HomeForJsonLd & {
+  status: 'DRAFT' | 'PENDING_REVIEW' | 'ACTIVE' | 'SUSPENDED' | 'INACTIVE';
+};
+
+async function loadHomeForSeo(id: string): Promise<HomeRecord | null> {
+  try {
+    const home = await prisma.assistedLivingHome.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        aiGeneratedDescription: true,
+        status: true,
+        careLevel: true,
+        amenities: true,
+        capacity: true,
+        priceMin: true,
+        priceMax: true,
+        address: {
+          select: {
+            street: true,
+            street2: true,
+            city: true,
+            state: true,
+            zipCode: true,
+            country: true,
+            latitude: true,
+            longitude: true,
+          },
+        },
+        photos: {
+          select: {
+            url: true,
+            caption: true,
+            isPrimary: true,
+            sortOrder: true,
+          },
+          orderBy: [{ isPrimary: 'desc' }, { sortOrder: 'asc' }],
+          take: 8,
+        },
+      },
+    });
+    if (!home) return null;
+
+    // Coerce Prisma Decimal columns to numbers for the JSON-LD builder.
+    const priceMin = home.priceMin == null ? null : Number(home.priceMin);
+    const priceMax = home.priceMax == null ? null : Number(home.priceMax);
+
+    return {
+      ...home,
+      priceMin,
+      priceMax,
+    } as HomeRecord;
+  } catch {
+    // If the DB is unreachable during build/render, fall back to no SEO data
+    // rather than failing the route. The client page renders independently.
+    return null;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const home = await loadHomeForSeo(id);
+  const canonical = `${SITE_URL}/homes/${id}`;
+
+  // Unknown / non-ACTIVE listings stay out of search results.
+  if (!home || home.status !== 'ACTIVE') {
+    return {
+      title: 'Senior care home | CareLinkAI',
+      description: 'Find assisted living, memory care, and senior care homes on CareLinkAI.',
+      alternates: { canonical },
+      robots: { index: false, follow: true },
+    };
+  }
+
+  const locality = home.address ? `${home.address.city}, ${home.address.state}` : '';
+  const title = locality
+    ? `${home.name} — Senior Care in ${locality} | CareLinkAI`
+    : `${home.name} | CareLinkAI`;
+
+  const rawDescription = home.aiGeneratedDescription?.trim() || home.description;
+  const description = rawDescription.length > 160 ? `${rawDescription.slice(0, 157)}…` : rawDescription;
+
+  const ogImage = home.photos?.find((p) => p.isPrimary)?.url ?? home.photos?.[0]?.url;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+      url: canonical,
+      siteName: 'CareLinkAI',
+      ...(ogImage ? { images: [{ url: ogImage }] } : {}),
+    },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function HomeDetailLayout({
+  params,
+  children,
+}: {
+  params: Promise<{ id: string }>;
+  children: React.ReactNode;
+}) {
+  const { id } = await params;
+  const home = await loadHomeForSeo(id);
+
+  // Only emit JSON-LD for ACTIVE listings. DRAFT/PENDING/SUSPENDED/INACTIVE
+  // shouldn't appear in Google rich results.
+  const shouldEmitJsonLd = home && home.status === 'ACTIVE';
+  const jsonLd = shouldEmitJsonLd ? buildHomeJsonLd(home) : null;
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
+      {children}
+    </>
+  );
+}

--- a/src/lib/seo/__tests__/homeJsonLd.test.ts
+++ b/src/lib/seo/__tests__/homeJsonLd.test.ts
@@ -1,0 +1,141 @@
+import { buildHomeJsonLd, type HomeForJsonLd } from '../homeJsonLd';
+
+const baseHome: HomeForJsonLd = {
+  id: 'test-home-id',
+  name: 'Maple Grove Senior Living',
+  description: 'A warm, family-run home in Cleveland.',
+  aiGeneratedDescription: null,
+  careLevel: ['ASSISTED', 'MEMORY_CARE'],
+  amenities: ['Wi-Fi', 'Garden'],
+  capacity: 40,
+  priceMin: 4500,
+  priceMax: 7200,
+  address: {
+    street: '1234 Main St',
+    street2: null,
+    city: 'Shaker Heights',
+    state: 'OH',
+    zipCode: '44120',
+    country: 'US',
+    latitude: 41.4737,
+    longitude: -81.5371,
+  },
+  photos: [
+    { url: 'https://cdn.example.com/a.jpg', caption: null, isPrimary: false, sortOrder: 2 },
+    { url: 'https://cdn.example.com/b.jpg', caption: null, isPrimary: true, sortOrder: 0 },
+  ],
+};
+
+describe('buildHomeJsonLd', () => {
+  it('emits a LodgingBusiness with canonical URL and id', () => {
+    const ld = buildHomeJsonLd(baseHome);
+    expect(ld['@type']).toBe('LodgingBusiness');
+    expect(ld['@context']).toBe('https://schema.org');
+    expect(ld['@id']).toBe('https://getcarelinkai.com/homes/test-home-id');
+    expect(ld.url).toBe('https://getcarelinkai.com/homes/test-home-id');
+    expect(ld.name).toBe('Maple Grove Senior Living');
+  });
+
+  it('prefers aiGeneratedDescription when present, falls back to description', () => {
+    const withAi = { ...baseHome, aiGeneratedDescription: 'AI-generated copy.' };
+    expect(buildHomeJsonLd(withAi).description).toBe('AI-generated copy.');
+    expect(buildHomeJsonLd(baseHome).description).toBe('A warm, family-run home in Cleveland.');
+  });
+
+  it('emits address + geo when present', () => {
+    const ld = buildHomeJsonLd(baseHome);
+    expect(ld.address).toMatchObject({
+      '@type': 'PostalAddress',
+      streetAddress: '1234 Main St',
+      addressLocality: 'Shaker Heights',
+      addressRegion: 'OH',
+      postalCode: '44120',
+      addressCountry: 'US',
+    });
+    expect(ld.geo).toMatchObject({
+      '@type': 'GeoCoordinates',
+      latitude: 41.4737,
+      longitude: -81.5371,
+    });
+  });
+
+  it('omits geo when lat/long are missing', () => {
+    const noGeo: HomeForJsonLd = {
+      ...baseHome,
+      address: { ...baseHome.address!, latitude: null, longitude: null },
+    };
+    expect(buildHomeJsonLd(noGeo).geo).toBeUndefined();
+  });
+
+  it('sorts photos isPrimary-first, then by sortOrder', () => {
+    const ld = buildHomeJsonLd(baseHome);
+    expect(ld.image).toEqual([
+      'https://cdn.example.com/b.jpg',
+      'https://cdn.example.com/a.jpg',
+    ]);
+  });
+
+  it('omits image when there are no photos', () => {
+    const ld = buildHomeJsonLd({ ...baseHome, photos: [] });
+    expect(ld.image).toBeUndefined();
+  });
+
+  it('emits priceRange band based on priceMax', () => {
+    expect(buildHomeJsonLd({ ...baseHome, priceMin: 2000, priceMax: 2500 }).priceRange).toBe('$');
+    expect(buildHomeJsonLd({ ...baseHome, priceMin: 3500, priceMax: 4500 }).priceRange).toBe('$$');
+    expect(buildHomeJsonLd({ ...baseHome, priceMin: 6000, priceMax: 7500 }).priceRange).toBe('$$$');
+    expect(buildHomeJsonLd({ ...baseHome, priceMin: 9000, priceMax: 11000 }).priceRange).toBe('$$$$');
+  });
+
+  it('omits priceRange when both prices are null', () => {
+    const ld = buildHomeJsonLd({ ...baseHome, priceMin: null, priceMax: null });
+    expect(ld.priceRange).toBeUndefined();
+    expect(ld.makesOffer).toBeUndefined();
+  });
+
+  it('emits makesOffer Offer with PriceSpecification when both prices set', () => {
+    const ld = buildHomeJsonLd(baseHome);
+    expect(ld.makesOffer).toMatchObject([
+      {
+        '@type': 'Offer',
+        priceCurrency: 'USD',
+        priceSpecification: {
+          '@type': 'PriceSpecification',
+          minPrice: 4500,
+          maxPrice: 7200,
+          priceCurrency: 'USD',
+          unitText: 'MONTH',
+        },
+      },
+    ]);
+  });
+
+  it('maps careLevel enum + amenities into amenityFeature', () => {
+    const ld = buildHomeJsonLd(baseHome);
+    const features = ld.amenityFeature as Array<{ name: string }>;
+    const names = features.map((f) => f.name);
+    expect(names).toContain('Assisted Living');
+    expect(names).toContain('Memory Care');
+    expect(names).toContain('Wi-Fi');
+    expect(names).toContain('Garden');
+  });
+
+  it('does NOT include aggregateRating or review fields (v1 omission)', () => {
+    const ld = buildHomeJsonLd(baseHome);
+    expect(ld.aggregateRating).toBeUndefined();
+    expect(ld.review).toBeUndefined();
+  });
+
+  it('emits numberOfRooms when capacity is present', () => {
+    expect(buildHomeJsonLd(baseHome).numberOfRooms).toBe(40);
+    expect(buildHomeJsonLd({ ...baseHome, capacity: 0 }).numberOfRooms).toBeUndefined();
+    expect(buildHomeJsonLd({ ...baseHome, capacity: null }).numberOfRooms).toBeUndefined();
+  });
+
+  it('handles missing address gracefully', () => {
+    const noAddress = { ...baseHome, address: null };
+    const ld = buildHomeJsonLd(noAddress);
+    expect(ld.address).toBeUndefined();
+    expect(ld.geo).toBeUndefined();
+  });
+});

--- a/src/lib/seo/homeJsonLd.ts
+++ b/src/lib/seo/homeJsonLd.ts
@@ -1,0 +1,160 @@
+/**
+ * LodgingBusiness JSON-LD builder for AssistedLivingHome.
+ *
+ * Used by `src/app/homes/[id]/layout.tsx` to emit schema.org structured data
+ * for senior-living facility detail pages, giving Google enough context to
+ * surface them as rich results.
+ *
+ * Design notes:
+ *  - We use `LodgingBusiness` (subclass of `LocalBusiness`) because Google's
+ *    rich-results guidance treats senior-living facilities as lodging-adjacent.
+ *  - `aggregateRating` and `review` are intentionally NOT included in v1.
+ *    Google requires that aggregateRating reflect the reviews actually shown
+ *    on the page. Until we confirm the on-page review rendering matches what
+ *    we'd emit here, we omit it (better silence than a Google penalty).
+ *  - `priceRange` uses the schema.org convention of '$' marks rather than the
+ *    raw priceMin/priceMax, but if both values exist we emit the explicit
+ *    range too via `offers.priceSpecification`.
+ *  - The builder is pure and side-effect-free — easy to unit-test.
+ */
+
+const SITE_URL = 'https://getcarelinkai.com';
+
+export type HomeForJsonLd = {
+  id: string;
+  name: string;
+  description: string;
+  aiGeneratedDescription?: string | null;
+  careLevel: Array<'INDEPENDENT' | 'ASSISTED' | 'MEMORY_CARE' | 'SKILLED_NURSING'>;
+  amenities: string[];
+  priceMin?: number | null;
+  priceMax?: number | null;
+  capacity?: number | null;
+  address?: {
+    street: string;
+    street2?: string | null;
+    city: string;
+    state: string;
+    zipCode: string;
+    country?: string | null;
+    latitude?: number | null;
+    longitude?: number | null;
+  } | null;
+  photos?: Array<{
+    url: string;
+    caption?: string | null;
+    isPrimary: boolean;
+    sortOrder: number;
+  }>;
+};
+
+const CARE_LEVEL_LABELS: Record<HomeForJsonLd['careLevel'][number], string> = {
+  INDEPENDENT: 'Independent Living',
+  ASSISTED: 'Assisted Living',
+  MEMORY_CARE: 'Memory Care',
+  SKILLED_NURSING: 'Skilled Nursing',
+};
+
+function toPriceRangeBand(priceMin?: number | null, priceMax?: number | null): string | undefined {
+  const ref = priceMax ?? priceMin;
+  if (ref == null) return undefined;
+  if (ref < 3000) return '$';
+  if (ref < 5000) return '$$';
+  if (ref < 8000) return '$$$';
+  return '$$$$';
+}
+
+function sortedPhotoUrls(home: HomeForJsonLd): string[] {
+  if (!home.photos || home.photos.length === 0) return [];
+  return [...home.photos]
+    .sort((a, b) => {
+      if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
+      return a.sortOrder - b.sortOrder;
+    })
+    .map((p) => p.url)
+    .filter((u): u is string => !!u);
+}
+
+export function buildHomeJsonLd(home: HomeForJsonLd): Record<string, unknown> {
+  const canonicalUrl = `${SITE_URL}/homes/${home.id}`;
+  const description = home.aiGeneratedDescription?.trim() || home.description;
+
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'LodgingBusiness',
+    '@id': canonicalUrl,
+    name: home.name,
+    description,
+    url: canonicalUrl,
+  };
+
+  // Address (PostalAddress)
+  if (home.address) {
+    const a = home.address;
+    const streetAddress = [a.street, a.street2].filter(Boolean).join(', ');
+    jsonLd.address = {
+      '@type': 'PostalAddress',
+      streetAddress,
+      addressLocality: a.city,
+      addressRegion: a.state,
+      postalCode: a.zipCode,
+      addressCountry: a.country || 'US',
+    };
+
+    // Geo (GeoCoordinates) — only if both lat/long are present
+    if (typeof a.latitude === 'number' && typeof a.longitude === 'number') {
+      jsonLd.geo = {
+        '@type': 'GeoCoordinates',
+        latitude: a.latitude,
+        longitude: a.longitude,
+      };
+    }
+  }
+
+  // Images
+  const photoUrls = sortedPhotoUrls(home);
+  if (photoUrls.length > 0) {
+    jsonLd.image = photoUrls;
+  }
+
+  // Price range band ('$' / '$$' / '$$$' / '$$$$')
+  const priceBand = toPriceRangeBand(home.priceMin, home.priceMax);
+  if (priceBand) {
+    jsonLd.priceRange = priceBand;
+  }
+
+  // Amenity features — combine domain amenities[] with the careLevel[] enum labels
+  const careLevelLabels = home.careLevel.map((cl) => CARE_LEVEL_LABELS[cl]).filter(Boolean);
+  const amenityNames = [...new Set([...careLevelLabels, ...home.amenities])];
+  if (amenityNames.length > 0) {
+    jsonLd.amenityFeature = amenityNames.map((name) => ({
+      '@type': 'LocationFeatureSpecification',
+      name,
+      value: true,
+    }));
+  }
+
+  // Total rooms (capacity = total beds, a reasonable proxy)
+  if (typeof home.capacity === 'number' && home.capacity > 0) {
+    jsonLd.numberOfRooms = home.capacity;
+  }
+
+  // Explicit price range as an offer when both ends are known
+  if (typeof home.priceMin === 'number' && typeof home.priceMax === 'number' && home.priceMax >= home.priceMin) {
+    jsonLd.makesOffer = [
+      {
+        '@type': 'Offer',
+        priceCurrency: 'USD',
+        priceSpecification: {
+          '@type': 'PriceSpecification',
+          minPrice: home.priceMin,
+          maxPrice: home.priceMax,
+          priceCurrency: 'USD',
+          unitText: 'MONTH',
+        },
+      },
+    ];
+  }
+
+  return jsonLd;
+}


### PR DESCRIPTION
## Why

Follow-up to the Cleveland SEO landing pages (PR #533). The facility detail page at `/homes/[id]` had **no SEO surface area** — it's a 2,254-line client component that fetches data via the browser, so the initial HTML Googlebot sees has no title, description, canonical, or structured data. This PR adds them without touching the existing client page.

## What

**3 files, all additive — zero edits to the existing client page.**

- `src/lib/seo/homeJsonLd.ts` — pure builder mapping `AssistedLivingHome` to schema.org `LodgingBusiness` (address, geo, image[], priceRange band + makesOffer, amenityFeature[] from careLevel + amenities, numberOfRooms from capacity).
- - `src/app/homes/[id]/layout.tsx` — server component that wraps the client page. Fetches the home server-side (one query per page load, same shape Prisma already serves), exports `generateMetadata()` (title, description, canonical, OpenGraph + image), and emits the `LodgingBusiness` JSON-LD as inline `<script type="application/ld+json">`.
- - `src/lib/seo/__tests__/homeJsonLd.test.ts` — 12 unit tests covering canonical URL, description fallback, address/geo, photo sorting, price band, makesOffer, amenityFeature, capacity guards, missing-address guard, and the v1 omission of aggregateRating.
## Indexing policy

- **ACTIVE** listings: full metadata + JSON-LD, `robots: index: true`.
- - **DRAFT / PENDING_REVIEW / SUSPENDED / INACTIVE**: noindex metadata, no JSON-LD. The 50 unclaimed seeded Cleveland directory listings stay out of Google search until an operator claims and the listing is approved.
## Notes

- `aggregateRating` is intentionally **omitted in v1**. Google requires it to reflect the on-page reviews; until the page's review rendering is confirmed to match, silence is safer than a Google penalty.
- - The DB fetch is wrapped in `try/catch` returning `null` on failure — if the DB is unreachable during build/render, the client page still renders.
- - Server-rendered metadata + JSON-LD addresses the remaining SEO open loop after PR #534 (sitemap/robots) and PR #533 (Cleveland landing pages).
Demand-side counterpart to Risk 2 (marketplace cold start). See `CARELINKAI_RISK_REGISTER.md#risk-2`.