### PR TITLE
fix(onboarding): three integration bugs in Cleveland founder flow

### DIFF
--- a/e2e/auth-register-flow.spec.ts
+++ b/e2e/auth-register-flow.spec.ts
@@ -144,7 +144,7 @@ test.describe('@critical Register — Operator path (?role=OPERATOR deep-link)',
 // ── Operator path — ?claimToken (Cleveland founder deep-link) ─────────────────
 
 test.describe('@critical Register — Cleveland founder claim-token flow', () => {
-  test('?claimToken redeemed after signup → clevelandFounder=true on operator record', async ({
+  test('?claimToken applied at signup time via API → clevelandFounder=true without manual claim call', async ({
     page,
     request,
   }) => {
@@ -199,12 +199,10 @@ test.describe('@critical Register — Cleveland founder claim-token flow', () =>
     await page.getByRole('checkbox', { name: /terms/i }).check();
     await page.getByRole('button', { name: /create account/i }).click();
 
-    // Wait for redirect to onboarding wizard
+    // Wait for redirect to onboarding wizard (claim was applied during register API call)
     await page.waitForURL(/\/operator\/onboarding\/1|\/auth\/login/, { timeout: 20000 });
 
-    // After redirect, verify the claim was applied (founder flag set)
-    // Use a short delay to let the claim redemption API call complete
-    await page.waitForTimeout(3000);
+    // Verify founder flags are already set — no separate /api/operator/claim call needed
     const statusRes = await page.evaluate(async () => {
       const r = await fetch('/api/operator/onboarding/status', {
         credentials: 'include',
@@ -213,5 +211,6 @@ test.describe('@critical Register — Cleveland founder claim-token flow', () =>
     });
     expect(statusRes.clevelandFounder).toBe(true);
     expect(statusRes.freeAccessUntil).toBeTruthy();
+    expect(statusRes.seededHomeId).toBeTruthy();
   });
 });

--- a/e2e/operator-onboarding-wizard.spec.ts
+++ b/e2e/operator-onboarding-wizard.spec.ts
@@ -25,7 +25,18 @@ async function registerOperator(request: any, email: string) {
 }
 
 test.describe('@critical Operator onboarding wizard (4-step)', () => {
-  test('new operator is redirected to wizard and can reach plan selection', async ({
+  test('after login, OPERATOR is sent to /operator (not /dashboard)', async ({
+    page,
+    request,
+  }) => {
+    const email = `login-redirect-${Date.now()}@test.carelinkai.com`;
+    await registerOperator(request, email);
+    await loginAs(page, email);
+    // Should land in the operator area (wizard or dashboard, not /dashboard)
+    await expect(page).toHaveURL(/\/operator/, { timeout: 15000 });
+  });
+
+  test('new operator is redirected to wizard and can reach plan selection with all 4 tiers', async ({
     page,
     request,
   }) => {
@@ -59,22 +70,17 @@ test.describe('@critical Operator onboarding wizard (4-step)', () => {
     await page.getByText('Assisted Living').click();
     await page.getByRole('button', { name: /continue/i }).click();
 
-    // Step 3: Claim link — skip it
+    // Step 3: Claim link — skip
     await page.waitForURL(/\/operator\/onboarding\/3/, { timeout: 10000 });
-    await expect(page.getByText(/cleveland founder/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/cleveland founder access/i)).toBeVisible({ timeout: 10000 });
     await page.getByRole('button', { name: /skip/i }).click();
 
-    // Step 4: Plan selection
+    // Step 4: All 4 paid tiers visible
     await page.waitForURL(/\/operator\/onboarding\/4/, { timeout: 10000 });
     await expect(page.getByText(/choose a plan/i)).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(/professional/i)).toBeVisible({ timeout: 5000 });
-  });
-
-  test('register page pre-selects OPERATOR role when ?role=OPERATOR is in URL', async ({ page }) => {
-    await page.goto('/auth/register?role=OPERATOR', { waitUntil: 'domcontentloaded' });
-    // The OPERATOR radio/option should be selected by default
-    const operatorOption = page.getByRole('radio', { name: /care home operator/i });
-    await expect(operatorOption).toBeChecked({ timeout: 8000 });
+    for (const tier of ['starter', 'professional', 'growth', 'agency']) {
+      await expect(page.getByText(new RegExp(tier, 'i'))).toBeVisible({ timeout: 5000 });
+    }
   });
 });
 
@@ -136,12 +142,110 @@ test.describe('@critical Cleveland founder claim flow', () => {
     expect(redeemRes.body.clevelandFounder).toBe(true);
     expect(redeemRes.body.freeAccessUntil).toBeTruthy();
 
-    // Onboarding status should reflect clevelandFounder
+    // Onboarding status should reflect clevelandFounder + seededHomeId
     const statusRes = await page.evaluate(async () => {
       const r = await fetch('/api/operator/onboarding/status', { credentials: 'include' });
       return r.json();
     });
     expect(statusRes.clevelandFounder).toBe(true);
+    expect(statusRes.seededHomeId).toBeTruthy();
+    expect(statusRes.seededHome).toBeTruthy();
+  });
+
+  test('claim token applied at signup: founder flag set without manual /api/operator/claim call', async ({
+    page,
+    request,
+  }) => {
+    const opEmail = `founder-signup-${Date.now()}@test.carelinkai.com`;
+
+    // Seed a home for the claim token
+    await request.post('/api/dev/upsert-admin', { data: { email: 'admin@carelinkai.com' } });
+    const seedRes = await request.post('/api/dev/upsert-operator', {
+      data: { email: `seed-only-${Date.now()}@test.carelinkai.com`, companyName: 'Seed Co', homes: [{ name: 'Seed Home', capacity: 8 }] },
+    });
+    expect(seedRes.ok()).toBeTruthy();
+    const seedData = await seedRes.json();
+    const homeId = seedData.homes?.[0]?.id ?? seedData.homeId;
+
+    // Admin generates claim link for the new operator's email
+    await loginAs(page, 'admin@carelinkai.com');
+    const claimRes = await page.evaluate(
+      async ({ hid, email }: { hid: string; email: string }) => {
+        const r = await fetch(`/api/admin/homes/${hid}/claim-link`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ operatorEmail: email, clevelandFounder: true }),
+        });
+        return r.json();
+      },
+      { hid: homeId, email: opEmail }
+    );
+    expect(claimRes.token).toBeTruthy();
+
+    // Register via API with claimToken in body (simulates the register page submitting it)
+    const regRes = await request.post('/api/auth/register', {
+      data: {
+        email: opEmail,
+        password: 'Test@12345',
+        firstName: 'Founder',
+        lastName: 'Signup',
+        role: 'OPERATOR',
+        agreeToTerms: true,
+        claimToken: claimRes.token,
+      },
+    });
+    expect(regRes.status()).toBe(201);
+
+    // Log in and verify founder flags are already set (no manual claim call needed)
+    await loginAs(page, opEmail);
+    const statusRes = await page.evaluate(async () => {
+      const r = await fetch('/api/operator/onboarding/status', { credentials: 'include' });
+      return r.json();
+    });
+    expect(statusRes.clevelandFounder).toBe(true);
+    expect(statusRes.freeAccessUntil).toBeTruthy();
+    expect(statusRes.seededHomeId).toBe(homeId);
+  });
+
+  test('Step 2 pre-populates seeded home for founders', async ({
+    page,
+    request,
+  }) => {
+    const opEmail = `founder-step2-${Date.now()}@test.carelinkai.com`;
+
+    await request.post('/api/dev/upsert-admin', { data: { email: 'admin@carelinkai.com' } });
+    const seedRes = await request.post('/api/dev/upsert-operator', {
+      data: { email: `seed-s2-${Date.now()}@test.carelinkai.com`, companyName: 'S2 Co', homes: [{ name: 'Canterbury Commons', capacity: 12 }] },
+    });
+    const seedData = await seedRes.json();
+    const homeId = seedData.homes?.[0]?.id ?? seedData.homeId;
+
+    await loginAs(page, 'admin@carelinkai.com');
+    const claimRes = await page.evaluate(
+      async ({ hid, email }: { hid: string; email: string }) => {
+        const r = await fetch(`/api/admin/homes/${hid}/claim-link`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ operatorEmail: email, clevelandFounder: true }),
+        });
+        return r.json();
+      },
+      { hid: homeId, email: opEmail }
+    );
+
+    // Register with claim token
+    await request.post('/api/auth/register', {
+      data: { email: opEmail, password: 'Test@12345', firstName: 'Step2', lastName: 'Test', role: 'OPERATOR', agreeToTerms: true, claimToken: claimRes.token },
+    });
+    await loginAs(page, opEmail);
+    await page.goto('/operator/onboarding/2', { waitUntil: 'domcontentloaded' });
+
+    // Step 2 should show "Confirm your home" and pre-populate the home name
+    await expect(page.getByText(/confirm your home/i)).toBeVisible({ timeout: 10000 });
+    const nameInput = page.locator('input[placeholder="Sunrise East Wing"]');
+    await expect(nameInput).toHaveValue('Canterbury Commons', { timeout: 8000 });
   });
 
   test('claim token locked to operator email — different operator cannot redeem', async ({

--- a/prisma/migrations/20260602000001_operator_seeded_home/migration.sql
+++ b/prisma/migrations/20260602000001_operator_seeded_home/migration.sql
@@ -1,0 +1,3 @@
+-- Add seededHomeId to Operator for tracking which admin-seeded home was assigned
+-- via a Cleveland founder claim token. Cleared after the operator claims the home.
+ALTER TABLE "Operator" ADD COLUMN IF NOT EXISTS "seededHomeId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -174,6 +174,7 @@ model Operator {
   clevelandFounder     Boolean             @default(false)
   freeAccessUntil      DateTime?
   accessTier           AccessTier          @default(FULL)
+  seededHomeId         String?
   createdAt            DateTime            @default(now())
   updatedAt            DateTime            @updatedAt
   homes                    AssistedLivingHome[]

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -21,6 +21,7 @@ import { v4 as uuidv4 } from "uuid";
 import { randomBytes } from "crypto";
 import { sendVerificationEmail } from "@/lib/email";
 import { captureError } from '@/lib/sentry';
+import { verifyClaimToken } from '@/lib/claim-token';
 
 // Initialize Prisma client
 const prisma = new PrismaClient();
@@ -52,6 +53,7 @@ const registrationSchema = z.object({
   carePreferences: z.string().max(1000, "Care preferences must be under 1000 characters").optional(),
   preferredContactMethod: z.enum(["EMAIL", "PHONE", "BOTH"]).optional(),
   referredByCode: z.string().max(20).optional(), // affiliate ?ref= code captured from URL
+  claimToken: z.string().optional(), // Cleveland founder claim token
 });
 
 /**
@@ -180,18 +182,19 @@ export async function POST(request: NextRequest) {
     console.log("[REGISTER API] Validation PASSED");
     
     // Extract validated data
-    const { 
-      email, 
-      password, 
-      firstName, 
-      lastName, 
-      phone, 
-      role, 
+    const {
+      email,
+      password,
+      firstName,
+      lastName,
+      phone,
+      role,
       agreeToTerms,
       relationshipToRecipient,
       carePreferences,
       preferredContactMethod,
       referredByCode,
+      claimToken,
     } = validationResult.data;
     
     // Normalize email to lowercase
@@ -292,18 +295,44 @@ export async function POST(request: NextRequest) {
           console.log("[REGISTER API] Family profile created successfully");
           break;
           
-        case "OPERATOR":
+        case "OPERATOR": {
           console.log("[REGISTER API] Creating OPERATOR profile...");
-          await tx.operator.create({
+          const newOperator = await tx.operator.create({
             data: {
               userId: user.id,
-              companyName: `${firstName}'s Care Home`, // Default company name
+              companyName: `${firstName}'s Care Home`,
               taxId: null,
-              businessLicense: null
-            }
+              businessLicense: null,
+            },
           });
+
+          // Apply Cleveland founder claim token at signup time so it survives
+          // the email-verification redirect (token is no longer needed in the URL)
+          if (claimToken) {
+            const payload = verifyClaimToken(
+              claimToken,
+              process.env['NEXTAUTH_SECRET'] ?? ''
+            );
+            if (payload && payload.operatorEmail.toLowerCase() === normalizedEmail) {
+              console.log("[REGISTER API] Applying Cleveland founder claim token");
+              await tx.operator.update({
+                where: { id: newOperator.id },
+                data: {
+                  clevelandFounder: true,
+                  freeAccessUntil: new Date(
+                    Date.now() + 1000 * 60 * 60 * 24 * 180
+                  ),
+                  seededHomeId: payload.homeId ?? null,
+                },
+              });
+            } else {
+              console.log("[REGISTER API] Claim token invalid or email mismatch — skipping");
+            }
+          }
+
           console.log("[REGISTER API] Operator profile created successfully");
           break;
+        }
           
         case "CAREGIVER":
           console.log("[REGISTER API] Creating CAREGIVER profile...");

--- a/src/app/api/operator/claim/route.ts
+++ b/src/app/api/operator/claim/route.ts
@@ -62,8 +62,14 @@ export async function POST(request: NextRequest) {
     data: {
       clevelandFounder: true,
       freeAccessUntil: freeUntil,
+      seededHomeId: payload.homeId ?? null,
     },
   });
 
-  return NextResponse.json({ ok: true, clevelandFounder: true, freeAccessUntil: freeUntil });
+  return NextResponse.json({
+    ok: true,
+    clevelandFounder: true,
+    freeAccessUntil: freeUntil,
+    seededHomeId: payload.homeId ?? null,
+  });
 }

--- a/src/app/api/operator/homes/[id]/claim/route.ts
+++ b/src/app/api/operator/homes/[id]/claim/route.ts
@@ -1,0 +1,77 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { UserRole } from '@prisma/client';
+
+/**
+ * POST /api/operator/homes/[id]/claim
+ *
+ * Transfers ownership of an admin-seeded home to the authenticated Cleveland founder.
+ * Guards:
+ *   1. Operator must have clevelandFounder=true
+ *   2. operator.seededHomeId must match :id
+ *
+ * On success:
+ *   - home.operatorId → current operator
+ *   - home.status → 'ACTIVE'
+ *   - operator.seededHomeId → null (claimed, no longer pending)
+ */
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+  if (!user || user.role !== UserRole.OPERATOR) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const operator = await prisma.operator.findUnique({ where: { userId: user.id } });
+  if (!operator) {
+    return NextResponse.json({ error: 'Operator not found' }, { status: 404 });
+  }
+
+  if (!operator.clevelandFounder) {
+    return NextResponse.json(
+      { error: 'Only Cleveland founders can claim seeded homes' },
+      { status: 403 }
+    );
+  }
+
+  if (operator.seededHomeId !== params.id) {
+    return NextResponse.json(
+      { error: 'This home is not assigned to your founder account' },
+      { status: 403 }
+    );
+  }
+
+  const home = await prisma.assistedLivingHome.findUnique({
+    where: { id: params.id },
+    include: { address: true },
+  });
+  if (!home) {
+    return NextResponse.json({ error: 'Home not found' }, { status: 404 });
+  }
+
+  // Transfer ownership in a transaction
+  const [updatedHome] = await prisma.$transaction([
+    prisma.assistedLivingHome.update({
+      where: { id: params.id },
+      data: { operatorId: operator.id, status: 'ACTIVE' },
+      include: { address: true },
+    }),
+    prisma.operator.update({
+      where: { id: operator.id },
+      data: { seededHomeId: null },
+    }),
+  ]);
+
+  return NextResponse.json({ home: updatedHome });
+}

--- a/src/app/api/operator/homes/route.ts
+++ b/src/app/api/operator/homes/route.ts
@@ -39,8 +39,20 @@ export async function POST(req: NextRequest) {
 
     const body = await req.json();
     const { name, description, careLevel, capacity, priceMin, priceMax, address, amenities, genderRestriction, operatorId: bodyOperatorId } = body || {};
-    if (!name || !description || !Array.isArray(careLevel) || !capacity || !address?.city || !address?.state || !address?.street || !address?.zipCode) {
-      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+
+    // Validate required fields and surface specific errors
+    const fieldErrors: Record<string, string> = {};
+    if (!name) fieldErrors.name = 'Home name is required';
+    if (!description) fieldErrors.description = 'Description is required';
+    if (!Array.isArray(careLevel) || careLevel.length === 0) fieldErrors.careLevel = 'At least one care type is required';
+    if (!capacity) fieldErrors.capacity = 'Capacity is required';
+    if (!address?.street) fieldErrors['address.street'] = 'Street address is required';
+    if (!address?.city) fieldErrors['address.city'] = 'City is required';
+    if (!address?.state) fieldErrors['address.state'] = 'State is required';
+    if (!address?.zipCode) fieldErrors['address.zipCode'] = 'ZIP code is required';
+
+    if (Object.keys(fieldErrors).length > 0) {
+      return NextResponse.json({ error: 'Invalid payload', fields: fieldErrors }, { status: 400 });
     }
 
     // Determine operatorId based on user role

--- a/src/app/api/operator/onboarding/status/route.ts
+++ b/src/app/api/operator/onboarding/status/route.ts
@@ -8,7 +8,8 @@ import { UserRole } from '@prisma/client';
 
 /**
  * GET /api/operator/onboarding/status
- * Returns whether the current operator has completed onboarding.
+ * Returns onboarding state for the current operator, including seeded home data
+ * when a Cleveland founder claim has assigned one.
  */
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -27,10 +28,39 @@ export async function GET() {
     return NextResponse.json({ completed: false, clevelandFounder: false });
   }
 
+  // Fetch the seeded home if one is assigned (Cleveland founder flow)
+  let seededHome = null;
+  if (operator.seededHomeId) {
+    const home = await prisma.assistedLivingHome.findUnique({
+      where: { id: operator.seededHomeId },
+      include: { address: true },
+    });
+    if (home) {
+      seededHome = {
+        id: home.id,
+        name: home.name,
+        description: home.description,
+        capacity: home.capacity,
+        careLevel: home.careLevel,
+        status: home.status,
+        address: home.address
+          ? {
+              street: home.address.street,
+              city: home.address.city,
+              state: home.address.state,
+              zipCode: home.address.zipCode,
+            }
+          : null,
+      };
+    }
+  }
+
   return NextResponse.json({
     completed: !!operator.onboardingCompletedAt,
     clevelandFounder: operator.clevelandFounder ?? false,
     freeAccessUntil: operator.freeAccessUntil ?? null,
     accessTier: operator.accessTier ?? 'FULL',
+    seededHomeId: operator.seededHomeId ?? null,
+    seededHome,
   });
 }

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -97,6 +97,9 @@ export default function LoginPage() {
         const session = await response.json();
         if (session?.user?.role === 'DISCHARGE_PLANNER') {
           router.push('/discharge-planner');
+        } else if (session?.user?.role === 'OPERATOR' && (!callbackUrl || callbackUrl === '/')) {
+          // Send operators to /operator so AcceptanceGate can enforce onboarding/BAA redirect
+          router.push('/operator');
         } else if (callbackUrl && callbackUrl !== '/') {
           router.push(callbackUrl);
         } else {

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -277,6 +277,9 @@ export default function RegisterPage() {
           data.role === "FAMILY" ? data.relationshipToRecipient : undefined,
         carePreferences:
           data.role === "FAMILY" ? data.carePreferences : undefined,
+        // Pass claimToken in the body so the register API redeems it at signup
+        // time — this survives the email-verification redirect
+        claimToken: claimTokenFromUrl ?? undefined,
       };
 
       await axios.post("/api/auth/register", cleanedData);
@@ -291,20 +294,7 @@ export default function RegisterPage() {
           });
 
           if (signInResult?.ok) {
-            // Redeem claim token if present (operator deep-link flow)
-            if (claimTokenFromUrl && data.role === "OPERATOR") {
-              try {
-                await fetch("/api/operator/claim", {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({ token: claimTokenFromUrl }),
-                });
-              } catch {
-                // Non-fatal — continue to onboarding even if redemption fails
-              }
-            }
-
-            // Role-specific redirect
+            // Role-specific redirect (claim token was already redeemed by the API)
             if (data.role === "OPERATOR") {
               router.push("/operator/onboarding/1");
             } else if (data.role === "FAMILY") {

--- a/src/app/operator/onboarding/[step]/page.tsx
+++ b/src/app/operator/onboarding/[step]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter, useParams, useSearchParams } from "next/navigation";
+import { useRouter, useParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { FiCheck, FiArrowRight, FiHome, FiUser, FiZap, FiGift } from "react-icons/fi";
 
@@ -23,6 +23,16 @@ interface HomeForm {
   zipCode: string;
   capacity: string;
   careLevel: string[];
+}
+
+interface SeededHome {
+  id: string;
+  name: string;
+  description: string;
+  capacity: number;
+  careLevel: string[];
+  status: string;
+  address: { street: string; city: string; state: string; zipCode: string } | null;
 }
 
 const CARE_LEVELS = [
@@ -63,6 +73,19 @@ const PLANS = [
       "Custom analytics",
       "Dedicated support",
       "API access",
+    ],
+    highlight: false,
+  },
+  {
+    key: "AGENCY",
+    name: "Agency",
+    price: "$799",
+    features: [
+      "Everything in Growth",
+      "Multi-operator management",
+      "White-label options",
+      "SLA support",
+      "Custom integrations",
     ],
     highlight: false,
   },
@@ -122,15 +145,14 @@ export default function OperatorOnboardingStepPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const params = useParams();
-  const searchParams = useSearchParams();
 
-  // Derive step number from URL param
   const rawStep = Number(params?.step);
   const step: StepNum = ([1, 2, 3, 4].includes(rawStep) ? rawStep : 1) as StepNum;
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [clevelandFounder, setClevelandFounder] = useState(false);
+  const [seededHome, setSeededHome] = useState<SeededHome | null>(null);
 
   const [profile, setProfile] = useState<ProfileForm>({ companyName: "", phone: "" });
   const [home, setHome] = useState<HomeForm>({
@@ -143,7 +165,9 @@ export default function OperatorOnboardingStepPage() {
     capacity: "",
     careLevel: [],
   });
-  const [claimToken, setClaimToken] = useState(searchParams?.get("claimToken") || "");
+
+  // Only used on Step 3 when the operator manually enters a token
+  const [manualToken, setManualToken] = useState("");
   const [claimApplied, setClaimApplied] = useState(false);
 
   // Redirect non-operators
@@ -154,9 +178,36 @@ export default function OperatorOnboardingStepPage() {
     }
   }, [status, session, router]);
 
-  // Pre-fill existing profile data
+  // Load onboarding status + profile on mount
   useEffect(() => {
     if (status !== "authenticated") return;
+
+    // Fetch onboarding status (includes seededHome for founders)
+    fetch("/api/operator/onboarding/status")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.clevelandFounder) {
+          setClevelandFounder(true);
+          setClaimApplied(true);
+        }
+        if (d.seededHome) {
+          setSeededHome(d.seededHome);
+          // Pre-populate Step 2 form with seeded home data
+          setHome({
+            name: d.seededHome.name ?? "",
+            description: d.seededHome.description ?? "",
+            street: d.seededHome.address?.street ?? "",
+            city: d.seededHome.address?.city ?? "",
+            state: d.seededHome.address?.state ?? "",
+            zipCode: d.seededHome.address?.zipCode ?? "",
+            capacity: String(d.seededHome.capacity ?? ""),
+            careLevel: d.seededHome.careLevel ?? [],
+          });
+        }
+      })
+      .catch(() => {});
+
+    // Pre-fill company profile
     fetch("/api/operator/profile")
       .then((r) => r.json())
       .then((d) => {
@@ -166,17 +217,13 @@ export default function OperatorOnboardingStepPage() {
             phone: d.user?.phone || "",
           });
         }
-        if (d.operator?.clevelandFounder) {
-          setClevelandFounder(true);
-          setClaimApplied(true);
-        }
       })
       .catch(() => {});
   }, [status]);
 
   const goToStep = (n: StepNum) => router.push(`/operator/onboarding/${n}`);
 
-  // ── Step 1 submit ──────────────────────────────────────────────────────────
+  // ── Step 1: Save company profile ─────────────────────────────────────────
   const submitProfile = async () => {
     if (!profile.companyName.trim()) {
       setError("Company name is required.");
@@ -202,7 +249,7 @@ export default function OperatorOnboardingStepPage() {
     }
   };
 
-  // ── Step 2 submit ──────────────────────────────────────────────────────────
+  // ── Step 2: Add / claim first home ───────────────────────────────────────
   const submitHome = async () => {
     if (!home.name.trim()) { setError("Home name is required."); return; }
     if (!home.description.trim()) { setError("A brief description is required."); return; }
@@ -212,24 +259,46 @@ export default function OperatorOnboardingStepPage() {
     }
     if (home.careLevel.length === 0) { setError("Select at least one care type."); return; }
     if (!home.capacity || parseInt(home.capacity) < 1) { setError("Capacity must be at least 1."); return; }
+
     setError(null);
     setSaving(true);
     try {
-      const res = await fetch("/api/operator/homes", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: home.name.trim(),
-          description: home.description.trim(),
-          street: home.street.trim(),
-          city: home.city.trim(),
-          state: home.state.trim(),
-          zipCode: home.zipCode.trim(),
-          capacity: parseInt(home.capacity),
-          careLevel: home.careLevel,
-        }),
-      });
-      if (!res.ok) throw new Error("Failed to save home.");
+      if (clevelandFounder && seededHome) {
+        // Transfer the seeded home to this operator instead of creating a new one
+        const res = await fetch(`/api/operator/homes/${seededHome.id}/claim`, {
+          method: "POST",
+        });
+        if (!res.ok) {
+          const errData = await res.json().catch(() => ({}));
+          throw new Error(errData.error || "Failed to claim home.");
+        }
+      } else {
+        // Standard path: create a new home.
+        // Wrap address fields in the `address` object the API expects.
+        const res = await fetch("/api/operator/homes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: home.name.trim(),
+            description: home.description.trim(),
+            address: {
+              street: home.street.trim(),
+              city: home.city.trim(),
+              state: home.state.trim(),
+              zipCode: home.zipCode.trim(),
+            },
+            capacity: parseInt(home.capacity),
+            careLevel: home.careLevel,
+          }),
+        });
+        if (!res.ok) {
+          const errData = await res.json().catch(() => ({}));
+          const fieldMsg = errData.fields
+            ? Object.values(errData.fields as Record<string, string>).join(". ")
+            : null;
+          throw new Error(fieldMsg || errData.error || "Failed to save home.");
+        }
+      }
       goToStep(3);
     } catch (e: any) {
       setError(e.message || "Something went wrong.");
@@ -238,10 +307,10 @@ export default function OperatorOnboardingStepPage() {
     }
   };
 
-  // ── Step 3: Apply claim token ──────────────────────────────────────────────
+  // ── Step 3: Apply claim token manually (for operators who weren't deep-linked) ─
   const applyClaimToken = async () => {
-    if (!claimToken.trim()) {
-      setError("Enter your claim link token.");
+    if (!manualToken.trim()) {
+      setError("Enter your claim token.");
       return;
     }
     setError(null);
@@ -250,12 +319,19 @@ export default function OperatorOnboardingStepPage() {
       const res = await fetch("/api/operator/claim", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token: claimToken.trim() }),
+        body: JSON.stringify({ token: manualToken.trim() }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Invalid token.");
       setClaimApplied(true);
       setClevelandFounder(true);
+      if (data.seededHomeId) {
+        // Refresh seeded home data so Step 4 has the right context
+        fetch("/api/operator/onboarding/status")
+          .then((r) => r.json())
+          .then((d) => { if (d.seededHome) setSeededHome(d.seededHome); })
+          .catch(() => {});
+      }
     } catch (e: any) {
       setError(e.message || "Something went wrong.");
     } finally {
@@ -263,22 +339,12 @@ export default function OperatorOnboardingStepPage() {
     }
   };
 
-  const skipClaim = () => {
+  const proceedFromStep3 = () => {
     setError(null);
     goToStep(4);
   };
 
-  const proceedFromClaim = () => {
-    setError(null);
-    if (clevelandFounder) {
-      // Skip Stripe — complete onboarding directly
-      completeFreeOnboarding();
-    } else {
-      goToStep(4);
-    }
-  };
-
-  // ── Cleveland founder: complete without Stripe ────────────────────────────
+  // ── Step 4: Cleveland founder — complete without Stripe ──────────────────
   const completeFreeOnboarding = async () => {
     setSaving(true);
     try {
@@ -291,7 +357,7 @@ export default function OperatorOnboardingStepPage() {
     }
   };
 
-  // ── Step 4: subscribe to a plan ──────────────────────────────────────────
+  // ── Step 4: Subscribe to a paid plan ─────────────────────────────────────
   const selectPlan = async (planKey: string) => {
     setError(null);
     setSaving(true);
@@ -303,7 +369,6 @@ export default function OperatorOnboardingStepPage() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Failed to start checkout.");
-      // Mark onboarding complete before sending to Stripe
       await fetch("/api/operator/onboarding/complete", { method: "POST" });
       window.location.href = data.url;
     } catch (e: any) {
@@ -324,7 +389,6 @@ export default function OperatorOnboardingStepPage() {
   return (
     <div className="min-h-screen bg-neutral-50 flex flex-col items-center py-12 px-4">
       <div className="w-full max-w-xl">
-        {/* Logo */}
         <div className="text-center mb-8">
           <span className="text-xl font-bold text-primary-700">CareLinkAI</span>
         </div>
@@ -381,11 +445,17 @@ export default function OperatorOnboardingStepPage() {
             </div>
           )}
 
-          {/* ── Step 2: First Home ── */}
+          {/* ── Step 2: First Home (or claim seeded home for founders) ── */}
           {step === 2 && (
             <div>
-              <h1 className="text-2xl font-bold text-neutral-900 mb-1">Add your first home</h1>
-              <p className="text-neutral-500 text-sm mb-6">You can add more homes later.</p>
+              <h1 className="text-2xl font-bold text-neutral-900 mb-1">
+                {clevelandFounder && seededHome ? "Confirm your home" : "Add your first home"}
+              </h1>
+              <p className="text-neutral-500 text-sm mb-6">
+                {clevelandFounder && seededHome
+                  ? "We've pre-filled your seeded home. Review and confirm to claim it."
+                  : "You can add more homes later."}
+              </p>
 
               <div className="space-y-4">
                 <div>
@@ -427,7 +497,9 @@ export default function OperatorOnboardingStepPage() {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-neutral-700 mb-1">City <span className="text-error-500">*</span></label>
+                    <label className="block text-sm font-medium text-neutral-700 mb-1">
+                      City <span className="text-error-500">*</span>
+                    </label>
                     <input
                       type="text"
                       className="form-input w-full"
@@ -437,18 +509,24 @@ export default function OperatorOnboardingStepPage() {
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     <div>
-                      <label className="block text-sm font-medium text-neutral-700 mb-1">State <span className="text-error-500">*</span></label>
+                      <label className="block text-sm font-medium text-neutral-700 mb-1">
+                        State <span className="text-error-500">*</span>
+                      </label>
                       <input
                         type="text"
                         maxLength={2}
                         className="form-input w-full uppercase"
                         value={home.state}
-                        onChange={(e) => setHome({ ...home, state: e.target.value.toUpperCase() })}
+                        onChange={(e) =>
+                          setHome({ ...home, state: e.target.value.toUpperCase() })
+                        }
                         placeholder="OH"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-neutral-700 mb-1">ZIP <span className="text-error-500">*</span></label>
+                      <label className="block text-sm font-medium text-neutral-700 mb-1">
+                        ZIP <span className="text-error-500">*</span>
+                      </label>
                       <input
                         type="text"
                         className="form-input w-full"
@@ -458,7 +536,9 @@ export default function OperatorOnboardingStepPage() {
                     </div>
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-neutral-700 mb-1">Capacity <span className="text-error-500">*</span></label>
+                    <label className="block text-sm font-medium text-neutral-700 mb-1">
+                      Capacity <span className="text-error-500">*</span>
+                    </label>
                     <input
                       type="number"
                       min="1"
@@ -505,7 +585,11 @@ export default function OperatorOnboardingStepPage() {
                 disabled={saving}
                 className="btn btn-primary w-full mt-6 flex items-center justify-center gap-2"
               >
-                {saving ? "Saving…" : <>Continue <FiArrowRight /></>}
+                {saving
+                  ? "Saving…"
+                  : clevelandFounder && seededHome
+                  ? <>Claim this home <FiArrowRight /></>
+                  : <>Continue <FiArrowRight /></>}
               </button>
             </div>
           )}
@@ -513,16 +597,19 @@ export default function OperatorOnboardingStepPage() {
           {/* ── Step 3: Claim link (Cleveland founder) ── */}
           {step === 3 && (
             <div>
-              <h1 className="text-2xl font-bold text-neutral-900 mb-1">Cleveland founder access</h1>
+              <h1 className="text-2xl font-bold text-neutral-900 mb-1">
+                Cleveland founder access
+              </h1>
               <p className="text-neutral-500 text-sm mb-6">
-                If you received a CareLinkAI founder claim link, paste it here to unlock 6 months
-                of free access. Otherwise skip to choose a plan.
+                {claimApplied
+                  ? "Your founder access is active — proceed to choose your plan."
+                  : "If you received a CareLinkAI founder claim link, paste it here to unlock 6 months of free access. Otherwise skip to choose a plan."}
               </p>
 
               {claimApplied ? (
                 <div className="rounded-lg bg-success-50 border border-success-200 px-4 py-3 text-sm text-success-800 flex items-center gap-2 mb-6">
                   <FiCheck className="w-4 h-4 flex-shrink-0" />
-                  Claim applied — 6 months of free access unlocked!
+                  Founder access applied — 6 months free unlocked!
                 </div>
               ) : (
                 <div className="space-y-3 mb-6">
@@ -532,13 +619,13 @@ export default function OperatorOnboardingStepPage() {
                   <input
                     type="text"
                     className="form-input w-full font-mono text-xs"
-                    value={claimToken}
-                    onChange={(e) => setClaimToken(e.target.value)}
+                    value={manualToken}
+                    onChange={(e) => setManualToken(e.target.value)}
                     placeholder="Paste your claim token here…"
                   />
                   <button
                     onClick={applyClaimToken}
-                    disabled={saving || !claimToken.trim()}
+                    disabled={saving || !manualToken.trim()}
                     className="btn btn-secondary w-full"
                   >
                     {saving ? "Checking…" : "Apply token"}
@@ -548,77 +635,119 @@ export default function OperatorOnboardingStepPage() {
 
               <div className="flex gap-3">
                 {!claimApplied && (
-                  <button onClick={skipClaim} className="btn btn-ghost flex-1">
+                  <button onClick={proceedFromStep3} className="btn btn-ghost flex-1">
                     Skip — choose a plan
                   </button>
                 )}
                 {claimApplied && (
                   <button
-                    onClick={proceedFromClaim}
-                    disabled={saving}
+                    onClick={proceedFromStep3}
                     className="btn btn-primary flex-1 flex items-center justify-center gap-2"
                   >
-                    {saving ? "Setting up…" : <>Complete setup <FiArrowRight /></>}
+                    Continue to plan <FiArrowRight />
                   </button>
                 )}
               </div>
             </div>
           )}
 
-          {/* ── Step 4: Choose plan ── */}
+          {/* ── Step 4: Choose plan (or free founder card) ── */}
           {step === 4 && (
             <div>
               <h1 className="text-2xl font-bold text-neutral-900 mb-1">Choose a plan</h1>
               <p className="text-neutral-500 text-sm mb-6">
-                14-day free trial on all plans. Cancel anytime.
+                {clevelandFounder
+                  ? "Your founder access is active. Complete setup below."
+                  : "14-day free trial on all plans. Cancel anytime."}
               </p>
 
-              <div className="space-y-3">
-                {PLANS.map((plan) => (
-                  <div
-                    key={plan.key}
-                    className={`rounded-xl border p-4 ${
-                      plan.highlight
-                        ? "border-primary-400 bg-primary-50"
-                        : "border-neutral-200 bg-white"
-                    }`}
-                  >
-                    <div className="flex items-center justify-between mb-2">
-                      <div>
-                        <span className="font-semibold text-neutral-900">{plan.name}</span>
-                        {plan.highlight && (
-                          <span className="ml-2 text-xs font-medium text-primary-700 bg-primary-100 px-2 py-0.5 rounded-full">
-                            Popular
-                          </span>
-                        )}
-                      </div>
-                      <span className="text-lg font-bold text-neutral-900">
-                        {plan.price}
-                        <span className="text-xs font-normal text-neutral-500">/mo</span>
-                      </span>
+              {clevelandFounder ? (
+                /* Cleveland Founder — free card, no Stripe */
+                <div className="rounded-xl border-2 border-success-400 bg-success-50 p-6">
+                  <div className="flex items-center gap-3 mb-3">
+                    <div className="w-10 h-10 rounded-full bg-success-500 flex items-center justify-center">
+                      <FiGift className="text-white" size={20} />
                     </div>
-                    <ul className="text-xs text-neutral-600 space-y-1 mb-3">
-                      {plan.features.map((f) => (
-                        <li key={f} className="flex items-center gap-1.5">
-                          <FiCheck className="w-3 h-3 text-success-500 flex-shrink-0" />
-                          {f}
-                        </li>
-                      ))}
-                    </ul>
-                    <button
-                      onClick={() => selectPlan(plan.key)}
-                      disabled={saving}
-                      className={`w-full text-sm font-medium py-2 rounded-lg transition-colors ${
+                    <div>
+                      <div className="font-semibold text-neutral-900">
+                        Cleveland Founder Program
+                      </div>
+                      <div className="text-success-700 font-bold text-lg">
+                        Free for 6 months
+                      </div>
+                    </div>
+                  </div>
+                  <ul className="text-sm text-neutral-700 space-y-1.5 mb-5">
+                    {[
+                      "Full platform access",
+                      "Unlimited homes",
+                      "AI-powered matching",
+                      "Priority support",
+                      "No credit card required",
+                    ].map((f) => (
+                      <li key={f} className="flex items-center gap-2">
+                        <FiCheck className="w-4 h-4 text-success-500 flex-shrink-0" />
+                        {f}
+                      </li>
+                    ))}
+                  </ul>
+                  <button
+                    onClick={completeFreeOnboarding}
+                    disabled={saving}
+                    className="w-full bg-success-600 hover:bg-success-700 text-white font-semibold py-3 rounded-xl transition-colors flex items-center justify-center gap-2"
+                  >
+                    {saving ? "Setting up…" : <>Complete setup <FiArrowRight /></>}
+                  </button>
+                </div>
+              ) : (
+                /* Paid plans */
+                <div className="space-y-3">
+                  {PLANS.map((plan) => (
+                    <div
+                      key={plan.key}
+                      className={`rounded-xl border p-4 ${
                         plan.highlight
-                          ? "bg-primary-600 text-white hover:bg-primary-700"
-                          : "bg-neutral-100 text-neutral-800 hover:bg-neutral-200"
+                          ? "border-primary-400 bg-primary-50"
+                          : "border-neutral-200 bg-white"
                       }`}
                     >
-                      {saving ? "Loading…" : `Start with ${plan.name}`}
-                    </button>
-                  </div>
-                ))}
-              </div>
+                      <div className="flex items-center justify-between mb-2">
+                        <div>
+                          <span className="font-semibold text-neutral-900">{plan.name}</span>
+                          {plan.highlight && (
+                            <span className="ml-2 text-xs font-medium text-primary-700 bg-primary-100 px-2 py-0.5 rounded-full">
+                              Popular
+                            </span>
+                          )}
+                        </div>
+                        <span className="text-lg font-bold text-neutral-900">
+                          {plan.price}
+                          <span className="text-xs font-normal text-neutral-500">/mo</span>
+                        </span>
+                      </div>
+                      <ul className="text-xs text-neutral-600 space-y-1 mb-3">
+                        {plan.features.map((f) => (
+                          <li key={f} className="flex items-center gap-1.5">
+                            <FiCheck className="w-3 h-3 text-success-500 flex-shrink-0" />
+                            {f}
+                          </li>
+                        ))}
+                      </ul>
+                      <button
+                        onClick={() => selectPlan(plan.key)}
+                        disabled={saving}
+                        className={`w-full text-sm font-medium py-2 rounded-lg transition-colors ${
+                          plan.highlight
+                            ? "bg-primary-600 text-white hover:bg-primary-700"
+                            : "bg-neutral-100 text-neutral-800 hover:bg-neutral-200"
+                        }`}
+                      >
+                        {saving ? "Loading…" : `Start with ${plan.name}`}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/components/onboarding/OnboardingModal.tsx
+++ b/src/components/onboarding/OnboardingModal.tsx
@@ -130,6 +130,10 @@ export default function OnboardingModal() {
     // Only show onboarding for logged-in users
     if (!isClient || !session?.user) return;
 
+    // OPERATOR role uses the dedicated wizard — suppress this modal entirely
+    // so it doesn't conflict with AcceptanceGate's onboarding redirect
+    if (userRole === 'OPERATOR') return;
+
     // Check if onboarding has been completed
     const completed = localStorage.getItem(`${ONBOARDING_KEY}_${userRole}`);
     if (!completed) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug 1 — AcceptanceGate not reached:** Login page now redirects `OPERATOR` role to `/operator` so `AcceptanceGate` in `operator/layout.tsx` can enforce the onboarding/BAA redirect. Previously OPERATOR fell through to `/dashboard` and the wizard gate never fired.
- **Bug 2 — Claim token lost across email verification:** Register API now applies `clevelandFounder`, `freeAccessUntil`, and `seededHomeId` atomically during the signup transaction. No post-signIn `/api/operator/claim` call needed — token survives the redirect.
- **Bug 3 — Wizard Step 2 blank for founders / address 400:** Added `seededHomeId` to `Operator` schema + migration; onboarding status API returns full `seededHome` object; wizard Step 2 pre-populates the seeded home for founders and routes to `POST /api/operator/homes/[id]/claim` to transfer ownership; address wrapped as nested object to fix 400 error; Step 4 shows free founder card (no Stripe/card capture) or 4 paid tiers (Starter $99 / Professional $249 / Growth $499 / Agency $799); `OnboardingModal` suppressed for OPERATOR role.

## Files changed

- `src/app/auth/login/page.tsx` — OPERATOR redirect to `/operator`
- `src/app/api/auth/register/route.ts` — apply claim token at signup time
- `src/app/api/operator/claim/route.ts` — persist `seededHomeId`
- `src/app/api/operator/homes/[id]/claim/route.ts` — new: transfer home ownership
- `src/app/api/operator/homes/route.ts` — field-level 400 errors
- `src/app/api/operator/onboarding/status/route.ts` — return `seededHome` object
- `src/app/operator/onboarding/[step]/page.tsx` — full wizard rewrite (founder vs non-founder paths, 4 tiers, AGENCY)
- `src/components/onboarding/OnboardingModal.tsx` — suppress for OPERATOR
- `prisma/schema.prisma` — `seededHomeId String?` on Operator
- `prisma/migrations/20260602000001_operator_seeded_home/migration.sql` — new migration
- `e2e/operator-onboarding-wizard.spec.ts` — 4-tier check, claim-at-signup, Step 2 pre-population, email-lock tests
- `e2e/auth-register-flow.spec.ts` — founder test updated to reflect at-signup-time claim + `seededHomeId` assertion

## Test plan

- [ ] Register as new OPERATOR → lands at `/operator/onboarding/1` (not `/dashboard`)
- [ ] Complete all 4 wizard steps → plan selection shows Starter / Professional / Growth / Agency
- [ ] Register with `?claimToken=<token>` → `clevelandFounder=true` and `seededHomeId` set immediately after signup (no manual `/api/operator/claim` call)
- [ ] Wizard Step 2 for founder → shows "Confirm your home" with pre-populated name from seeded home
- [ ] "Claim this home" → home transferred to operator, `seededHomeId` cleared
- [ ] Step 4 for founder → free card (no Stripe), not paid tiers
- [ ] Claim token locked to email → different operator gets 403
- [ ] `OnboardingModal` does not appear for OPERATOR role

https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ)_