### PR TITLE
feat(auth): role-aware signup with type-specific forms

### DIFF
--- a/e2e/auth-register-flow.spec.ts
+++ b/e2e/auth-register-flow.spec.ts
@@ -1,0 +1,217 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from './_helpers';
+
+// E2E suite for the role-aware 3-step signup flow at /auth/register.
+//
+// Step 1 — Email + Password
+// Step 2 — Account type selector (role tiles)
+// Step 3 — Type-specific form (FAMILY gets full form; others get minimal form)
+//
+// ?role=ROLE deep-link: Step 1 → Next skips Step 2 entirely (auto-advance).
+// ?claimToken=<tok> deep-link: token redeemed after signup for operator founder flow.
+
+const PASSWORD = 'Test@12345';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+async function fillStep1(page: any, email: string) {
+  await page.fill('#email', email);
+  await page.fill('#password', PASSWORD);
+  await page.fill('#confirmPassword', PASSWORD);
+  await page.getByRole('button', { name: /next/i }).click();
+}
+
+// ── Family path ───────────────────────────────────────────────────────────────
+
+test.describe('@critical Register — Family path', () => {
+  test('full flow: email/pw → pick Family → fill care-recipient fields → land on family onboarding', async ({
+    page,
+  }) => {
+    const email = `reg-family-${Date.now()}@test.carelinkai.com`;
+
+    await page.goto('/auth/register', { waitUntil: 'domcontentloaded' });
+
+    // Step 1 — credentials
+    await expect(page.getByText(/login credentials/i)).toBeVisible({ timeout: 8000 });
+    await fillStep1(page, email);
+
+    // Step 2 — role selector
+    await expect(page.getByText(/select how you'll be using/i)).toBeVisible({ timeout: 8000 });
+    const familyTile = page.getByRole('radio', { name: /family member/i });
+    await familyTile.check();
+    await expect(familyTile).toBeChecked();
+    await page.getByRole('button', { name: /next/i }).click();
+
+    // Step 3 — FAMILY-specific fields visible
+    await expect(page.getByText(/tell us about yourself/i)).toBeVisible({ timeout: 8000 });
+    await expect(page.getByText(/who are you looking for care for/i)).toBeVisible();
+    await expect(page.getByPlaceholder(/care needs/i).or(page.getByText(/care needs or preferences/i))).toBeVisible();
+
+    // Fill profile
+    await page.fill('#firstName', 'Jane');
+    await page.fill('#lastName', 'Smith');
+    await page.getByRole('checkbox', { name: /terms/i }).check();
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    // Should redirect to family onboarding (after success splash)
+    await page.waitForURL(/\/settings\/family|\/auth\/login/, { timeout: 20000 });
+  });
+});
+
+// ── Operator path — no role param ─────────────────────────────────────────────
+
+test.describe('@critical Register — Operator path (manual role select)', () => {
+  test('email/pw → manually pick Operator on Step 2 → minimal Step 3 → land on /operator/onboarding/1', async ({
+    page,
+  }) => {
+    const email = `reg-op-${Date.now()}@test.carelinkai.com`;
+
+    await page.goto('/auth/register', { waitUntil: 'domcontentloaded' });
+
+    // Step 1
+    await expect(page.getByText(/login credentials/i)).toBeVisible({ timeout: 8000 });
+    await fillStep1(page, email);
+
+    // Step 2 — explicitly pick Operator
+    await expect(page.getByText(/select how you'll be using/i)).toBeVisible({ timeout: 8000 });
+    await page.getByRole('radio', { name: /care home operator/i }).check();
+    await page.getByRole('button', { name: /next/i }).click();
+
+    // Step 3 — family-only fields NOT visible
+    await expect(page.getByText(/tell us about yourself/i)).toBeVisible({ timeout: 8000 });
+    await expect(page.getByText(/who are you looking for care for/i)).not.toBeVisible();
+
+    // Fill minimal profile
+    await page.fill('#firstName', 'Alice');
+    await page.fill('#lastName', 'Operator');
+    await page.getByRole('checkbox', { name: /terms/i }).check();
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    // Should land on operator onboarding wizard
+    await page.waitForURL(/\/operator\/onboarding\/1|\/auth\/login/, { timeout: 20000 });
+  });
+});
+
+// ── Operator path — ?role=OPERATOR deep-link ──────────────────────────────────
+
+test.describe('@critical Register — Operator path (?role=OPERATOR deep-link)', () => {
+  test('?role=OPERATOR: Step 1 Next auto-advances to Step 3, skipping Step 2', async ({
+    page,
+  }) => {
+    const email = `reg-op-link-${Date.now()}@test.carelinkai.com`;
+
+    await page.goto('/auth/register?role=OPERATOR', { waitUntil: 'domcontentloaded' });
+
+    // Step 1
+    await expect(page.getByText(/login credentials/i)).toBeVisible({ timeout: 8000 });
+    await fillStep1(page, email);
+
+    // Should jump directly to Step 3 — "Select how you'll be using" (Step 2) should be skipped
+    await expect(page.getByText(/tell us about yourself/i)).toBeVisible({ timeout: 8000 });
+    await expect(page.getByText(/select how you'll be using/i)).not.toBeVisible();
+
+    // Family-only fields must NOT appear
+    await expect(page.getByText(/who are you looking for care for/i)).not.toBeVisible();
+
+    // Fill profile and submit
+    await page.fill('#firstName', 'Bob');
+    await page.fill('#lastName', 'DeepLink');
+    await page.getByRole('checkbox', { name: /terms/i }).check();
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    await page.waitForURL(/\/operator\/onboarding\/1|\/auth\/login/, { timeout: 20000 });
+  });
+
+  test('Back from Step 3 lands on Step 2 with Operator tile highlighted', async ({
+    page,
+  }) => {
+    await page.goto('/auth/register?role=OPERATOR', { waitUntil: 'domcontentloaded' });
+
+    // Step 1 → auto-advance to Step 3
+    await fillStep1(page, `reg-back-${Date.now()}@test.carelinkai.com`);
+    await expect(page.getByText(/tell us about yourself/i)).toBeVisible({ timeout: 8000 });
+
+    // Hit Back
+    await page.getByRole('button', { name: /back/i }).click();
+
+    // Should land on Step 2 with Operator pre-selected
+    await expect(page.getByText(/select how you'll be using/i)).toBeVisible({ timeout: 8000 });
+    const operatorRadio = page.getByRole('radio', { name: /care home operator/i });
+    await expect(operatorRadio).toBeChecked();
+  });
+});
+
+// ── Operator path — ?claimToken (Cleveland founder deep-link) ─────────────────
+
+test.describe('@critical Register — Cleveland founder claim-token flow', () => {
+  test('?claimToken redeemed after signup → clevelandFounder=true on operator record', async ({
+    page,
+    request,
+  }) => {
+    const opEmail = `reg-founder-${Date.now()}@test.carelinkai.com`;
+
+    // Seed a home so admin can generate a claim link against it
+    await request.post('/api/dev/upsert-admin', {
+      data: { email: 'admin@carelinkai.com' },
+    });
+
+    // We need a homeId — seed a dummy operator record to get one
+    const seedRes = await request.post('/api/dev/upsert-operator', {
+      data: {
+        email: `seed-home-${Date.now()}@test.carelinkai.com`,
+        companyName: 'Seed Co',
+        homes: [{ name: 'Seed Home', capacity: 5 }],
+      },
+    });
+    expect(seedRes.ok()).toBeTruthy();
+    const seedData = await seedRes.json();
+    const homeId = seedData.homes?.[0]?.id ?? seedData.homeId;
+    expect(homeId).toBeTruthy();
+
+    // Admin generates claim link for the new operator's email
+    await loginAs(page, 'admin@carelinkai.com');
+    const claimRes = await page.evaluate(
+      async ({ hid, email }: { hid: string; email: string }) => {
+        const r = await fetch(`/api/admin/homes/${hid}/claim-link`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ operatorEmail: email, clevelandFounder: true }),
+        });
+        return { status: r.status, body: await r.json() };
+      },
+      { hid: homeId, email: opEmail }
+    );
+    expect(claimRes.status).toBe(200);
+    const { token } = claimRes.body;
+    expect(token).toBeTruthy();
+
+    // New operator registers via the claim-token deep-link
+    const registerUrl = `/auth/register?role=OPERATOR&claimToken=${encodeURIComponent(token)}`;
+    await page.goto(registerUrl, { waitUntil: 'domcontentloaded' });
+
+    // Step 1 → auto-advance to Step 3
+    await fillStep1(page, opEmail);
+    await expect(page.getByText(/tell us about yourself/i)).toBeVisible({ timeout: 8000 });
+
+    await page.fill('#firstName', 'Chris');
+    await page.fill('#lastName', 'Founder');
+    await page.getByRole('checkbox', { name: /terms/i }).check();
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    // Wait for redirect to onboarding wizard
+    await page.waitForURL(/\/operator\/onboarding\/1|\/auth\/login/, { timeout: 20000 });
+
+    // After redirect, verify the claim was applied (founder flag set)
+    // Use a short delay to let the claim redemption API call complete
+    await page.waitForTimeout(3000);
+    const statusRes = await page.evaluate(async () => {
+      const r = await fetch('/api/operator/onboarding/status', {
+        credentials: 'include',
+      });
+      return r.json();
+    });
+    expect(statusRes.clevelandFounder).toBe(true);
+    expect(statusRes.freeAccessUntil).toBeTruthy();
+  });
+});

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -43,7 +43,7 @@ const registrationSchema = z.object({
     (val) => !val || /^(\+1\s?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/.test(val),
     { message: "Please enter a valid US phone number" }
   ),
-  role: z.enum(["FAMILY", "OPERATOR", "CAREGIVER", "AFFILIATE", "PROVIDER"]),
+  role: z.enum(["FAMILY", "OPERATOR", "CAREGIVER", "AFFILIATE", "PROVIDER", "DISCHARGE_PLANNER"]),
   agreeToTerms: z.boolean().refine(val => val === true, {
     message: "You must agree to the terms and conditions"
   }),
@@ -355,7 +355,19 @@ export async function POST(request: NextRequest) {
           });
           console.log("[REGISTER API] Provider profile created successfully");
           break;
-          
+
+        case "DISCHARGE_PLANNER":
+          console.log("[REGISTER API] Creating DISCHARGE_PLANNER profile...");
+          await tx.dischargePlannerProfile.create({
+            data: {
+              userId: user.id,
+              organization: null,
+              title: null,
+            }
+          });
+          console.log("[REGISTER API] DischargePlannerProfile created successfully");
+          break;
+
         default:
           console.log("[REGISTER API] ERROR: Invalid role:", role);
           throw new Error("Invalid role selected");

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -5,20 +5,17 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useRouter, useSearchParams } from "next/navigation";
-import Image from "next/image";
 import Link from "next/link";
 import axios from "axios";
 import { signIn } from "next-auth/react";
-import { motion, AnimatePresence } from "framer-motion";
 import { prefersReducedMotion } from "@/lib/animations";
 
-// Icons
-import { 
-  FiMail, 
-  FiLock, 
-  FiUser, 
-  FiPhone, 
-  FiAlertCircle, 
+import {
+  FiMail,
+  FiLock,
+  FiUser,
+  FiPhone,
+  FiAlertCircle,
   FiArrowRight,
   FiUsers,
   FiHome,
@@ -30,11 +27,16 @@ import {
   FiMessageSquare,
   FiCheck,
   FiX,
-  FiLoader
+  FiLoader,
 } from "react-icons/fi";
 
-// Types from schema
-type UserRole = "FAMILY" | "OPERATOR" | "CAREGIVER" | "AFFILIATE" | "PROVIDER" | "DISCHARGE_PLANNER";
+type UserRole =
+  | "FAMILY"
+  | "OPERATOR"
+  | "CAREGIVER"
+  | "AFFILIATE"
+  | "PROVIDER"
+  | "DISCHARGE_PLANNER";
 type RelationshipType = "SELF" | "PARENT" | "SPOUSE" | "SIBLING" | "OTHER";
 type ContactMethod = "EMAIL" | "PHONE" | "BOTH";
 
@@ -47,38 +49,38 @@ type FormData = {
   phone?: string;
   role: UserRole;
   agreeToTerms: boolean;
-  // New fields
   relationshipToRecipient?: RelationshipType;
   carePreferences?: string;
   preferredContactMethod?: ContactMethod;
 };
 
-// Password strength calculator
-const calculatePasswordStrength = (password: string): { score: number; label: string; color: string } => {
+const VALID_ROLES: UserRole[] = [
+  "FAMILY",
+  "OPERATOR",
+  "CAREGIVER",
+  "AFFILIATE",
+  "PROVIDER",
+  "DISCHARGE_PLANNER",
+];
+
+const calculatePasswordStrength = (
+  password: string
+): { score: number; label: string; color: string } => {
   if (!password) return { score: 0, label: "", color: "bg-neutral-200" };
-  
   let score = 0;
-  
-  // Length checks
   if (password.length >= 8) score += 1;
   if (password.length >= 12) score += 1;
-  
-  // Character type checks
   if (/[a-z]/.test(password)) score += 1;
   if (/[A-Z]/.test(password)) score += 1;
   if (/[0-9]/.test(password)) score += 1;
   if (/[@$!%*?&]/.test(password)) score += 1;
-  
-  // Calculate percentage and label
   const percentage = Math.min((score / 6) * 100, 100);
-  
   if (percentage <= 25) return { score: percentage, label: "Weak", color: "bg-error-500" };
   if (percentage <= 50) return { score: percentage, label: "Fair", color: "bg-warning-500" };
   if (percentage <= 75) return { score: percentage, label: "Good", color: "bg-warning-300" };
   return { score: percentage, label: "Strong", color: "bg-success-500" };
 };
 
-// Password requirement checker
 const checkPasswordRequirements = (password: string) => ({
   minLength: (password?.length ?? 0) >= 8,
   hasUppercase: /[A-Z]/.test(password ?? ""),
@@ -87,7 +89,6 @@ const checkPasswordRequirements = (password: string) => ({
   hasSpecial: /[@$!%*?&]/.test(password ?? ""),
 });
 
-// Relationship options
 const relationshipOptions: { value: RelationshipType; label: string }[] = [
   { value: "SELF", label: "For myself" },
   { value: "PARENT", label: "For my parent" },
@@ -96,64 +97,64 @@ const relationshipOptions: { value: RelationshipType; label: string }[] = [
   { value: "OTHER", label: "For someone else" },
 ];
 
-// Contact method options
-const contactMethodOptions: { value: ContactMethod; label: string; icon: React.ReactNode }[] = [
+const contactMethodOptions: {
+  value: ContactMethod;
+  label: string;
+  icon: React.ReactNode;
+}[] = [
   { value: "EMAIL", label: "Email", icon: <FiMail className="h-4 w-4" /> },
   { value: "PHONE", label: "Phone", icon: <FiPhone className="h-4 w-4" /> },
-  { value: "BOTH", label: "Both", icon: <FiMessageSquare className="h-4 w-4" /> },
+  {
+    value: "BOTH",
+    label: "Both",
+    icon: <FiMessageSquare className="h-4 w-4" />,
+  },
 ];
 
-// Role options with descriptions and icons
 const roleOptions = [
-  { 
-    id: "FAMILY", 
-    label: "Family Member", 
+  {
+    id: "FAMILY" as UserRole,
+    label: "Family Member",
     description: "I'm looking for care for a loved one",
-    icon: <FiHeart className="h-5 w-5" />
+    icon: <FiHeart className="h-5 w-5" />,
   },
-  { 
-    id: "OPERATOR", 
-    label: "Care Home Operator", 
+  {
+    id: "OPERATOR" as UserRole,
+    label: "Care Home Operator",
     description: "I operate an assisted living or memory care facility",
-    icon: <FiHome className="h-5 w-5" />
+    icon: <FiHome className="h-5 w-5" />,
   },
-  { 
-    id: "DISCHARGE_PLANNER", 
-    label: "Healthcare Professional", 
-    description: "I work at a hospital, rehab center, or healthcare facility",
-    icon: <FiActivity className="h-5 w-5" />
+  {
+    id: "DISCHARGE_PLANNER" as UserRole,
+    label: "Healthcare Professional",
+    description:
+      "I work at a hospital, rehab center, or healthcare facility",
+    icon: <FiActivity className="h-5 w-5" />,
   },
-  { 
-    id: "CAREGIVER", 
-    label: "Caregiver", 
+  {
+    id: "CAREGIVER" as UserRole,
+    label: "Caregiver",
     description: "I provide care services to residents",
-    icon: <FiActivity className="h-5 w-5" />
+    icon: <FiActivity className="h-5 w-5" />,
   },
-  { 
-    id: "PROVIDER", 
-    label: "Service Provider", 
-    description: "I provide professional services (transportation, home care, etc.)",
-    icon: <FiActivity className="h-5 w-5" />
+  {
+    id: "PROVIDER" as UserRole,
+    label: "Service Provider",
+    description:
+      "I provide professional services (transportation, home care, etc.)",
+    icon: <FiActivity className="h-5 w-5" />,
   },
-  { 
-    id: "AFFILIATE", 
-    label: "Affiliate Partner", 
+  {
+    id: "AFFILIATE" as UserRole,
+    label: "Affiliate Partner",
     description: "I refer clients to care homes",
-    icon: <FiUsers className="h-5 w-5" />
-  }
+    icon: <FiUsers className="h-5 w-5" />,
+  },
 ];
 
 export default function RegisterPage() {
-  /* --------------------------------------------------------------------
-   * Prevent React-hydration mismatches:
-   * 1.  Render a minimalist "shell" during SSR (or immediately after an
-   *     export build) that matches what the client will first hydrate.
-   * 2.  Once we are certain we're running in the browser (`mounted === true`)
-   *     render the full interactive form.
-   * ------------------------------------------------------------------ */
   const [mounted, setMounted] = useState(false);
 
-  /* We only mark the component as mounted after the first client render. */
   React.useEffect(() => {
     setMounted(true);
     setReducedMotion(prefersReducedMotion());
@@ -162,23 +163,20 @@ export default function RegisterPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // Pre-select role from ?role= query param (e.g. links from operator sign-up page)
-  useEffect(() => {
-    const roleParam = searchParams?.get('role')?.toUpperCase() as UserRole | undefined;
-    const validRoles: UserRole[] = ['FAMILY', 'OPERATOR', 'CAREGIVER', 'AFFILIATE', 'PROVIDER', 'DISCHARGE_PLANNER'];
-    if (roleParam && validRoles.includes(roleParam)) {
-      setValue('role', roleParam);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // Derive role and claim token from URL at render time
+  const rawRoleParam = searchParams
+    ?.get("role")
+    ?.toUpperCase() as UserRole | undefined;
+  const roleFromUrl =
+    rawRoleParam && VALID_ROLES.includes(rawRoleParam) ? rawRoleParam : null;
+  const claimTokenFromUrl = searchParams?.get("claimToken") ?? null;
 
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [step, setStep] = useState(1);
   const [reducedMotion, setReducedMotion] = useState(false);
-  
-  // Password visibility toggles
+
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
@@ -194,101 +192,98 @@ export default function RegisterPage() {
   } = useForm<FormData>({
     mode: "onChange",
     defaultValues: {
-      role: "FAMILY",
+      role: roleFromUrl ?? "FAMILY",
       agreeToTerms: false,
-      preferredContactMethod: "EMAIL"
-    }
+      preferredContactMethod: "EMAIL",
+    },
   });
-  
-  // Watch confirmPassword for mismatch validation
-  const confirmPassword = watch("confirmPassword");
 
-  // Watch form fields
+  // Sync URL role into form once mounted
+  useEffect(() => {
+    if (roleFromUrl) {
+      setValue("role", roleFromUrl);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const confirmPassword = watch("confirmPassword");
   const password = watch("password");
   const currentRole = watch("role");
   const watchedPhone = watch("phone");
   const selectedContactMethod = watch("preferredContactMethod");
-  
-  // Calculate password strength
-  const passwordStrength = useMemo(() => calculatePasswordStrength(password ?? ""), [password]);
-  const passwordRequirements = useMemo(() => checkPasswordRequirements(password ?? ""), [password]);
-  
-  // BUG-002 FIX: Re-validate confirmPassword when password changes
+
+  const passwordStrength = useMemo(
+    () => calculatePasswordStrength(password ?? ""),
+    [password]
+  );
+  const passwordRequirements = useMemo(
+    () => checkPasswordRequirements(password ?? ""),
+    [password]
+  );
+
+  // Re-validate confirmPassword when password changes
   React.useEffect(() => {
-    // Only validate if confirmPassword has a value (user has entered something)
     if (confirmPassword) {
       if (password !== confirmPassword) {
-        setError("confirmPassword", { 
-          type: "manual", 
-          message: "Passwords do not match" 
+        setError("confirmPassword", {
+          type: "manual",
+          message: "Passwords do not match",
         });
       } else {
         clearErrors("confirmPassword");
       }
     }
   }, [password, confirmPassword, setError, clearErrors]);
-  
-  // BUG-001 FIX: Trigger validation when entering step 2 to handle browser autofilled fields
-  // This ensures pre-filled firstName/lastName fields are validated properly
+
+  // Trigger autofill validation when entering step 3 (name fields)
   React.useEffect(() => {
-    if (step === 2) {
-      // Small delay to allow browser autofill to complete
+    if (step === 3) {
       const timer = setTimeout(() => {
-        // Get current values and manually trigger validation if fields have values
         const firstName = watch("firstName");
         const lastName = watch("lastName");
-        
-        // If fields have values (either typed or autofilled), trigger validation
         if (firstName || lastName) {
           trigger(["firstName", "lastName"]);
         }
       }, 100);
-      
       return () => clearTimeout(timer);
     }
     return undefined;
   }, [step, trigger, watch]);
-  
-  // Format phone number as user types
+
   const formatPhoneNumber = (value: string) => {
     const cleaned = value.replace(/\D/g, "");
     if (cleaned.length <= 3) return cleaned;
-    if (cleaned.length <= 6) return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3)}`;
+    if (cleaned.length <= 6)
+      return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3)}`;
     return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3, 6)}-${cleaned.slice(6, 10)}`;
   };
-  
+
   const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const formatted = formatPhoneNumber(e.target.value);
     setValue("phone", formatted, { shouldValidate: true });
   };
 
-  // Handle form submission
   const onSubmit = async (data: FormData) => {
     try {
       setIsLoading(true);
       setApiError(null);
 
-      // Remove confirmPassword before sending to API
-      const { confirmPassword, ...registrationData } = data;
-      
-      // Clean up the data - only send relationship/care fields for FAMILY role
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { confirmPassword: _cp, ...registrationData } = data;
+
       const cleanedData = {
         ...registrationData,
-        relationshipToRecipient: data.role === "FAMILY" ? data.relationshipToRecipient : undefined,
-        carePreferences: data.role === "FAMILY" ? data.carePreferences : undefined,
+        relationshipToRecipient:
+          data.role === "FAMILY" ? data.relationshipToRecipient : undefined,
+        carePreferences:
+          data.role === "FAMILY" ? data.carePreferences : undefined,
       };
 
-      // Call registration API
-      const response = await axios.post("/api/auth/register", cleanedData);
-
-      // Show success message briefly
+      await axios.post("/api/auth/register", cleanedData);
       setSuccess(true);
 
-      // Auto-login and redirect based on role
-      // Wait a moment to show success message
       setTimeout(async () => {
         try {
-          // Attempt to sign in the user automatically
           const signInResult = await signIn("credentials", {
             email: data.email,
             password: data.password,
@@ -296,90 +291,100 @@ export default function RegisterPage() {
           });
 
           if (signInResult?.ok) {
-            // Redirect based on role
-            if (data.role === "FAMILY") {
-              // Family users go to onboarding
+            // Redeem claim token if present (operator deep-link flow)
+            if (claimTokenFromUrl && data.role === "OPERATOR") {
+              try {
+                await fetch("/api/operator/claim", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ token: claimTokenFromUrl }),
+                });
+              } catch {
+                // Non-fatal — continue to onboarding even if redemption fails
+              }
+            }
+
+            // Role-specific redirect
+            if (data.role === "OPERATOR") {
+              router.push("/operator/onboarding/1");
+            } else if (data.role === "FAMILY") {
               router.push("/settings/family?onboarding=true");
             } else if (data.role === "DISCHARGE_PLANNER") {
-              // Discharge planners go to discharge planner portal
               router.push("/discharge-planner");
             } else {
-              // Other users go to dashboard
               router.push("/dashboard");
             }
           } else {
-            // If auto-login fails, redirect to login page
             router.push("/auth/login?registered=true");
           }
         } catch (signInError) {
           console.error("Auto sign-in error:", signInError);
-          // Fall back to manual login
           router.push("/auth/login?registered=true");
         }
       }, 2000);
     } catch (err: any) {
       console.error("Registration error:", err);
       setApiError(
-        err.response?.data?.message || 
-        "Registration failed. Please try again."
+        err.response?.data?.message || "Registration failed. Please try again."
       );
     } finally {
       setIsLoading(false);
     }
   };
 
-  // Handle next step in multi-step form
   const handleNextStep = async () => {
-    // Validate current step fields
-    let fieldsToValidate: (keyof FormData)[] = [];
-    
     if (step === 1) {
-      fieldsToValidate = ["email", "password", "confirmPassword"];
-      
-      // BUG-002 FIX: Explicit password mismatch check before proceeding
-      const currentPassword = watch("password");
-      const currentConfirmPassword = watch("confirmPassword");
-      
-      if (currentPassword !== currentConfirmPassword) {
-        setError("confirmPassword", { 
-          type: "manual", 
-          message: "Passwords do not match" 
+      const fieldsToValidate: (keyof FormData)[] = [
+        "email",
+        "password",
+        "confirmPassword",
+      ];
+
+      const pw = watch("password");
+      const cpw = watch("confirmPassword");
+      if (pw !== cpw) {
+        setError("confirmPassword", {
+          type: "manual",
+          message: "Passwords do not match",
         });
-        return; // Block progression
+        return;
+      }
+
+      const isStepValid = await trigger(fieldsToValidate);
+      const hasStepErrors =
+        Object.keys(errors).filter((k) =>
+          fieldsToValidate.includes(k as keyof FormData)
+        ).length > 0;
+
+      if (isStepValid && !hasStepErrors) {
+        // Skip step 2 if role was pre-selected via ?role= URL param
+        setStep(roleFromUrl ? 3 : 2);
       }
     } else if (step === 2) {
-      fieldsToValidate = ["firstName", "lastName", "phone"];
-    }
-    
-    const isStepValid = await trigger(fieldsToValidate);
-    
-    // BUG-002 FIX: Also check for any existing errors
-    if (isStepValid && Object.keys(errors).filter(key => fieldsToValidate.includes(key as keyof FormData)).length === 0) {
-      setStep(step + 1);
+      // Role is already selected; no fields to validate
+      setStep(3);
     }
   };
 
-  // Handle previous step
   const handlePrevStep = () => {
     setStep(step - 1);
   };
 
-  // If not mounted yet (SSR), render a simple shell
   if (!mounted) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-neutral-50">
         <div className="p-8 bg-white rounded-lg shadow-md w-full max-w-md">
           <div className="text-center mb-6">
-            <h1 className="text-2xl font-bold text-neutral-800">Create an Account</h1>
+            <h1 className="text-2xl font-bold text-neutral-800">
+              Create an Account
+            </h1>
           </div>
         </div>
       </div>
     );
   }
 
-  // Success state after registration
   if (success) {
-    const isFamilyRole = currentRole === "FAMILY";
     return (
       <div className="min-h-screen flex items-center justify-center bg-neutral-50">
         <div className="p-8 bg-white rounded-lg shadow-md w-full max-w-md">
@@ -389,12 +394,13 @@ export default function RegisterPage() {
                 <FiCheckCircle className="h-8 w-8 text-success-600" />
               </div>
             </div>
-            <h1 className="text-2xl font-bold text-neutral-800">Registration Successful!</h1>
+            <h1 className="text-2xl font-bold text-neutral-800">
+              Registration Successful!
+            </h1>
             <p className="mt-2 text-neutral-600">
-              {isFamilyRole 
+              {currentRole === "FAMILY"
                 ? "Welcome! Let's set up your care profile..."
-                : "Your account has been created. Redirecting you..."
-              }
+                : "Your account has been created. Redirecting you..."}
             </p>
           </div>
         </div>
@@ -405,20 +411,25 @@ export default function RegisterPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-neutral-50 py-8">
       <div className="p-8 bg-white rounded-lg shadow-md w-full max-w-md">
+        {/* Header */}
         <div className="text-center mb-6">
           <Link href="/" className="inline-block">
             <div className="flex items-center justify-center mb-6">
               <div className="h-10 w-10 rounded-md bg-primary-500 flex items-center justify-center mr-2">
                 <span className="text-white font-bold text-xl">C</span>
               </div>
-              <span className="text-xl font-semibold text-neutral-800">CareLinkAI</span>
+              <span className="text-xl font-semibold text-neutral-800">
+                CareLinkAI
+              </span>
             </div>
           </Link>
-          <h1 className="text-2xl font-bold text-neutral-800">Create an Account</h1>
+          <h1 className="text-2xl font-bold text-neutral-800">
+            Create an Account
+          </h1>
           <p className="mt-2 text-neutral-600">
             {step === 1 && "Start by setting up your login credentials"}
-            {step === 2 && "Tell us a bit about yourself"}
-            {step === 3 && "Select how you'll be using CareLinkAI"}
+            {step === 2 && "Select how you'll be using CareLinkAI"}
+            {step === 3 && "Tell us about yourself"}
           </p>
         </div>
 
@@ -430,12 +441,14 @@ export default function RegisterPage() {
         )}
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-          {/* Step 1: Email and Password */}
+          {/* ── Step 1: Email + Password ─────────────────────────────── */}
           {step === 1 && (
             <>
-              {/* Email Field */}
               <div>
-                <label htmlFor="email" className="block text-sm font-medium text-neutral-700 mb-1">
+                <label
+                  htmlFor="email"
+                  className="block text-sm font-medium text-neutral-700 mb-1"
+                >
                   Email Address
                 </label>
                 <div className="relative">
@@ -448,14 +461,17 @@ export default function RegisterPage() {
                     autoComplete="email"
                     autoFocus
                     className={`form-input block w-full pl-10 py-2 rounded-md shadow-sm ${
-                      errors.email ? "border-error-300 focus:ring-error-500 focus:border-error-500" : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
+                      errors.email
+                        ? "border-error-300 focus:ring-error-500 focus:border-error-500"
+                        : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
                     }`}
                     placeholder="you@example.com"
                     {...register("email", {
                       required: "Email is required",
                       pattern: {
                         value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-                        message: "Please enter a valid email address (e.g., name@example.com)",
+                        message:
+                          "Please enter a valid email address (e.g., name@example.com)",
                       },
                     })}
                   />
@@ -468,9 +484,11 @@ export default function RegisterPage() {
                 )}
               </div>
 
-              {/* Password Field */}
               <div>
-                <label htmlFor="password" className="block text-sm font-medium text-neutral-700 mb-1">
+                <label
+                  htmlFor="password"
+                  className="block text-sm font-medium text-neutral-700 mb-1"
+                >
                   Password
                 </label>
                 <div className="relative">
@@ -482,7 +500,9 @@ export default function RegisterPage() {
                     type={showPassword ? "text" : "password"}
                     autoComplete="new-password"
                     className={`form-input block w-full pl-10 pr-10 py-2 rounded-md shadow-sm ${
-                      errors.password ? "border-error-300 focus:ring-error-500 focus:border-error-500" : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
+                      errors.password
+                        ? "border-error-300 focus:ring-error-500 focus:border-error-500"
+                        : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
                     }`}
                     placeholder="Create a strong password"
                     {...register("password", {
@@ -492,7 +512,8 @@ export default function RegisterPage() {
                         message: "Password must be at least 8 characters",
                       },
                       pattern: {
-                        value: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/,
+                        value:
+                          /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/,
                         message: "Password doesn't meet all requirements",
                       },
                     })}
@@ -502,20 +523,31 @@ export default function RegisterPage() {
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute inset-y-0 right-0 pr-3 flex items-center text-neutral-400 hover:text-neutral-600"
                   >
-                    {showPassword ? <FiEyeOff className="h-5 w-5" /> : <FiEye className="h-5 w-5" />}
+                    {showPassword ? (
+                      <FiEyeOff className="h-5 w-5" />
+                    ) : (
+                      <FiEye className="h-5 w-5" />
+                    )}
                   </button>
                 </div>
-                
-                {/* Password Strength Meter */}
+
                 {password && (
                   <div className="mt-2">
                     <div className="flex items-center justify-between mb-1">
-                      <span className="text-xs text-neutral-500">Password strength:</span>
-                      <span className={`text-xs font-medium ${
-                        passwordStrength.label === "Strong" ? "text-success-600" :
-                        passwordStrength.label === "Good" ? "text-warning-700" :
-                        passwordStrength.label === "Fair" ? "text-warning-600" : "text-error-600"
-                      }`}>
+                      <span className="text-xs text-neutral-500">
+                        Password strength:
+                      </span>
+                      <span
+                        className={`text-xs font-medium ${
+                          passwordStrength.label === "Strong"
+                            ? "text-success-600"
+                            : passwordStrength.label === "Good"
+                            ? "text-warning-700"
+                            : passwordStrength.label === "Fair"
+                            ? "text-warning-600"
+                            : "text-error-600"
+                        }`}
+                      >
                         {passwordStrength.label}
                       </span>
                     </div>
@@ -527,7 +559,7 @@ export default function RegisterPage() {
                     </div>
                   </div>
                 )}
-                
+
                 {errors.password && (
                   <p className="mt-1 text-sm text-error-600 flex items-center">
                     <FiAlertCircle className="h-4 w-4 mr-1" />
@@ -536,9 +568,11 @@ export default function RegisterPage() {
                 )}
               </div>
 
-              {/* Confirm Password Field */}
               <div>
-                <label htmlFor="confirmPassword" className="block text-sm font-medium text-neutral-700 mb-1">
+                <label
+                  htmlFor="confirmPassword"
+                  className="block text-sm font-medium text-neutral-700 mb-1"
+                >
                   Confirm Password
                 </label>
                 <div className="relative">
@@ -550,12 +584,15 @@ export default function RegisterPage() {
                     type={showConfirmPassword ? "text" : "password"}
                     autoComplete="new-password"
                     className={`form-input block w-full pl-10 pr-10 py-2 rounded-md shadow-sm ${
-                      errors.confirmPassword ? "border-error-300 focus:ring-error-500 focus:border-error-500" : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
+                      errors.confirmPassword
+                        ? "border-error-300 focus:ring-error-500 focus:border-error-500"
+                        : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
                     }`}
                     placeholder="Re-enter your password"
                     {...register("confirmPassword", {
                       required: "Please confirm your password",
-                      validate: value => value === password || "Passwords do not match",
+                      validate: (value) =>
+                        value === password || "Passwords do not match",
                     })}
                   />
                   <button
@@ -563,7 +600,11 @@ export default function RegisterPage() {
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                     className="absolute inset-y-0 right-0 pr-3 flex items-center text-neutral-400 hover:text-neutral-600"
                   >
-                    {showConfirmPassword ? <FiEyeOff className="h-5 w-5" /> : <FiEye className="h-5 w-5" />}
+                    {showConfirmPassword ? (
+                      <FiEyeOff className="h-5 w-5" />
+                    ) : (
+                      <FiEye className="h-5 w-5" />
+                    )}
                   </button>
                 </div>
                 {errors.confirmPassword && (
@@ -574,28 +615,79 @@ export default function RegisterPage() {
                 )}
               </div>
 
-              {/* Password Requirements Checklist */}
               <div className="bg-neutral-50 p-3 rounded-md">
-                <p className="text-xs text-neutral-600 font-medium mb-2">Password requirements:</p>
+                <p className="text-xs text-neutral-600 font-medium mb-2">
+                  Password requirements:
+                </p>
                 <ul className="text-xs space-y-1">
-                  <li className={`flex items-center ${passwordRequirements.minLength ? "text-success-600" : "text-neutral-500"}`}>
-                    {passwordRequirements.minLength ? <FiCheck className="h-3 w-3 mr-1.5" /> : <FiX className="h-3 w-3 mr-1.5" />}
+                  <li
+                    className={`flex items-center ${
+                      passwordRequirements.minLength
+                        ? "text-success-600"
+                        : "text-neutral-500"
+                    }`}
+                  >
+                    {passwordRequirements.minLength ? (
+                      <FiCheck className="h-3 w-3 mr-1.5" />
+                    ) : (
+                      <FiX className="h-3 w-3 mr-1.5" />
+                    )}
                     At least 8 characters long
                   </li>
-                  <li className={`flex items-center ${passwordRequirements.hasUppercase ? "text-success-600" : "text-neutral-500"}`}>
-                    {passwordRequirements.hasUppercase ? <FiCheck className="h-3 w-3 mr-1.5" /> : <FiX className="h-3 w-3 mr-1.5" />}
+                  <li
+                    className={`flex items-center ${
+                      passwordRequirements.hasUppercase
+                        ? "text-success-600"
+                        : "text-neutral-500"
+                    }`}
+                  >
+                    {passwordRequirements.hasUppercase ? (
+                      <FiCheck className="h-3 w-3 mr-1.5" />
+                    ) : (
+                      <FiX className="h-3 w-3 mr-1.5" />
+                    )}
                     At least one uppercase letter (A-Z)
                   </li>
-                  <li className={`flex items-center ${passwordRequirements.hasLowercase ? "text-success-600" : "text-neutral-500"}`}>
-                    {passwordRequirements.hasLowercase ? <FiCheck className="h-3 w-3 mr-1.5" /> : <FiX className="h-3 w-3 mr-1.5" />}
+                  <li
+                    className={`flex items-center ${
+                      passwordRequirements.hasLowercase
+                        ? "text-success-600"
+                        : "text-neutral-500"
+                    }`}
+                  >
+                    {passwordRequirements.hasLowercase ? (
+                      <FiCheck className="h-3 w-3 mr-1.5" />
+                    ) : (
+                      <FiX className="h-3 w-3 mr-1.5" />
+                    )}
                     At least one lowercase letter (a-z)
                   </li>
-                  <li className={`flex items-center ${passwordRequirements.hasNumber ? "text-success-600" : "text-neutral-500"}`}>
-                    {passwordRequirements.hasNumber ? <FiCheck className="h-3 w-3 mr-1.5" /> : <FiX className="h-3 w-3 mr-1.5" />}
+                  <li
+                    className={`flex items-center ${
+                      passwordRequirements.hasNumber
+                        ? "text-success-600"
+                        : "text-neutral-500"
+                    }`}
+                  >
+                    {passwordRequirements.hasNumber ? (
+                      <FiCheck className="h-3 w-3 mr-1.5" />
+                    ) : (
+                      <FiX className="h-3 w-3 mr-1.5" />
+                    )}
                     At least one number (0-9)
                   </li>
-                  <li className={`flex items-center ${passwordRequirements.hasSpecial ? "text-success-600" : "text-neutral-500"}`}>
-                    {passwordRequirements.hasSpecial ? <FiCheck className="h-3 w-3 mr-1.5" /> : <FiX className="h-3 w-3 mr-1.5" />}
+                  <li
+                    className={`flex items-center ${
+                      passwordRequirements.hasSpecial
+                        ? "text-success-600"
+                        : "text-neutral-500"
+                    }`}
+                  >
+                    {passwordRequirements.hasSpecial ? (
+                      <FiCheck className="h-3 w-3 mr-1.5" />
+                    ) : (
+                      <FiX className="h-3 w-3 mr-1.5" />
+                    )}
                     At least one special character (@$!%*?&)
                   </li>
                 </ul>
@@ -603,12 +695,56 @@ export default function RegisterPage() {
             </>
           )}
 
-          {/* Step 2: Personal Information */}
+          {/* ── Step 2: Role / Account-type selector ─────────────────── */}
           {step === 2 && (
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-neutral-700 mb-3">
+                I am registering as:
+              </label>
+              <div className="space-y-3">
+                {roleOptions.map((role) => (
+                  <label
+                    key={role.id}
+                    className={`flex items-start p-3 border rounded-md cursor-pointer transition-colors ${
+                      currentRole === role.id
+                        ? "border-primary-500 bg-primary-50"
+                        : "border-neutral-300 hover:bg-neutral-50"
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      value={role.id}
+                      {...register("role", { required: true })}
+                      className="form-radio mt-1 text-primary-600 focus:ring-primary-500"
+                    />
+                    <div className="ml-3 flex-1">
+                      <div className="flex items-center">
+                        <span className="text-sm font-medium text-neutral-900 mr-2">
+                          {role.label}
+                        </span>
+                        <span className="bg-neutral-100 rounded-full p-1">
+                          {role.icon}
+                        </span>
+                      </div>
+                      <p className="text-xs text-neutral-500 mt-1">
+                        {role.description}
+                      </p>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* ── Step 3: Type-specific profile fields ─────────────────── */}
+          {step === 3 && (
             <>
-              {/* First Name Field */}
+              {/* First Name */}
               <div>
-                <label htmlFor="firstName" className="block text-sm font-medium text-neutral-700 mb-1">
+                <label
+                  htmlFor="firstName"
+                  className="block text-sm font-medium text-neutral-700 mb-1"
+                >
                   First Name
                 </label>
                 <div className="relative">
@@ -620,7 +756,9 @@ export default function RegisterPage() {
                     type="text"
                     autoComplete="given-name"
                     className={`form-input block w-full pl-10 py-2 rounded-md shadow-sm ${
-                      errors.firstName ? "border-error-300 focus:ring-error-500 focus:border-error-500" : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
+                      errors.firstName
+                        ? "border-error-300 focus:ring-error-500 focus:border-error-500"
+                        : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
                     }`}
                     placeholder="John"
                     {...register("firstName", {
@@ -640,9 +778,12 @@ export default function RegisterPage() {
                 )}
               </div>
 
-              {/* Last Name Field */}
+              {/* Last Name */}
               <div>
-                <label htmlFor="lastName" className="block text-sm font-medium text-neutral-700 mb-1">
+                <label
+                  htmlFor="lastName"
+                  className="block text-sm font-medium text-neutral-700 mb-1"
+                >
                   Last Name
                 </label>
                 <div className="relative">
@@ -654,7 +795,9 @@ export default function RegisterPage() {
                     type="text"
                     autoComplete="family-name"
                     className={`form-input block w-full pl-10 py-2 rounded-md shadow-sm ${
-                      errors.lastName ? "border-error-300 focus:ring-error-500 focus:border-error-500" : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
+                      errors.lastName
+                        ? "border-error-300 focus:ring-error-500 focus:border-error-500"
+                        : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
                     }`}
                     placeholder="Doe"
                     {...register("lastName", {
@@ -674,10 +817,14 @@ export default function RegisterPage() {
                 )}
               </div>
 
-              {/* Phone Field with Formatting */}
+              {/* Phone */}
               <div>
-                <label htmlFor="phone" className="block text-sm font-medium text-neutral-700 mb-1">
-                  Phone Number <span className="text-neutral-400">(Optional)</span>
+                <label
+                  htmlFor="phone"
+                  className="block text-sm font-medium text-neutral-700 mb-1"
+                >
+                  Phone Number{" "}
+                  <span className="text-neutral-400">(Optional)</span>
                 </label>
                 <div className="relative">
                   <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -688,7 +835,9 @@ export default function RegisterPage() {
                     type="tel"
                     autoComplete="tel"
                     className={`form-input block w-full pl-10 py-2 rounded-md shadow-sm ${
-                      errors.phone ? "border-error-300 focus:ring-error-500 focus:border-error-500" : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
+                      errors.phone
+                        ? "border-error-300 focus:ring-error-500 focus:border-error-500"
+                        : "border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
                     }`}
                     placeholder="(555) 123-4567"
                     value={watchedPhone ?? ""}
@@ -696,7 +845,9 @@ export default function RegisterPage() {
                     maxLength={14}
                   />
                 </div>
-                <p className="mt-1 text-xs text-neutral-500">US phone format: (555) 123-4567</p>
+                <p className="mt-1 text-xs text-neutral-500">
+                  US phone format: (555) 123-4567
+                </p>
                 {errors.phone && (
                   <p className="mt-1 text-sm text-error-600 flex items-center">
                     <FiAlertCircle className="h-4 w-4 mr-1" />
@@ -704,7 +855,7 @@ export default function RegisterPage() {
                   </p>
                 )}
               </div>
-              
+
               {/* Preferred Contact Method */}
               <div>
                 <label className="block text-sm font-medium text-neutral-700 mb-2">
@@ -733,103 +884,69 @@ export default function RegisterPage() {
                 </div>
               </div>
 
-              {/* Relationship to Care Recipient - Only for FAMILY role */}
+              {/* FAMILY-only: relationship + care needs */}
               {currentRole === "FAMILY" && (
-                <div>
-                  <label htmlFor="relationshipToRecipient" className="block text-sm font-medium text-neutral-700 mb-1">
-                    Who are you looking for care for?
-                  </label>
-                  <div className="relative">
-                    <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                      <FiHeart className="h-5 w-5 text-neutral-400" />
-                    </div>
-                    <select
-                      id="relationshipToRecipient"
-                      className="form-select block w-full pl-10 py-2 rounded-md shadow-sm border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
-                      {...register("relationshipToRecipient")}
-                    >
-                      <option value="">Select relationship...</option>
-                      {relationshipOptions.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-              )}
-
-              {/* Care Preferences - Only for FAMILY role */}
-              {currentRole === "FAMILY" && (
-                <div>
-                  <label htmlFor="carePreferences" className="block text-sm font-medium text-neutral-700 mb-1">
-                    Care Needs or Preferences <span className="text-neutral-400">(Optional)</span>
-                  </label>
-                  <textarea
-                    id="carePreferences"
-                    rows={3}
-                    className="form-textarea block w-full py-2 px-3 rounded-md shadow-sm border-neutral-300 focus:ring-primary-500 focus:border-primary-500 resize-none"
-                    placeholder="Tell us about any specific care needs, preferences, or concerns..."
-                    maxLength={1000}
-                    {...register("carePreferences", {
-                      maxLength: {
-                        value: 1000,
-                        message: "Care preferences must be under 1000 characters",
-                      },
-                    })}
-                  />
-                  <p className="mt-1 text-xs text-neutral-500">
-                    This helps us match you with the right care homes
-                  </p>
-                  {errors.carePreferences && (
-                    <p className="mt-1 text-sm text-error-600 flex items-center">
-                      <FiAlertCircle className="h-4 w-4 mr-1" />
-                      {errors.carePreferences.message}
-                    </p>
-                  )}
-                </div>
-              )}
-            </>
-          )}
-
-          {/* Step 3: Role Selection */}
-          {step === 3 && (
-            <>
-              <div className="mb-4">
-                <label className="block text-sm font-medium text-neutral-700 mb-3">
-                  I am registering as:
-                </label>
-                <div className="space-y-3">
-                  {roleOptions.map((role) => (
+                <>
+                  <div>
                     <label
-                      key={role.id}
-                      className={`flex items-start p-3 border rounded-md cursor-pointer transition-colors ${
-                        currentRole === role.id
-                          ? "border-primary-500 bg-primary-50"
-                          : "border-neutral-300 hover:bg-neutral-50"
-                      }`}
+                      htmlFor="relationshipToRecipient"
+                      className="block text-sm font-medium text-neutral-700 mb-1"
                     >
-                      <input
-                        type="radio"
-                        value={role.id}
-                        {...register("role", { required: true })}
-                        className="form-radio mt-1 text-primary-600 focus:ring-primary-500"
-                      />
-                      <div className="ml-3 flex-1">
-                        <div className="flex items-center">
-                          <span className="text-sm font-medium text-neutral-900 mr-2">
-                            {role.label}
-                          </span>
-                          <span className="bg-neutral-100 rounded-full p-1">
-                            {role.icon}
-                          </span>
-                        </div>
-                        <p className="text-xs text-neutral-500 mt-1">{role.description}</p>
-                      </div>
+                      Who are you looking for care for?
                     </label>
-                  ))}
-                </div>
-              </div>
+                    <div className="relative">
+                      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                        <FiHeart className="h-5 w-5 text-neutral-400" />
+                      </div>
+                      <select
+                        id="relationshipToRecipient"
+                        className="form-select block w-full pl-10 py-2 rounded-md shadow-sm border-neutral-300 focus:ring-primary-500 focus:border-primary-500"
+                        {...register("relationshipToRecipient")}
+                      >
+                        <option value="">Select relationship...</option>
+                        {relationshipOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="carePreferences"
+                      className="block text-sm font-medium text-neutral-700 mb-1"
+                    >
+                      Care Needs or Preferences{" "}
+                      <span className="text-neutral-400">(Optional)</span>
+                    </label>
+                    <textarea
+                      id="carePreferences"
+                      rows={3}
+                      className="form-textarea block w-full py-2 px-3 rounded-md shadow-sm border-neutral-300 focus:ring-primary-500 focus:border-primary-500 resize-none"
+                      placeholder="Tell us about any specific care needs, preferences, or concerns..."
+                      maxLength={1000}
+                      {...register("carePreferences", {
+                        maxLength: {
+                          value: 1000,
+                          message:
+                            "Care preferences must be under 1000 characters",
+                        },
+                      })}
+                    />
+                    <p className="mt-1 text-xs text-neutral-500">
+                      This helps us match you with the right care homes
+                    </p>
+                    {errors.carePreferences && (
+                      <p className="mt-1 text-sm text-error-600 flex items-center">
+                        <FiAlertCircle className="h-4 w-4 mr-1" />
+                        {errors.carePreferences.message}
+                      </p>
+                    )}
+                  </div>
+                </>
+              )}
 
               {/* Terms and Conditions */}
               <div className="mt-6">
@@ -847,18 +964,29 @@ export default function RegisterPage() {
                     />
                   </div>
                   <div className="ml-3 text-sm">
-                    <label htmlFor="agreeToTerms" className="font-medium text-neutral-700">
+                    <label
+                      htmlFor="agreeToTerms"
+                      className="font-medium text-neutral-700"
+                    >
                       I agree to the{" "}
-                      <Link href="/terms" className="text-primary-600 hover:text-primary-500">
+                      <Link
+                        href="/terms"
+                        className="text-primary-600 hover:text-primary-500"
+                      >
                         Terms of Service
                       </Link>{" "}
                       and{" "}
-                      <Link href="/privacy" className="text-primary-600 hover:text-primary-500">
+                      <Link
+                        href="/privacy"
+                        className="text-primary-600 hover:text-primary-500"
+                      >
                         Privacy Policy
                       </Link>
                     </label>
                     {errors.agreeToTerms && (
-                      <p className="mt-1 text-sm text-error-600">{errors.agreeToTerms.message}</p>
+                      <p className="mt-1 text-sm text-error-600">
+                        {errors.agreeToTerms.message}
+                      </p>
                     )}
                   </div>
                 </div>
@@ -866,7 +994,7 @@ export default function RegisterPage() {
             </>
           )}
 
-          {/* Navigation buttons */}
+          {/* ── Navigation ────────────────────────────────────────────── */}
           <div className="flex justify-between pt-4">
             {step > 1 ? (
               <button
@@ -877,7 +1005,7 @@ export default function RegisterPage() {
                 Back
               </button>
             ) : (
-              <div></div> // Empty div for spacing
+              <div />
             )}
 
             {step < 3 ? (
@@ -912,17 +1040,21 @@ export default function RegisterPage() {
           </div>
         </form>
 
-        {/* Form progress indicator */}
+        {/* Progress indicator */}
         <div className="mt-8">
           <div className="flex justify-between mb-2">
-            <span className="text-xs font-medium text-neutral-600">Step {step} of 3</span>
-            <span className="text-xs font-medium text-neutral-600">{Math.round((step / 3) * 100)}% Complete</span>
+            <span className="text-xs font-medium text-neutral-600">
+              Step {step} of 3
+            </span>
+            <span className="text-xs font-medium text-neutral-600">
+              {Math.round((step / 3) * 100)}% Complete
+            </span>
           </div>
           <div className="w-full bg-neutral-200 rounded-full h-1.5">
             <div
               className="bg-primary-600 h-1.5 rounded-full transition-all duration-300"
               style={{ width: `${(step / 3) * 100}%` }}
-            ></div>
+            />
           </div>
         </div>
 
@@ -930,7 +1062,10 @@ export default function RegisterPage() {
         <div className="mt-8 text-center">
           <p className="text-sm text-neutral-600">
             Already have an account?{" "}
-            <Link href="/auth/login" className="font-medium text-primary-600 hover:text-primary-500">
+            <Link
+              href="/auth/login"
+              className="font-medium text-primary-600 hover:text-primary-500"
+            >
               Sign in
             </Link>
           </p>


### PR DESCRIPTION
Restructures the 3-step /auth/register flow:

  Step 1 — Email + password (unchanged)
  Step 2 — Account type selector (role tiles; was Step 3)
  Step 3 — Type-specific form:
    • FAMILY: name, phone, contact method, relationship, care needs
    • All others: name, phone, contact method only

?role=ROLE deep-link: Next on Step 1 skips Step 2 entirely (auto-advance). Back from Step 3 always lands on Step 2 with the role tile still selected.

?claimToken deep-link: token is redeemed via /api/operator/claim after signIn succeeds, before redirecting OPERATOR users to /operator/onboarding/1.

Also fixes a pre-existing bug: DISCHARGE_PLANNER was shown in the role selector but rejected by the API schema. Added it to the Zod enum and added a DischargePlannerProfile creation case in the register handler.

E2E: e2e/auth-register-flow.spec.ts covers Family path, Operator manual select, ?role=OPERATOR auto-advance + Back-button state preservation, and the Cleveland founder claimToken deep-link flow.

https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ