### PR TITLE
fix(hipaa+billing): close 2026-05-18 scoping incident + Stripe session loss

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,15 +19,32 @@ NEXTAUTH_SECRET="generate-with: openssl rand -base64 32"
 # STRIPE — Payments (required for billing features)
 # Keys from: https://dashboard.stripe.com/apikeys
 # Webhook secret from: https://dashboard.stripe.com/webhooks
+# When swapping Stripe accounts: update all 12 values below.
 # ------------------------------------------------------------
-STRIPE_SECRET_KEY="sk_live_..."
-STRIPE_PUBLISHABLE_KEY="pk_live_..."
+STRIPE_SECRET_KEY="sk_test_..."
+# NOTE: must be NEXT_PUBLIC_ prefix — used client-side by Stripe Elements
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_..."
 STRIPE_WEBHOOK_SECRET="whsec_..."
-# Subscription tier Price IDs — create these Products/Prices in Stripe dashboard
-# When swapping Stripe accounts, update these four values along with the keys above
+
+# Operator subscription tier Price IDs (recurring monthly)
 STRIPE_PRICE_STARTER="price_..."
 STRIPE_PRICE_PROFESSIONAL="price_..."
 STRIPE_PRICE_GROWTH="price_..."
+STRIPE_PRICE_AGENCY="price_..."
+
+# Caregiver Pro tier ($19/mo recurring)
+STRIPE_PRICE_PRO_CAREGIVER="price_..."
+
+# Provider listing fee ($99/mo recurring)
+STRIPE_PRICE_PROVIDER_LISTING="price_..."
+
+# Family Plus tier ($19/mo recurring)
+STRIPE_PRICE_FAMILY_PLUS="price_..."
+
+# Discharge Planner tiers
+STRIPE_PRICE_DISCHARGE_PLANNER="price_..."       # Individual: $99/seat/mo
+STRIPE_PRICE_DISCHARGE_PLANNER_DEPT="price_..."  # Department: $499/mo (up to 10 seats)
+
 # Placement fee charged to operator on inquiry → resident conversion (in cents, default $500)
 PLACEMENT_FEE_CENTS=50000
 # Care Wallet transaction fee percentage charged to families (default 2.5%)

--- a/e2e/operator-dashboard-scoping.spec.ts
+++ b/e2e/operator-dashboard-scoping.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from './_helpers';
+
+// Regression suite for the 2026-05-18 dashboard scoping incident:
+// API routes were returning cross-operator aggregates with no WHERE clause.
+// Extended 2026-05-31 to cover leads and pipeline endpoints found in follow-up audit.
+//
+// Pattern: seed operators via dev endpoint, call APIs, assert isolation.
+// Note: BAA-gate redirect tests live in the BAA extension PR; not included here
+// because they depend on /api/acceptance and /legal/acceptance which ship separately.
+
+async function seedOperator(request: any, email: string, name: string) {
+  const res = await request.post('/api/dev/upsert-operator', {
+    data: { email, companyName: name, homes: [{ name: `${name} Home`, capacity: 10 }] },
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+test.describe('@critical Operator dashboard scoping (regression 2026-05-18)', () => {
+  test('operator A sees only their residents/inquiries — /api/dashboard/metrics isolated', async ({ page, request }) => {
+    const opA = `scope-metrics-a-${Date.now()}@test.carelinkai.com`;
+    const opB = `scope-metrics-b-${Date.now()}@test.carelinkai.com`;
+
+    await seedOperator(request, opA, 'Scope Metrics A');
+    await seedOperator(request, opB, 'Scope Metrics B');
+
+    // --- Operator A ---
+    await loginAs(page, opA);
+    const metricsA = await page.evaluate(async () => {
+      const r = await fetch('/api/dashboard/metrics', { credentials: 'include' });
+      return r.json();
+    });
+    // upsert-operator seeds homes but NO residents — must be 0, not cross-tenant total
+    expect(metricsA.totalResidents?.value).toBe(0);
+    expect(metricsA.pendingInquiries?.value).toBe(0);
+
+    // --- Operator B ---
+    await loginAs(page, opB);
+    const metricsB = await page.evaluate(async () => {
+      const r = await fetch('/api/dashboard/metrics', { credentials: 'include' });
+      return r.json();
+    });
+    expect(metricsB.totalResidents?.value).toBe(0);
+    expect(metricsB.pendingInquiries?.value).toBe(0);
+  });
+
+  test('/api/dashboard/charts conversion funnel is zero for brand-new operator', async ({ page, request }) => {
+    const opEmail = `scope-charts-${Date.now()}@test.carelinkai.com`;
+    await seedOperator(request, opEmail, 'Scope Charts Op');
+    await loginAs(page, opEmail);
+
+    const charts = await page.evaluate(async () => {
+      const r = await fetch('/api/dashboard/charts', { credentials: 'include' });
+      return r.json();
+    });
+
+    const funnelTotal = (charts.conversionFunnel as Array<{ count: number }>)
+      ?.reduce((sum, s) => sum + (s.count ?? 0), 0) ?? 0;
+    expect(funnelTotal).toBe(0);
+  });
+
+  test('/api/operator/leads returns empty list for brand-new operator (Bug 2026-05-31)', async ({ page, request }) => {
+    const opEmail = `scope-leads-${Date.now()}@test.carelinkai.com`;
+    await seedOperator(request, opEmail, 'Leads Scope Op');
+    await loginAs(page, opEmail);
+
+    const leads = await page.evaluate(async () => {
+      const r = await fetch('/api/operator/leads', { credentials: 'include' });
+      return r.json();
+    });
+
+    // A brand-new operator with no leads must see 0, not the full cross-operator list.
+    expect(leads.data?.pagination?.total ?? leads.data?.leads?.length ?? 0).toBe(0);
+  });
+
+  test('/api/operator/inquiries/pipeline returns zero stats for brand-new operator (Bug 2026-05-31)', async ({ page, request }) => {
+    const opEmail = `scope-pipeline-${Date.now()}@test.carelinkai.com`;
+    await seedOperator(request, opEmail, 'Pipeline Scope Op');
+    await loginAs(page, opEmail);
+
+    const pipeline = await page.evaluate(async () => {
+      const r = await fetch('/api/operator/inquiries/pipeline', { credentials: 'include' });
+      return r.json();
+    });
+
+    // Brand-new operator with no inquiries must see 0 total, not platform-wide counts.
+    expect(pipeline.stats?.total ?? 0).toBe(0);
+  });
+});

--- a/src/app/api/dashboard/activity/route.ts
+++ b/src/app/api/dashboard/activity/route.ts
@@ -8,20 +8,41 @@ export const revalidate = 0;
 
 /**
  * GET /api/dashboard/activity
- * ENHANCED VERSION - Phase 3 Implementation
- * Returns recent activity feed from inquiries, assessments, incidents, and residents
+ * Returns operator-scoped activity feed. OPERATOR: scoped to their homes.
+ * ADMIN: platform-wide.
  */
 export async function GET(request: NextRequest) {
   try {
-    console.log('=== Dashboard Activity API Called (Enhanced) ===');
-    
     const session = await getServerSession(authOptions);
     if (!session?.user?.email) {
-      console.log('No session found');
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    console.log('User email:', session.user.email);
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+      select: { id: true, role: true },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    let operatorId: string | null = null;
+    if (user.role === 'OPERATOR') {
+      const operator = await prisma.operator.findUnique({
+        where: { userId: user.id },
+        select: { id: true },
+      });
+      if (!operator) {
+        return NextResponse.json({ error: 'Operator record not found' }, { status: 404 });
+      }
+      operatorId = operator.id;
+    }
+
+    const residentScope = operatorId ? { home: { operatorId } } : {};
+    const inquiryScope  = operatorId ? { home: { operatorId } } : {};
+    const incidentScope = operatorId ? { resident: { home: { operatorId } } } : {};
+    const assessScope   = operatorId ? { resident: { home: { operatorId } } } : {};
 
     const activities: Array<{
       id: string;
@@ -32,263 +53,150 @@ export async function GET(request: NextRequest) {
       link: string;
     }> = [];
 
-    // ACTIVITY 1: New Inquiries (Last 24 hours)
-    try {
-      const twentyFourHoursAgo = new Date();
-      twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24);
+    const twentyFourHoursAgo = new Date();
+    twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24);
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
+    // ACTIVITY 1: New Inquiries
+    try {
       const newInquiries = await prisma.inquiry.findMany({
-        where: {
-          createdAt: {
-            gte: twentyFourHoursAgo
-          }
-        },
+        where: { ...inquiryScope, createdAt: { gte: twentyFourHoursAgo } },
         include: {
-          family: {
-            include: {
-              user: {
-                select: {
-                  firstName: true,
-                  lastName: true
-                }
-              }
-            }
-          },
-          home: {
-            select: {
-              name: true
-            }
-          }
+          family: { include: { user: { select: { firstName: true, lastName: true } } } },
+          home: { select: { name: true } },
         },
-        orderBy: {
-          createdAt: 'desc'
-        },
-        take: 5
+        orderBy: { createdAt: 'desc' },
+        take: 5,
       });
 
       newInquiries.forEach((inquiry) => {
         const familyName = `${inquiry?.family?.user?.firstName ?? ''} ${inquiry?.family?.user?.lastName ?? ''}`.trim() || 'Unknown Family';
         const homeName = inquiry?.home?.name ?? 'Unknown Home';
-        
         activities.push({
           id: `inquiry-${inquiry.id}`,
           type: 'inquiry',
           title: 'New Inquiry Received',
           description: `${familyName} inquired about ${homeName}`,
           timestamp: inquiry.createdAt.toISOString(),
-          link: `/operator/inquiries/${inquiry.id}`
+          link: `/operator/inquiries/${inquiry.id}`,
         });
       });
-
-      console.log('New inquiries:', newInquiries.length);
     } catch (error) {
       console.error('Error fetching new inquiries:', error);
     }
 
-    // ACTIVITY 2: Completed Assessments (Last 24 hours)
+    // ACTIVITY 2: Completed Assessments
     try {
-      const twentyFourHoursAgo = new Date();
-      twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24);
-
       const completedAssessments = await prisma.assessmentResult.findMany({
-        where: {
-          status: 'COMPLETED',
-          conductedAt: {
-            gte: twentyFourHoursAgo
-          }
-        },
-        include: {
-          resident: {
-            select: {
-              id: true,
-              firstName: true,
-              lastName: true
-            }
-          }
-        },
-        orderBy: {
-          conductedAt: 'desc'
-        },
-        take: 5
+        where: { ...assessScope, status: 'COMPLETED', conductedAt: { gte: twentyFourHoursAgo } },
+        include: { resident: { select: { id: true, firstName: true, lastName: true } } },
+        orderBy: { conductedAt: 'desc' },
+        take: 5,
       });
 
       completedAssessments.forEach((assessment) => {
         const residentName = `${assessment?.resident?.firstName ?? ''} ${assessment?.resident?.lastName ?? ''}`.trim() || 'Unknown Resident';
-        
         activities.push({
           id: `assessment-${assessment.id}`,
           type: 'assessment',
           title: 'Assessment Completed',
           description: `${assessment.type} assessment completed for ${residentName}`,
           timestamp: (assessment.conductedAt ?? assessment.createdAt).toISOString(),
-          link: `/operator/residents/${assessment.residentId}`
+          link: `/operator/residents/${assessment.residentId}`,
         });
       });
-
-      console.log('Completed assessments:', completedAssessments.length);
     } catch (error) {
       console.error('Error fetching completed assessments:', error);
     }
 
-    // ACTIVITY 3: Recent Incidents (Last 24 hours)
+    // ACTIVITY 3: Recent Incidents
     try {
-      const twentyFourHoursAgo = new Date();
-      twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24);
-
       const recentIncidents = await prisma.residentIncident.findMany({
-        where: {
-          reportedAt: {
-            gte: twentyFourHoursAgo
-          }
-        },
-        include: {
-          resident: {
-            select: {
-              id: true,
-              firstName: true,
-              lastName: true
-            }
-          }
-        },
-        orderBy: {
-          reportedAt: 'desc'
-        },
-        take: 5
+        where: { ...incidentScope, reportedAt: { gte: twentyFourHoursAgo } },
+        include: { resident: { select: { id: true, firstName: true, lastName: true } } },
+        orderBy: { reportedAt: 'desc' },
+        take: 5,
       });
 
       recentIncidents.forEach((incident) => {
         const residentName = `${incident?.resident?.firstName ?? ''} ${incident?.resident?.lastName ?? ''}`.trim() || 'Unknown Resident';
-        const severityLabel = incident.severity?.toLowerCase() ?? 'unknown';
-        
         activities.push({
           id: `incident-${incident.id}`,
           type: 'incident',
           title: `${incident.severity} Incident Reported`,
           description: `${incident.type} - ${residentName}`,
           timestamp: incident.reportedAt.toISOString(),
-          link: `/operator/residents/${incident.residentId}`
+          link: `/operator/residents/${incident.residentId}`,
         });
       });
-
-      console.log('Recent incidents:', recentIncidents.length);
     } catch (error) {
       console.error('Error fetching recent incidents:', error);
     }
 
-    // ACTIVITY 4: New Residents Admitted (Last 7 Days)
+    // ACTIVITY 4: New Residents Admitted
     try {
-      const sevenDaysAgo = new Date();
-      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-
       const newResidents = await prisma.resident.findMany({
-        where: {
-          admissionDate: {
-            gte: sevenDaysAgo
-          },
-          status: 'ACTIVE'
-        },
+        where: { ...residentScope, admissionDate: { gte: sevenDaysAgo }, status: 'ACTIVE' },
         select: {
-          id: true,
-          firstName: true,
-          lastName: true,
-          admissionDate: true,
-          home: {
-            select: {
-              name: true
-            }
-          }
+          id: true, firstName: true, lastName: true, admissionDate: true,
+          home: { select: { name: true } },
         },
-        orderBy: {
-          admissionDate: 'desc'
-        },
-        take: 5
+        orderBy: { admissionDate: 'desc' },
+        take: 5,
       });
 
       newResidents.forEach((resident) => {
         const residentName = `${resident?.firstName ?? ''} ${resident?.lastName ?? ''}`.trim() || 'Unknown Resident';
         const homeName = resident?.home?.name ?? 'Unknown Home';
-        
         activities.push({
           id: `resident-${resident.id}`,
           type: 'admission',
           title: 'New Resident Admitted',
           description: `${residentName} admitted to ${homeName}`,
           timestamp: resident.admissionDate?.toISOString() ?? new Date().toISOString(),
-          link: `/operator/residents/${resident.id}`
+          link: `/operator/residents/${resident.id}`,
         });
       });
-
-      console.log('New residents:', newResidents.length);
     } catch (error) {
       console.error('Error fetching new residents:', error);
     }
 
-    // ACTIVITY 5: Status Updates (Inquiries that changed status in last 24 hours)
+    // ACTIVITY 5: Inquiry Status Updates
     try {
-      const twentyFourHoursAgo = new Date();
-      twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24);
-
       const statusUpdates = await prisma.inquiry.findMany({
         where: {
-          updatedAt: {
-            gte: twentyFourHoursAgo
-          },
-          status: {
-            in: ['TOUR_COMPLETED', 'QUALIFIED', 'CONVERTED']
-          }
+          ...inquiryScope,
+          updatedAt: { gte: twentyFourHoursAgo },
+          status: { in: ['TOUR_COMPLETED', 'QUALIFIED', 'CONVERTED'] },
         },
         include: {
-          family: {
-            include: {
-              user: {
-                select: {
-                  firstName: true,
-                  lastName: true
-                }
-              }
-            }
-          }
+          family: { include: { user: { select: { firstName: true, lastName: true } } } },
         },
-        orderBy: {
-          updatedAt: 'desc'
-        },
-        take: 5
+        orderBy: { updatedAt: 'desc' },
+        take: 5,
       });
 
       statusUpdates.forEach((inquiry) => {
         const familyName = `${inquiry?.family?.user?.firstName ?? ''} ${inquiry?.family?.user?.lastName ?? ''}`.trim() || 'Unknown Family';
         const statusLabel = inquiry.status.replace(/_/g, ' ').toLowerCase();
-        
         activities.push({
           id: `status-${inquiry.id}`,
           type: 'status',
           title: 'Inquiry Status Updated',
           description: `${familyName} - ${statusLabel}`,
           timestamp: inquiry.updatedAt.toISOString(),
-          link: `/operator/inquiries/${inquiry.id}`
+          link: `/operator/inquiries/${inquiry.id}`,
         });
       });
-
-      console.log('Status updates:', statusUpdates.length);
     } catch (error) {
       console.error('Error fetching status updates:', error);
     }
 
-    // Sort all activities by timestamp (most recent first) and limit to 15
-    activities.sort((a, b) => {
-      return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
-    });
-
-    const limitedActivities = activities.slice(0, 15);
-
-    console.log(`Returning ${limitedActivities.length} activities`);
-    return NextResponse.json({ activities: limitedActivities });
-
+    activities.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    return NextResponse.json({ activities: activities.slice(0, 15) });
   } catch (error: any) {
-    console.error('=== Dashboard Activity Error ===');
-    console.error('Error:', error);
-    console.error('Message:', error.message);
-    console.error('Stack:', error.stack);
+    console.error('Dashboard activity error:', error);
     return NextResponse.json(
       { error: 'Failed to fetch activity', details: error.message },
       { status: 500 }

--- a/src/app/api/dashboard/alerts/route.ts
+++ b/src/app/api/dashboard/alerts/route.ts
@@ -8,20 +8,43 @@ export const revalidate = 0;
 
 /**
  * GET /api/dashboard/alerts
- * ENHANCED VERSION - Phase 3 Implementation
- * Returns real alerts for overdue assessments, critical incidents, and follow-ups
+ * Returns operator-scoped alerts. OPERATOR: scoped to their homes.
+ * ADMIN: platform-wide.
  */
 export async function GET(request: NextRequest) {
   try {
-    console.log('=== Dashboard Alerts API Called (Enhanced) ===');
-    
     const session = await getServerSession(authOptions);
     if (!session?.user?.email) {
-      console.log('No session found');
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    console.log('User email:', session.user.email);
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+      select: { id: true, role: true },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    let operatorId: string | null = null;
+    if (user.role === 'OPERATOR') {
+      const operator = await prisma.operator.findUnique({
+        where: { userId: user.id },
+        select: { id: true },
+      });
+      if (!operator) {
+        return NextResponse.json({ error: 'Operator record not found' }, { status: 404 });
+      }
+      operatorId = operator.id;
+    }
+
+    const assessScope   = operatorId ? { resident: { home: { operatorId } } } : {};
+    const incidentScope = operatorId ? { resident: { home: { operatorId } } } : {};
+    const inquiryScope  = operatorId ? { home: { operatorId } } : {};
+    const certScope     = operatorId
+      ? { caregiver: { employments: { some: { operatorId } } } }
+      : {};
 
     const alerts: Array<{
       id: string;
@@ -40,37 +63,22 @@ export async function GET(request: NextRequest) {
 
       const overdueAssessments = await prisma.assessmentResult.findMany({
         where: {
-          status: {
-            in: ['PENDING_REVIEW', 'IN_PROGRESS']
-          },
-          createdAt: {
-            lt: sevenDaysAgo
-          }
+          ...assessScope,
+          status: { in: ['PENDING_REVIEW', 'IN_PROGRESS'] },
+          createdAt: { lt: sevenDaysAgo },
         },
-        include: {
-          resident: {
-            select: {
-              id: true,
-              firstName: true,
-              lastName: true
-            }
-          }
-        },
+        include: { resident: { select: { id: true, firstName: true, lastName: true } } },
         take: 5,
-        orderBy: {
-          createdAt: 'asc'
-        }
+        orderBy: { createdAt: 'asc' },
       });
 
       if (overdueAssessments.length > 0) {
-        const residentNames = overdueAssessments
-          .slice(0, 3)
+        const residentNames = overdueAssessments.slice(0, 3)
           .map(a => `${a?.resident?.firstName ?? ''} ${a?.resident?.lastName ?? ''}`.trim())
-          .filter(name => name.length > 0)
+          .filter(n => n.length > 0)
           .join(', ');
-        
         const moreCount = overdueAssessments.length > 3 ? ` and ${overdueAssessments.length - 3} more` : '';
-        
+
         alerts.push({
           id: 'overdue-assessments',
           type: 'warning',
@@ -78,11 +86,9 @@ export async function GET(request: NextRequest) {
           description: `Assessments pending review for ${residentNames}${moreCount}`,
           actionLabel: 'View Assessments',
           actionUrl: '/operator/residents',
-          timestamp: new Date().toISOString()
+          timestamp: new Date().toISOString(),
         });
       }
-
-      console.log('Overdue assessments alert:', overdueAssessments.length);
     } catch (error) {
       console.error('Error fetching overdue assessments:', error);
     }
@@ -94,35 +100,18 @@ export async function GET(request: NextRequest) {
 
       const criticalIncidents = await prisma.residentIncident.findMany({
         where: {
+          ...incidentScope,
           severity: 'Critical',
-          occurredAt: {
-            gte: sevenDaysAgo
-          },
-          status: {
-            in: ['REPORTED', 'UNDER_REVIEW']
-          }
+          occurredAt: { gte: sevenDaysAgo },
+          status: { in: ['REPORTED', 'UNDER_REVIEW'] },
         },
-        include: {
-          resident: {
-            select: {
-              id: true,
-              firstName: true,
-              lastName: true
-            }
-          }
-        },
+        include: { resident: { select: { id: true, firstName: true, lastName: true } } },
         take: 5,
-        orderBy: {
-          occurredAt: 'desc'
-        }
+        orderBy: { occurredAt: 'desc' },
       });
 
       if (criticalIncidents.length > 0) {
-        const incidentTypes = criticalIncidents
-          .slice(0, 2)
-          .map(i => i.type)
-          .join(', ');
-        
+        const incidentTypes = criticalIncidents.slice(0, 2).map(i => i.type).join(', ');
         alerts.push({
           id: 'critical-incidents',
           type: 'error',
@@ -130,16 +119,14 @@ export async function GET(request: NextRequest) {
           description: `Recent critical incidents: ${incidentTypes}`,
           actionLabel: 'View Incidents',
           actionUrl: '/operator/residents',
-          timestamp: criticalIncidents[0]?.occurredAt?.toISOString() ?? new Date().toISOString()
+          timestamp: criticalIncidents[0]?.occurredAt?.toISOString() ?? new Date().toISOString(),
         });
       }
-
-      console.log('Critical incidents alert:', criticalIncidents.length);
     } catch (error) {
       console.error('Error fetching critical incidents:', error);
     }
 
-    // ALERT 3: Follow-ups Due Today
+    // ALERT 3: Tours Scheduled Today
     try {
       const today = new Date();
       today.setHours(0, 0, 0, 0);
@@ -148,38 +135,25 @@ export async function GET(request: NextRequest) {
 
       const followUpsDue = await prisma.inquiry.findMany({
         where: {
-          tourDate: {
-            gte: today,
-            lt: tomorrow
-          },
-          status: {
-            in: ['TOUR_SCHEDULED', 'CONTACTED']
-          }
+          ...inquiryScope,
+          tourDate: { gte: today, lt: tomorrow },
+          status: { in: ['TOUR_SCHEDULED', 'CONTACTED'] },
         },
         include: {
           family: {
-            include: {
-              user: {
-                select: {
-                  firstName: true,
-                  lastName: true
-                }
-              }
-            }
-          }
+            include: { user: { select: { firstName: true, lastName: true } } },
+          },
         },
-        take: 5
+        take: 5,
       });
 
       if (followUpsDue.length > 0) {
-        const familyNames = followUpsDue
-          .slice(0, 2)
+        const familyNames = followUpsDue.slice(0, 2)
           .map(f => `${f?.family?.user?.firstName ?? ''} ${f?.family?.user?.lastName ?? ''}`.trim())
-          .filter(name => name.length > 0)
+          .filter(n => n.length > 0)
           .join(', ');
-        
         const moreCount = followUpsDue.length > 2 ? ` and ${followUpsDue.length - 2} more` : '';
-        
+
         alerts.push({
           id: 'followups-due',
           type: 'info',
@@ -187,55 +161,40 @@ export async function GET(request: NextRequest) {
           description: `Tours for ${familyNames}${moreCount}`,
           actionLabel: 'View Tours',
           actionUrl: '/operator/inquiries',
-          timestamp: new Date().toISOString()
+          timestamp: new Date().toISOString(),
         });
       }
-
-      console.log('Follow-ups due alert:', followUpsDue.length);
     } catch (error) {
       console.error('Error fetching follow-ups:', error);
     }
 
-    // ALERT 4: Expiring Certifications (Caregivers with certs expiring in 30 days)
+    // ALERT 4: Expiring Certifications
     try {
       const thirtyDaysFromNow = new Date();
       thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
 
       const expiringCerts = await prisma.caregiverCertification.findMany({
         where: {
-          expiryDate: {
-            lte: thirtyDaysFromNow,
-            gte: new Date()
-          },
-          status: 'CURRENT'
+          ...certScope,
+          expiryDate: { lte: thirtyDaysFromNow, gte: new Date() },
+          status: 'CURRENT',
         },
         include: {
           caregiver: {
-            include: {
-              user: {
-                select: {
-                  firstName: true,
-                  lastName: true
-                }
-              }
-            }
-          }
+            include: { user: { select: { firstName: true, lastName: true } } },
+          },
         },
         take: 5,
-        orderBy: {
-          expiryDate: 'asc'
-        }
+        orderBy: { expiryDate: 'asc' },
       });
 
       if (expiringCerts.length > 0) {
-        const caregiverNames = expiringCerts
-          .slice(0, 2)
+        const caregiverNames = expiringCerts.slice(0, 2)
           .map(c => `${c?.caregiver?.user?.firstName ?? ''} ${c?.caregiver?.user?.lastName ?? ''}`.trim())
-          .filter(name => name.length > 0)
+          .filter(n => n.length > 0)
           .join(', ');
-        
         const moreCount = expiringCerts.length > 2 ? ` and ${expiringCerts.length - 2} more` : '';
-        
+
         alerts.push({
           id: 'expiring-certifications',
           type: 'warning',
@@ -243,23 +202,16 @@ export async function GET(request: NextRequest) {
           description: `Certifications expiring for ${caregiverNames}${moreCount}`,
           actionLabel: 'View Caregivers',
           actionUrl: '/operator/caregivers',
-          timestamp: new Date().toISOString()
+          timestamp: new Date().toISOString(),
         });
       }
-
-      console.log('Expiring certifications alert:', expiringCerts.length);
     } catch (error) {
       console.error('Error fetching expiring certifications:', error);
     }
 
-    console.log(`Returning ${alerts.length} alerts`);
     return NextResponse.json({ alerts });
-
   } catch (error: any) {
-    console.error('=== Dashboard Alerts Error ===');
-    console.error('Error:', error);
-    console.error('Message:', error.message);
-    console.error('Stack:', error.stack);
+    console.error('Dashboard alerts error:', error);
     return NextResponse.json(
       { error: 'Failed to fetch alerts', details: error.message },
       { status: 500 }

--- a/src/app/api/dashboard/charts/route.ts
+++ b/src/app/api/dashboard/charts/route.ts
@@ -8,91 +8,80 @@ export const revalidate = 0;
 
 /**
  * GET /api/dashboard/charts
- * ENHANCED VERSION - Phase 2 Implementation
- * Returns real chart data for occupancy, conversion funnel, and incidents
+ * Returns operator-scoped chart data. OPERATOR: scoped to their homes.
+ * ADMIN: platform-wide.
  */
 export async function GET(request: NextRequest) {
   try {
-    console.log('=== Dashboard Charts API Called (Enhanced) ===');
-    
     const session = await getServerSession(authOptions);
     if (!session?.user?.email) {
-      console.log('No session found');
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    console.log('User email:', session.user.email);
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+      select: { id: true, role: true },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    let operatorId: string | null = null;
+    if (user.role === 'OPERATOR') {
+      const operator = await prisma.operator.findUnique({
+        where: { userId: user.id },
+        select: { id: true },
+      });
+      if (!operator) {
+        return NextResponse.json({ error: 'Operator record not found' }, { status: 404 });
+      }
+      operatorId = operator.id;
+    }
+
+    const residentScope = operatorId ? { home: { operatorId } } : {};
+    const inquiryScope  = operatorId ? { home: { operatorId } } : {};
+    const incidentScope = operatorId ? { resident: { home: { operatorId } } } : {};
+    const homeScope     = operatorId ? { operatorId } : {};
 
     // CHART 1: Occupancy Trend (Last 6 Months)
     let occupancyTrend: Array<{ month: string; occupancy: number }> = [];
-    
     try {
       const now = new Date();
       const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-      
-      // Get total capacity (stays same for all months)
+
       const homesData = await prisma.assistedLivingHome.aggregate({
-        _sum: {
-          capacity: true
-        },
-        where: {
-          status: 'ACTIVE'
-        }
+        _sum: { capacity: true },
+        where: { ...homeScope, status: 'ACTIVE' },
       });
-      
-      const totalCapacity = homesData?._sum?.capacity ?? 100; // Default to 100 if no data
-      
-      // Calculate occupancy for last 6 months
+      const totalCapacity = homesData?._sum?.capacity ?? 100;
+
       for (let i = 5; i >= 0; i--) {
         const monthDate = new Date(now.getFullYear(), now.getMonth() - i, 1);
         const nextMonthDate = new Date(now.getFullYear(), now.getMonth() - i + 1, 1);
-        
+
         const residentCount = await prisma.resident.count({
           where: {
-            admissionDate: {
-              lt: nextMonthDate
-            },
-            OR: [
-              {
-                dischargeDate: null
-              },
-              {
-                dischargeDate: {
-                  gte: monthDate
-                }
-              }
-            ],
-            archivedAt: null
-          }
+            ...residentScope,
+            admissionDate: { lt: nextMonthDate },
+            OR: [{ dischargeDate: null }, { dischargeDate: { gte: monthDate } }],
+            archivedAt: null,
+          },
         });
-        
-        const occupancyPercentage = totalCapacity > 0 
+
+        const occupancyPercentage = totalCapacity > 0
           ? Math.round((residentCount / totalCapacity) * 100)
           : 0;
-        
-        occupancyTrend.push({
-          month: monthNames[monthDate.getMonth()],
-          occupancy: occupancyPercentage
-        });
+
+        occupancyTrend.push({ month: monthNames[monthDate.getMonth()], occupancy: occupancyPercentage });
       }
-      
-      console.log('Occupancy trend:', occupancyTrend);
     } catch (error) {
       console.error('Error calculating occupancy trend:', error);
-      // Provide fallback data
-      occupancyTrend = [
-        { month: 'Jul', occupancy: 0 },
-        { month: 'Aug', occupancy: 0 },
-        { month: 'Sep', occupancy: 0 },
-        { month: 'Oct', occupancy: 0 },
-        { month: 'Nov', occupancy: 0 },
-        { month: 'Dec', occupancy: 0 }
-      ];
+      occupancyTrend = ['Jul','Aug','Sep','Oct','Nov','Dec'].map(m => ({ month: m, occupancy: 0 }));
     }
 
     // CHART 2: Conversion Funnel
     let conversionFunnel: Array<{ stage: string; count: number }> = [];
-    
     try {
       const stages = [
         { label: 'New', status: 'NEW' },
@@ -100,80 +89,41 @@ export async function GET(request: NextRequest) {
         { label: 'Tour Scheduled', status: 'TOUR_SCHEDULED' },
         { label: 'Tour Completed', status: 'TOUR_COMPLETED' },
         { label: 'Qualified', status: 'QUALIFIED' },
-        { label: 'Converted', status: 'CONVERTED' }
+        { label: 'Converted', status: 'CONVERTED' },
       ];
-      
+
       for (const stage of stages) {
         const count = await prisma.inquiry.count({
-          where: {
-            status: stage.status as any
-          }
+          where: { ...inquiryScope, status: stage.status as any },
         });
-        
-        conversionFunnel.push({
-          stage: stage.label,
-          count
-        });
+        conversionFunnel.push({ stage: stage.label, count });
       }
-      
-      console.log('Conversion funnel:', conversionFunnel);
     } catch (error) {
       console.error('Error calculating conversion funnel:', error);
       conversionFunnel = [
-        { stage: 'New', count: 0 },
-        { stage: 'Contacted', count: 0 },
-        { stage: 'Tour Scheduled', count: 0 },
-        { stage: 'Tour Completed', count: 0 },
-        { stage: 'Qualified', count: 0 },
-        { stage: 'Converted', count: 0 }
+        { stage: 'New', count: 0 }, { stage: 'Contacted', count: 0 },
+        { stage: 'Tour Scheduled', count: 0 }, { stage: 'Tour Completed', count: 0 },
+        { stage: 'Qualified', count: 0 }, { stage: 'Converted', count: 0 },
       ];
     }
 
-    // CHART 3: Incident Distribution (by severity)
+    // CHART 3: Incident Distribution
     let incidentDistribution: Array<{ severity: string; count: number }> = [];
-    
     try {
-      const severities = ['Minor', 'Moderate', 'Severe', 'Critical'];
-      
-      for (const severity of severities) {
+      for (const severity of ['Minor', 'Moderate', 'Severe', 'Critical']) {
         const count = await prisma.residentIncident.count({
-          where: {
-            severity
-          }
+          where: { ...incidentScope, severity },
         });
-        
-        incidentDistribution.push({
-          severity,
-          count
-        });
+        incidentDistribution.push({ severity, count });
       }
-      
-      console.log('Incident distribution:', incidentDistribution);
     } catch (error) {
       console.error('Error calculating incident distribution:', error);
-      incidentDistribution = [
-        { severity: 'Minor', count: 0 },
-        { severity: 'Moderate', count: 0 },
-        { severity: 'Severe', count: 0 },
-        { severity: 'Critical', count: 0 }
-      ];
+      incidentDistribution = ['Minor','Moderate','Severe','Critical'].map(s => ({ severity: s, count: 0 }));
     }
 
-    // Return enhanced chart data
-    const charts = {
-      occupancyTrend,
-      conversionFunnel,
-      incidentDistribution,
-    };
-
-    console.log('Returning enhanced charts');
-    return NextResponse.json(charts);
-
+    return NextResponse.json({ occupancyTrend, conversionFunnel, incidentDistribution });
   } catch (error: any) {
-    console.error('=== Dashboard Charts Error ===');
-    console.error('Error:', error);
-    console.error('Message:', error.message);
-    console.error('Stack:', error.stack);
+    console.error('Dashboard charts error:', error);
     return NextResponse.json(
       { error: 'Failed to fetch charts', details: error.message },
       { status: 500 }

--- a/src/app/api/dashboard/metrics/route.ts
+++ b/src/app/api/dashboard/metrics/route.ts
@@ -9,95 +9,77 @@ export const revalidate = 0;
 
 /**
  * GET /api/dashboard/metrics
- * ENHANCED VERSION - Phase 1 Implementation
- * Returns calculated metrics with trends and real data
+ * Returns operator-scoped metrics. OPERATOR role: scoped to their homes.
+ * ADMIN role: platform-wide aggregates.
  */
 export async function GET(request: NextRequest) {
   try {
-    console.log('=== Dashboard Metrics API Called (Enhanced) ===');
-    
     const session = await getServerSession(authOptions);
     if (!session?.user?.email) {
-      console.log('No session found');
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    console.log('User email:', session.user.email);
-
-    // Get user WITHOUT any includes/relations
     const user = await prisma.user.findUnique({
       where: { email: session.user.email },
-      select: { 
-        id: true,
-        email: true,
-        role: true 
-      },
+      select: { id: true, role: true },
     });
 
     if (!user) {
-      console.log('User not found');
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    console.log('User role:', user.role);
+    // Resolve operator scope — null means ADMIN (no scope restriction).
+    let operatorId: string | null = null;
+    if (user.role === 'OPERATOR') {
+      const operator = await prisma.operator.findUnique({
+        where: { userId: user.id },
+        select: { id: true },
+      });
+      if (!operator) {
+        return NextResponse.json({ error: 'Operator record not found' }, { status: 404 });
+      }
+      operatorId = operator.id;
+    }
 
-    // METRIC 1: Total Residents with Occupancy
+    // Scoped WHERE fragments — empty objects for ADMIN, nested filters for OPERATOR.
+    const residentScope = operatorId ? { home: { operatorId } } : {};
+    const inquiryScope  = operatorId ? { home: { operatorId } } : {};
+    const incidentScope = operatorId ? { resident: { home: { operatorId } } } : {};
+    const assessScope   = operatorId ? { resident: { home: { operatorId } } } : {};
+    const homeScope     = operatorId ? { operatorId } : {};
+
+    // METRIC 1: Total Residents
     let totalResidents = 0;
     let occupancyPercentage = 0;
     let residentTrend: 'up' | 'down' | 'neutral' = 'neutral';
     let residentTrendValue = 0;
-    
+
     try {
       totalResidents = await prisma.resident.count({
-        where: {
-          status: {
-            in: ['ACTIVE', 'PENDING']
-          },
-          archivedAt: null
-        }
+        where: { ...residentScope, status: { in: ['ACTIVE', 'PENDING'] }, archivedAt: null },
       });
 
-      // Get total capacity from all active homes
       const homesData = await prisma.assistedLivingHome.aggregate({
-        _sum: {
-          capacity: true,
-          currentOccupancy: true
-        },
-        where: {
-          status: 'ACTIVE'
-        }
+        _sum: { capacity: true, currentOccupancy: true },
+        where: { ...homeScope, status: 'ACTIVE' },
       });
 
       const totalCapacity = homesData?._sum?.capacity ?? 0;
       const currentOccupancy = homesData?._sum?.currentOccupancy ?? totalResidents;
-      
       if (totalCapacity > 0) {
         occupancyPercentage = Math.round((currentOccupancy / totalCapacity) * 100);
       }
 
-      // Calculate trend: compare last 30 days vs previous 30 days
       const thirtyDaysAgo = new Date();
       thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
       const sixtyDaysAgo = new Date();
       sixtyDaysAgo.setDate(sixtyDaysAgo.getDate() - 60);
 
       const last30Days = await prisma.resident.count({
-        where: {
-          admissionDate: {
-            gte: thirtyDaysAgo
-          },
-          archivedAt: null
-        }
+        where: { ...residentScope, admissionDate: { gte: thirtyDaysAgo }, archivedAt: null },
       });
-
       const previous30Days = await prisma.resident.count({
-        where: {
-          admissionDate: {
-            gte: sixtyDaysAgo,
-            lt: thirtyDaysAgo
-          },
-          archivedAt: null
-        }
+        where: { ...residentScope, admissionDate: { gte: sixtyDaysAgo, lt: thirtyDaysAgo }, archivedAt: null },
       });
 
       if (previous30Days > 0) {
@@ -105,14 +87,11 @@ export async function GET(request: NextRequest) {
       } else if (last30Days > 0) {
         residentTrendValue = 100;
       }
-
       if (residentTrendValue > 0) residentTrend = 'up';
       else if (residentTrendValue < 0) residentTrend = 'down';
-
-      console.log('Residents:', { totalResidents, occupancyPercentage, residentTrend, residentTrendValue });
     } catch (error) {
       captureError(error instanceof Error ? error : new Error(String(error)), {
-        tags: { route: 'dashboard:metrics' },
+        tags: { route: 'dashboard:metrics', metric: 'residents' },
       });
       console.error('Error calculating residents/occupancy:', error);
     }
@@ -120,33 +99,26 @@ export async function GET(request: NextRequest) {
     // METRIC 2: Active Caregivers
     let activeCaregivers = 0;
     try {
-      activeCaregivers = await prisma.caregiver.count({
-        where: {
-          employmentStatus: 'ACTIVE'
-        }
-      });
-      console.log('Active caregivers:', activeCaregivers);
+      const caregiverScope = operatorId
+        ? { employmentStatus: 'ACTIVE', employments: { some: { operatorId } } }
+        : { employmentStatus: 'ACTIVE' };
+      activeCaregivers = await prisma.caregiver.count({ where: caregiverScope as any });
     } catch (error) {
       captureError(error instanceof Error ? error : new Error(String(error)), {
-        tags: { route: 'dashboard:metrics' },
+        tags: { route: 'dashboard:metrics', metric: 'caregivers' },
       });
       console.error('Error counting caregivers:', error);
     }
 
-    // METRIC 3: Pending Inquiries (active statuses only)
+    // METRIC 3: Pending Inquiries
     let pendingInquiries = 0;
     try {
       pendingInquiries = await prisma.inquiry.count({
-        where: {
-          status: {
-            in: ['NEW', 'CONTACTED', 'TOUR_SCHEDULED', 'QUALIFIED']
-          }
-        }
+        where: { ...inquiryScope, status: { in: ['NEW', 'CONTACTED', 'TOUR_SCHEDULED', 'QUALIFIED'] } },
       });
-      console.log('Pending inquiries:', pendingInquiries);
     } catch (error) {
       captureError(error instanceof Error ? error : new Error(String(error)), {
-        tags: { route: 'dashboard:metrics' },
+        tags: { route: 'dashboard:metrics', metric: 'inquiries' },
       });
       console.error('Error counting pending inquiries:', error);
     }
@@ -156,43 +128,27 @@ export async function GET(request: NextRequest) {
     try {
       const thirtyDaysAgo = new Date();
       thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
       criticalIncidents = await prisma.residentIncident.count({
-        where: {
-          severity: 'Critical',
-          occurredAt: {
-            gte: thirtyDaysAgo
-          }
-        }
+        where: { ...incidentScope, severity: 'Critical', occurredAt: { gte: thirtyDaysAgo } },
       });
-      console.log('Critical incidents (last 30 days):', criticalIncidents);
     } catch (error) {
       captureError(error instanceof Error ? error : new Error(String(error)), {
-        tags: { route: 'dashboard:metrics' },
+        tags: { route: 'dashboard:metrics', metric: 'incidents' },
       });
       console.error('Error counting critical incidents:', error);
     }
 
-    // METRIC 5: Overdue Assessments (pending review older than 7 days)
+    // METRIC 5: Overdue Assessments
     let overdueAssessments = 0;
     try {
       const sevenDaysAgo = new Date();
       sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-
       overdueAssessments = await prisma.assessmentResult.count({
-        where: {
-          status: {
-            in: ['PENDING_REVIEW', 'IN_PROGRESS']
-          },
-          createdAt: {
-            lt: sevenDaysAgo
-          }
-        }
+        where: { ...assessScope, status: { in: ['PENDING_REVIEW', 'IN_PROGRESS'] }, createdAt: { lt: sevenDaysAgo } },
       });
-      console.log('Overdue assessments:', overdueAssessments);
     } catch (error) {
       captureError(error instanceof Error ? error : new Error(String(error)), {
-        tags: { route: 'dashboard:metrics' },
+        tags: { route: 'dashboard:metrics', metric: 'assessments' },
       });
       console.error('Error counting overdue assessments:', error);
     }
@@ -202,30 +158,21 @@ export async function GET(request: NextRequest) {
     try {
       const now = new Date();
       const startOfWeek = new Date(now);
-      startOfWeek.setDate(now.getDate() - now.getDay()); // Sunday
+      startOfWeek.setDate(now.getDate() - now.getDay());
       startOfWeek.setHours(0, 0, 0, 0);
-      
       const endOfWeek = new Date(startOfWeek);
       endOfWeek.setDate(startOfWeek.getDate() + 7);
-
       toursThisWeek = await prisma.inquiry.count({
-        where: {
-          tourDate: {
-            gte: startOfWeek,
-            lt: endOfWeek
-          }
-        }
+        where: { ...inquiryScope, tourDate: { gte: startOfWeek, lt: endOfWeek } },
       });
-      console.log('Tours this week:', toursThisWeek);
     } catch (error) {
       captureError(error instanceof Error ? error : new Error(String(error)), {
-        tags: { route: 'dashboard:metrics' },
+        tags: { route: 'dashboard:metrics', metric: 'tours' },
       });
       console.error('Error counting tours this week:', error);
     }
 
-    // Return enhanced metrics structure
-    const metrics = {
+    return NextResponse.json({
       totalResidents: {
         value: totalResidents,
         subtitle: `${occupancyPercentage}% occupancy`,
@@ -262,19 +209,12 @@ export async function GET(request: NextRequest) {
         trend: 'neutral' as const,
         trendValue: 0,
       },
-    };
-
-    console.log('Returning enhanced metrics:', metrics);
-    return NextResponse.json(metrics);
-
+    });
   } catch (error: any) {
     captureError(error instanceof Error ? error : new Error(String(error)), {
       tags: { route: 'dashboard:metrics' },
     });
-    console.error('=== Dashboard Metrics Error ===');
-    console.error('Error:', error);
-    console.error('Message:', error.message);
-    console.error('Stack:', error.stack);
+    console.error('Dashboard metrics error:', error);
     return NextResponse.json(
       { error: 'Failed to fetch metrics', details: error.message },
       { status: 500 }

--- a/src/app/api/operator/billing/portal/route.ts
+++ b/src/app/api/operator/billing/portal/route.ts
@@ -35,7 +35,12 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const appUrl = process.env['NEXT_PUBLIC_APP_URL'] || 'https://getcarelinkai.com';
+  const forwardedProto = request.headers.get('x-forwarded-proto');
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  const requestOrigin = (forwardedProto && forwardedHost)
+    ? `${forwardedProto}://${forwardedHost}`
+    : request.headers.get('origin');
+  const appUrl = requestOrigin || process.env['NEXT_PUBLIC_APP_URL'] || 'https://getcarelinkai.com';
 
   const portalSession = await stripe.billingPortal.sessions.create({
     customer: operator.stripeCustomerId,

--- a/src/app/api/operator/billing/subscribe/route.ts
+++ b/src/app/api/operator/billing/subscribe/route.ts
@@ -66,7 +66,16 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  const appUrl = process.env['NEXT_PUBLIC_APP_URL'] || 'https://getcarelinkai.com';
+  // Derive the base URL from the incoming request so the success/cancel URLs always
+  // match the origin the user is actually browsing from. Falls back to the env var,
+  // then the canonical production URL. This prevents session loss when NEXT_PUBLIC_APP_URL
+  // differs from the actual host (e.g., Render internal URL vs custom domain).
+  const forwardedProto = request.headers.get('x-forwarded-proto');
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  const requestOrigin = (forwardedProto && forwardedHost)
+    ? `${forwardedProto}://${forwardedHost}`
+    : request.headers.get('origin');
+  const appUrl = requestOrigin || process.env['NEXT_PUBLIC_APP_URL'] || 'https://getcarelinkai.com';
 
   const checkoutSession = await stripe.checkout.sessions.create({
     customer: stripeCustomerId,

--- a/src/app/api/operator/dashboard/route.ts
+++ b/src/app/api/operator/dashboard/route.ts
@@ -38,6 +38,12 @@ export async function GET(request: NextRequest) {
       ? await prisma.operator.findUnique({ where: { userId: user.id } })
       : null;
 
+    // Guard: an OPERATOR without a profile record should not fall through to
+    // an empty filter (which would return platform-wide data).
+    if (user.role === UserRole.OPERATOR && !operator) {
+      return NextResponse.json({ error: 'Operator profile not found' }, { status: 404 });
+    }
+
     // Determine homeFilter based on user role and query params
     const homeFilter = operatorIdParam && user.role === UserRole.ADMIN
       ? { operatorId: operatorIdParam }

--- a/src/app/api/operator/inquiries/pipeline/route.ts
+++ b/src/app/api/operator/inquiries/pipeline/route.ts
@@ -47,10 +47,14 @@ export async function GET(request: NextRequest) {
     }
     // Admins see all inquiries (no where clause)
 
-    // Get conversion statistics
-    const stats = user.role === UserRole.OPERATOR && scope.homeIds.length > 0
-      ? await getConversionStats(scope.homeIds[0]) // Use first home for operator
-      : await getConversionStats(); // All stats for admin
+    // Get conversion statistics scoped to operator.
+    // scope.operatorId is the Operator record ID — getConversionStats filters by home.operatorId.
+    // For a brand-new operator with no homes, return empty stats rather than platform-wide data.
+    const stats = user.role === UserRole.OPERATOR
+      ? (scope.operatorId
+          ? await getConversionStats(scope.operatorId)
+          : { total: 0, converted: 0, conversionRate: 0, byStatus: {} })
+      : await getConversionStats(); // ADMIN: platform-wide
 
     // Get detailed pipeline data by status
     const pipeline = await prisma.inquiry.groupBy({

--- a/src/app/api/operator/leads/route.ts
+++ b/src/app/api/operator/leads/route.ts
@@ -73,12 +73,19 @@ export async function GET(request: NextRequest) {
       deletedAt: null // Only non-deleted leads
     };
 
+    // OPERATOR scope: restrict to leads assigned to this operator user.
+    // Without this, all operators can see all leads across all accounts.
+    const isAdmin = session!.user!.role === "ADMIN";
+    if (!isAdmin) {
+      where.assignedOperatorId = session!.user!.id;
+    }
+
     // Handle status filter (can be multiple statuses)
     if (statusParam) {
-      const statuses = statusParam.split(",").filter(s => 
+      const statuses = statusParam.split(",").filter(s =>
         Object.values(LeadStatus).includes(s as LeadStatus)
       ) as LeadStatus[];
-      
+
       if (statuses.length > 0) {
         where.status = statuses.length === 1 ? statuses[0] : { in: statuses };
       }
@@ -89,8 +96,8 @@ export async function GET(request: NextRequest) {
       where.targetType = targetType;
     }
 
-    // Handle assignedOperatorId filter
-    if (assignedOperatorId) {
+    // Handle assignedOperatorId filter (ADMIN only — OPERATOR scope is already locked above)
+    if (isAdmin && assignedOperatorId) {
       if (assignedOperatorId === "unassigned") {
         where.assignedOperatorId = null;
       } else if (assignedOperatorId === "me") {

--- a/src/app/operator/billing/page.tsx
+++ b/src/app/operator/billing/page.tsx
@@ -10,12 +10,13 @@ export const revalidate = 0;
 
 const prisma = new PrismaClient();
 
-export default async function OperatorBillingPage({ searchParams }: { searchParams?: { operatorId?: string } }) {
+export default async function OperatorBillingPage({ searchParams }: { searchParams?: { operatorId?: string; subscription?: string } }) {
   const session = await getServerSession(authOptions);
   const email = session?.user?.email ?? null;
   const user = email ? await prisma.user.findUnique({ where: { email } }) : null;
   const isAdmin = user?.role === UserRole.ADMIN;
   const operatorOverrideId = isAdmin ? (searchParams?.operatorId || null) : null;
+  const subscriptionParam = searchParams?.subscription;
   const op = user?.role === UserRole.OPERATOR ? await prisma.operator.findUnique({ where: { userId: user.id } }) : null;
   const effectiveOperatorId = operatorOverrideId || op?.id || null;
 
@@ -57,6 +58,18 @@ export default async function OperatorBillingPage({ searchParams }: { searchPara
         { label: 'Operator', href: '/operator' },
         { label: 'Billing' }
       ]} />
+
+      {subscriptionParam === 'success' && (
+        <div className="rounded-lg bg-success-50 border border-success-200 px-4 py-3 text-sm text-success-800 flex items-center gap-2">
+          <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+          Your subscription is active. Welcome aboard!
+        </div>
+      )}
+      {subscriptionParam === 'canceled' && (
+        <div className="rounded-lg bg-neutral-50 border border-neutral-200 px-4 py-3 text-sm text-neutral-700">
+          Checkout was canceled — no charge was made.
+        </div>
+      )}
 
       {/* Subscription management — only shown to operators, not admins viewing all operators */}
       {user?.role === UserRole.OPERATOR && !isAdmin && (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -150,6 +150,16 @@ export default function middleware(req: NextRequest) {
       }
     },
     {
+      // Explicitly wire the secret and cookie name to match auth.ts, so the Edge Runtime
+      // getToken call looks for the same cookie regardless of NEXTAUTH_URL configuration.
+      secret: process.env['NEXTAUTH_SECRET'],
+      cookies: {
+        sessionToken: {
+          name: (process.env.NODE_ENV === 'production' && process.env['ALLOW_INSECURE_AUTH_COOKIE'] !== '1')
+            ? '__Secure-next-auth.session-token'
+            : 'next-auth.session-token',
+        },
+      },
       callbacks: {
         authorized({ req, token }: { req: any; token: any }) {
           try {


### PR DESCRIPTION
## Summary

**This is the production-critical subset of `claude/review-carelink-docs-49Ycv`.** It contains only the three scoping/billing fixes needed to ship today. The BAA gate extension (CAREGIVER/DISCHARGE_PLANNER) and testing infrastructure remain on the feature branch for separate PRs.

### 1 — HIPAA scoping leak (2026-05-18 incident, live 12 days)

7 API routes were returning cross-tenant data with no operator-scoped WHERE clause.

**`/api/dashboard/metrics|charts|alerts|activity` (root cause of reported numbers):**
Any logged-in OPERATOR received platform-wide aggregates ("8 residents", "57 caregivers"). Fix: each route resolves the caller's `Operator` record and applies scoped filters on every Prisma query:
- Residents / Incidents / Assessments → `{ home: { operatorId } }`
- Inquiries → `{ home: { operatorId } }`
- Caregivers → `{ employments: { some: { operatorId } } }`
- ADMIN role retains platform-wide visibility.

**Follow-up audit (2026-05-31) — 3 more leaks:**
- `/api/operator/leads` — completely unscoped for OPERATOR role; returned all leads from all accounts. Fix: auto-apply `assignedOperatorId = session.user.id` for non-ADMIN callers.
- `/api/operator/inquiries/pipeline` — called `getConversionStats(scope.homeIds[0])` passing a `homeId` where `operatorId` is expected, and fell back to platform-wide stats when the operator had no homes. Fix: use `scope.operatorId`; return empty stats when absent.
- `/api/operator/dashboard` (legacy route) — null-operator path built `homeFilter = {}` which leaked all data. Fix: return 404 if OPERATOR role has no associated operator record.

Regression spec: `e2e/operator-dashboard-scoping.spec.ts` (`@critical`) — seeds 2 operators, asserts isolation on metrics, charts funnel, leads, and pipeline.

### 2 — Stripe post-checkout session loss

Operators were redirected to `/auth/login?callbackUrl=...` after successful Stripe checkout instead of the billing success page.

- **`src/middleware.ts`**: `withAuth`'s internal `getToken` auto-detected the session cookie name from `NEXTAUTH_URL`, while `auth.ts` uses `NODE_ENV==='production'`. These diverge when `NEXTAUTH_URL` is unset or wrong on Render. Fix: explicitly pass `secret` + `cookieName` to `withAuth` to match `auth.ts` exactly.
- **`billing/subscribe` + `billing/portal`**: `success_url` / `cancel_url` / `return_url` were built from `NEXT_PUBLIC_APP_URL`, which may differ from the origin the user is browsing (e.g. `onrender.com` vs custom domain). Fix: derive base URL from `x-forwarded-proto` + `x-forwarded-host` headers, fall back to env var.
- **`billing/page.tsx`**: Render success/canceled banner when returning from Stripe (`?subscription=success|canceled`).

### 3 — `.env.example` corrections

- `STRIPE_PUBLISHABLE_KEY` → `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (5 source files read the `NEXT_PUBLIC_` form; old name was silently dead)
- Added 6 missing `STRIPE_PRICE_*` vars

## What's NOT in this PR

- BAA/DPA gate extension to CAREGIVER / DISCHARGE_PLANNER / PROVIDER roles
- 9-spec e2e testing infrastructure suite
- ChrisOS Vault / context file updates
- OL-037 Rides feature

All of the above remain on `claude/review-carelink-docs-49Ycv` for separate PRs.

## Test plan

- [ ] Deploy to staging; log in as a brand-new OPERATOR with no data — all dashboard cards should show 0
- [ ] Log in as two different operators in separate browser sessions — verify each sees only their own counts
- [ ] Trigger a Stripe test-mode checkout and confirm redirect lands on `/operator/billing?subscription=success` without hitting the login page
- [ ] Confirm `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` is set in Render env (was silently broken under old name)
- [ ] Run `e2e/operator-dashboard-scoping.spec.ts` against staging: `npx playwright test e2e/operator-dashboard-scoping.spec.ts`

## Action required (Render dashboard)

Update `NEXT_PUBLIC_APP_URL` → `https://getcarelinkai.com` (exact HTTPS, no trailing slash). This is the highest-confidence single fix for the Stripe session loss.

https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ)_