### PR TITLE
feat(autopopulate): operator profile pre-population from website scraping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ out
 # Playwright test artifacts
 test-results/
 playwright-report/
+
+# Operator website scrape cache
+scripts/scraped-cache/

--- a/prisma/migrations/20260605000001_home_auto_populate_fields/migration.sql
+++ b/prisma/migrations/20260605000001_home_auto_populate_fields/migration.sql
@@ -1,0 +1,8 @@
+-- Add AI auto-population tracking fields to AssistedLivingHome
+ALTER TABLE "AssistedLivingHome"
+  ADD COLUMN IF NOT EXISTS "websiteUrl"             TEXT,
+  ADD COLUMN IF NOT EXISTS "autoPopulatedAt"        TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "autoPopulatedFromUrl"   TEXT,
+  ADD COLUMN IF NOT EXISTS "autoPopulatedVersion"   INTEGER DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "preFilledFields"        JSONB,
+  ADD COLUMN IF NOT EXISTS "aiPopulationConfidence" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -514,12 +514,18 @@ model AssistedLivingHome {
   amenities              String[]
   createdAt              DateTime         @default(now())
   updatedAt              DateTime         @updatedAt
-  aiGeneratedDescription String?
-  highlights             String[]         @default([])
-  lastProfileGenerated   DateTime?
-  slug                   String?          @unique
-  isFeatured             Boolean          @default(false)
-  featuredUntil          DateTime?
+  aiGeneratedDescription  String?
+  highlights              String[]         @default([])
+  lastProfileGenerated    DateTime?
+  slug                    String?          @unique
+  isFeatured              Boolean          @default(false)
+  featuredUntil           DateTime?
+  websiteUrl              String?
+  autoPopulatedAt         DateTime?
+  autoPopulatedFromUrl    String?
+  autoPopulatedVersion    Int?             @default(0)
+  preFilledFields         Json?
+  aiPopulationConfidence  String?
   address                Address?
   operator               Operator         @relation(fields: [operatorId], references: [id], onDelete: Cascade)
   bookings               Booking[]

--- a/scripts/autopopulate-cohort.ts
+++ b/scripts/autopopulate-cohort.ts
@@ -1,0 +1,302 @@
+#!/usr/bin/env npx tsx
+/**
+ * scripts/autopopulate-cohort.ts
+ *
+ * Batch AI profile extraction from operator websites.
+ *
+ * Usage:
+ *   node_modules/.bin/tsx scripts/autopopulate-cohort.ts \
+ *     path/to/first_batch_websites.csv --dry-run
+ *
+ * CSV format:
+ *   homeName,homeId,websiteUrl
+ *   "Canterbury Commons","cmp71kmu9002ulpioyuv8hf5x","https://example.com"
+ *
+ * Flags:
+ *   --dry-run          Run pipeline, show what would update, don't write (default)
+ *   --force            Write results to DB
+ *   --resume           Skip facilities that already have autoPopulatedAt set
+ *   --facility <id>    Process only this homeId
+ */
+
+import { PrismaClient, HomeStatus } from '@prisma/client';
+import { readFileSync } from 'fs';
+import path from 'path';
+import Papa from 'papaparse';
+import { scrapeOperatorWebsite, prepareHtmlForExtraction, ScrapeError } from '../src/lib/operator-profile-scraper';
+import { extractProfileFromWebsite } from '../src/lib/profile-generator/home-profile-generator';
+
+const prisma = new PrismaClient();
+
+// Sonnet 4.6 pricing (per 1M tokens)
+const PRICE_IN_PER_1M = 3.0;
+const PRICE_OUT_PER_1M = 15.0;
+
+function cost(tokensIn: number, tokensOut: number): number {
+  return (tokensIn / 1_000_000) * PRICE_IN_PER_1M + (tokensOut / 1_000_000) * PRICE_OUT_PER_1M;
+}
+
+interface CsvRow {
+  homeName: string;
+  homeId: string;
+  websiteUrl: string;
+}
+
+type FacilityResult =
+  | { status: 'success'; homeId: string; homeName: string; fieldsExtracted: number; confidence: string; dollars: number }
+  | { status: 'skipped'; homeId: string; homeName: string; reason: string }
+  | { status: 'sparse'; homeId: string; homeName: string; confidence: string; dollars: number }
+  | { status: 'blocked'; homeId: string; homeName: string; reason: string };
+
+function parseCsv(filePath: string): CsvRow[] {
+  const csv = readFileSync(filePath, 'utf-8');
+  const result = Papa.parse<CsvRow>(csv, { header: true, skipEmptyLines: true });
+  if (result.errors.length > 0) {
+    throw new Error(`CSV parse errors: ${result.errors.map(e => e.message).join(', ')}`);
+  }
+  return result.data;
+}
+
+async function processRow(
+  row: CsvRow,
+  { dryRun, resume }: { dryRun: boolean; resume: boolean },
+): Promise<FacilityResult> {
+  const { homeName, homeId, websiteUrl } = row;
+
+  // Fetch home from DB
+  const home = await prisma.assistedLivingHome.findUnique({
+    where: { id: homeId },
+    include: { address: true },
+  });
+
+  if (!home) {
+    return { status: 'skipped', homeId, homeName, reason: 'Home not found in DB' };
+  }
+  if (home.status !== HomeStatus.DRAFT) {
+    return { status: 'skipped', homeId, homeName, reason: `status=${home.status} (only DRAFT homes)` };
+  }
+  if (resume && home.autoPopulatedAt) {
+    return { status: 'skipped', homeId, homeName, reason: 'already auto-populated (--resume)' };
+  }
+
+  // Scrape
+  let html: string;
+  let finalUrl: string;
+  try {
+    const scraped = await scrapeOperatorWebsite(websiteUrl);
+    html = scraped.html;
+    finalUrl = scraped.finalUrl;
+  } catch (e) {
+    const err = e instanceof ScrapeError ? e : new ScrapeError('PERMANENT', String(e));
+    return { status: 'blocked', homeId, homeName, reason: err.message };
+  }
+
+  const preparedHtml = prepareHtmlForExtraction(html);
+
+  // Extract
+  let extracted;
+  try {
+    extracted = await extractProfileFromWebsite(
+      {
+        name: home.name,
+        careLevel: home.careLevel,
+        capacity: home.capacity,
+        currentOccupancy: home.currentOccupancy,
+        amenities: home.amenities,
+        address: home.address
+          ? { city: home.address.city, state: home.address.state }
+          : undefined,
+      },
+      preparedHtml,
+      websiteUrl,
+    );
+  } catch (e: any) {
+    return { status: 'blocked', homeId, homeName, reason: `Extraction failed: ${e?.message ?? e}` };
+  }
+
+  const dollars = cost(extracted.tokensIn, extracted.tokensOut);
+
+  // Build update payload
+  const preFilledFields: Record<string, 'AI' | 'SEED'> = {};
+
+  const updateData: Parameters<typeof prisma.assistedLivingHome.update>[0]['data'] = {
+    websiteUrl: websiteUrl,
+    autoPopulatedAt: new Date(),
+    autoPopulatedFromUrl: finalUrl,
+    autoPopulatedVersion: (home.autoPopulatedVersion ?? 0) + 1,
+    aiPopulationConfidence: extracted.extractionConfidence,
+  };
+
+  if (extracted.description) {
+    updateData.description = extracted.description;
+    preFilledFields['description'] = 'AI';
+  }
+
+  if (extracted.amenities.length > 0) {
+    updateData.amenities = extracted.amenities;
+    preFilledFields['amenities'] = 'AI';
+  }
+
+  if (extracted.careLevel.length > 0) {
+    updateData.careLevel = extracted.careLevel as any;
+    preFilledFields['careLevel'] = 'AI';
+  }
+
+  // Address: only update fields that are currently empty or missing
+  const addr = extracted.address;
+  if (addr) {
+    if (!home.address?.street && addr.streetAddress) {
+      preFilledFields['street'] = 'AI';
+    }
+    if (addr.zipCode && !home.address?.zipCode) {
+      preFilledFields['zipCode'] = 'AI';
+    }
+  }
+
+  // Mark existing seed fields (from DOH) as SEED provenance
+  if (home.name) preFilledFields['name'] = 'SEED';
+  if (home.capacity) preFilledFields['capacity'] = 'SEED';
+  if (home.address?.city) preFilledFields['city'] = 'SEED';
+  if (home.address?.state) preFilledFields['state'] = 'SEED';
+
+  updateData.preFilledFields = preFilledFields;
+
+  // Count extracted fields (description + services + amenities + careLevel + address fields)
+  const fieldsExtracted = [
+    extracted.description,
+    extracted.services.length > 0,
+    extracted.amenities.length > 0,
+    extracted.careLevel.length > 0,
+    extracted.address?.streetAddress,
+    extracted.address?.zip,
+    extracted.phone,
+    extracted.contactEmail,
+    extracted.tagline,
+  ].filter(Boolean).length;
+
+  const icon = extracted.extractionConfidence === 'LOW' ? '⚠' : '✓';
+  console.log(
+    `  ${icon} ${homeName} — extracted ${fieldsExtracted} fields (${extracted.extractionConfidence} confidence), $${dollars.toFixed(3)}`,
+  );
+  if (extracted.extractionNotes) {
+    console.log(`    Notes: ${extracted.extractionNotes}`);
+  }
+
+  if (!dryRun) {
+    await prisma.assistedLivingHome.update({ where: { id: homeId }, data: updateData });
+
+    // Upsert address if we got street/zip from AI and home already has an address record
+    if (home.address && addr) {
+      const addrUpdate: Record<string, string> = {};
+      if (!home.address.street && addr.streetAddress) addrUpdate.street = addr.streetAddress;
+      if (!home.address.zipCode && addr.zip) addrUpdate.zipCode = addr.zip;
+      if (Object.keys(addrUpdate).length > 0) {
+        await prisma.address.update({ where: { id: home.address.id }, data: addrUpdate });
+      }
+    }
+  }
+
+  if (extracted.extractionConfidence === 'LOW') {
+    return { status: 'sparse', homeId, homeName, confidence: extracted.extractionConfidence, dollars };
+  }
+  return { status: 'success', homeId, homeName, fieldsExtracted, confidence: extracted.extractionConfidence, dollars };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const csvPath = args.find(a => !a.startsWith('--'));
+  const dryRun = !args.includes('--force') && (args.includes('--dry-run') || !args.includes('--force'));
+  const resume = args.includes('--resume');
+  const facilityFlag = args.indexOf('--facility');
+  const onlyFacilityId = facilityFlag !== -1 ? args[facilityFlag + 1] : null;
+
+  if (!csvPath) {
+    console.error('Usage: autopopulate-cohort.ts <path/to/websites.csv> [--dry-run|--force] [--resume] [--facility <id>]');
+    process.exit(1);
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('ERROR: ANTHROPIC_API_KEY environment variable is not set.');
+    process.exit(1);
+  }
+
+  console.log(dryRun ? '=== DRY RUN — no DB writes ===' : '=== LIVE RUN ===');
+  console.log('');
+
+  let rows: CsvRow[];
+  try {
+    rows = parseCsv(path.resolve(csvPath));
+  } catch (e: any) {
+    console.error(`Failed to parse CSV: ${e.message}`);
+    process.exit(1);
+  }
+
+  if (onlyFacilityId) {
+    rows = rows.filter(r => r.homeId === onlyFacilityId);
+    if (rows.length === 0) {
+      console.error(`No CSV row found with homeId=${onlyFacilityId}`);
+      process.exit(1);
+    }
+  }
+
+  console.log(`Processing ${rows.length} facilit${rows.length === 1 ? 'y' : 'ies'}…\n`);
+
+  const results: FacilityResult[] = [];
+  let totalDollars = 0;
+
+  for (const row of rows) {
+    try {
+      const result = await processRow(row, { dryRun, resume });
+      results.push(result);
+      if (result.status === 'success' || result.status === 'sparse') {
+        totalDollars += result.dollars;
+      }
+    } catch (e: any) {
+      console.error(`  ✗ ${row.homeName} — unexpected error: ${e?.message ?? e}`);
+      results.push({ status: 'blocked', homeId: row.homeId, homeName: row.homeName, reason: `Unexpected: ${e?.message}` });
+    }
+  }
+
+  const succeeded = results.filter(r => r.status === 'success').length;
+  const sparse = results.filter(r => r.status === 'sparse').length;
+  const blocked = results.filter(r => r.status === 'blocked').length;
+  const skipped = results.filter(r => r.status === 'skipped').length;
+
+  console.log('');
+  console.log('─────────────────────────────────────────────────────────');
+  console.log(`${rows.length} facilities processed: ${succeeded} succeeded, ${sparse} sparse, ${blocked} blocked, ${skipped} skipped`);
+  console.log(`Total Anthropic spend:  $${totalDollars.toFixed(3)}`);
+  if (succeeded + sparse > 0) {
+    console.log(`Est. cost per facility: $${(totalDollars / (succeeded + sparse)).toFixed(3)}`);
+  }
+  console.log('─────────────────────────────────────────────────────────');
+
+  if (blocked > 0) {
+    console.log('\nBlocked / failed:');
+    results.filter(r => r.status === 'blocked').forEach(r => {
+      if (r.status === 'blocked') console.log(`  ✗ ${r.homeName}: ${r.reason}`);
+    });
+  }
+  if (skipped > 0) {
+    console.log('\nSkipped:');
+    results.filter(r => r.status === 'skipped').forEach(r => {
+      if (r.status === 'skipped') console.log(`  – ${r.homeName}: ${r.reason}`);
+    });
+  }
+  if (sparse > 0) {
+    console.log('\nSparse extractions (LOW confidence — review before relying on these):');
+    results.filter(r => r.status === 'sparse').forEach(r => {
+      if (r.status === 'sparse') console.log(`  ⚠ ${r.homeName}`);
+    });
+  }
+
+  if (dryRun) {
+    console.log('\nDRY RUN complete. Re-run with --force to write to DB.');
+  } else {
+    console.log('\nLIVE RUN complete. Homes updated in DB.');
+  }
+}
+
+main()
+  .catch(e => { console.error('FATAL:', e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/src/app/admin/homes/[id]/page.tsx
+++ b/src/app/admin/homes/[id]/page.tsx
@@ -160,6 +160,12 @@ type HomeDetail = {
     totalLicenses: number;
     pendingInquiries: number;
   };
+  // AI auto-population (optional — not in all API responses yet)
+  websiteUrl?: string | null;
+  autoPopulatedAt?: string | null;
+  autoPopulatedFromUrl?: string | null;
+  autoPopulatedVersion?: number | null;
+  aiPopulationConfidence?: string | null;
 };
 
 export default function AdminHomeDetailPage({ params }: { params: Promise<{ id: string }> | { id: string } }) {
@@ -748,6 +754,51 @@ export default function AdminHomeDetailPage({ params }: { params: Promise<{ id: 
                     </div>
                   ) : (
                     <p className="text-neutral-500">No photos uploaded</p>
+                  )}
+                </div>
+
+                {/* AI Auto-population status */}
+                <div className="border-t pt-6">
+                  <h3 className="text-sm font-semibold text-neutral-500 uppercase tracking-wide mb-3">
+                    AI Auto-population
+                  </h3>
+                  {(home as any).autoPopulatedAt ? (
+                    <div className="rounded-lg bg-violet-50 border border-violet-200 p-4 text-sm space-y-1.5">
+                      <div className="flex items-center gap-2 text-violet-800 font-medium">
+                        ✨ Pipeline ran on {formatDate((home as any).autoPopulatedAt)}
+                      </div>
+                      <div className="text-neutral-600">
+                        <span className="font-medium">Source URL:</span>{' '}
+                        <a
+                          href={(home as any).autoPopulatedFromUrl ?? (home as any).websiteUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary-600 hover:underline break-all"
+                        >
+                          {(home as any).autoPopulatedFromUrl ?? (home as any).websiteUrl}
+                        </a>
+                      </div>
+                      <div className="text-neutral-600">
+                        <span className="font-medium">Confidence:</span>{' '}
+                        <span className={
+                          (home as any).aiPopulationConfidence === 'HIGH' ? 'text-success-700 font-medium' :
+                          (home as any).aiPopulationConfidence === 'MEDIUM' ? 'text-amber-700 font-medium' :
+                          'text-neutral-500'
+                        }>
+                          {(home as any).aiPopulationConfidence ?? 'N/A'}
+                        </span>
+                      </div>
+                      <div className="text-neutral-600">
+                        <span className="font-medium">Run #:</span>{' '}
+                        {(home as any).autoPopulatedVersion ?? 1}
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-neutral-400 text-sm">
+                      {(home as any).websiteUrl
+                        ? `Website on file: ${(home as any).websiteUrl} — pipeline not yet run.`
+                        : 'No website URL set. Run autopopulate-cohort.ts to populate.'}
+                    </p>
                   )}
                 </div>
               </div>

--- a/src/app/api/operator/onboarding/status/route.ts
+++ b/src/app/api/operator/onboarding/status/route.ts
@@ -42,6 +42,7 @@ export async function GET() {
         description: home.description,
         capacity: home.capacity,
         careLevel: home.careLevel,
+        amenities: home.amenities,
         status: home.status,
         address: home.address
           ? {
@@ -51,6 +52,12 @@ export async function GET() {
               zipCode: home.address.zipCode,
             }
           : null,
+        // AI auto-population fields
+        websiteUrl: home.websiteUrl ?? null,
+        autoPopulatedAt: home.autoPopulatedAt ?? null,
+        autoPopulatedFromUrl: home.autoPopulatedFromUrl ?? null,
+        aiPopulationConfidence: home.aiPopulationConfidence ?? null,
+        preFilledFields: home.preFilledFields ?? null,
       };
     }
   }

--- a/src/app/operator/onboarding/[step]/page.tsx
+++ b/src/app/operator/onboarding/[step]/page.tsx
@@ -25,14 +25,23 @@ interface HomeForm {
   careLevel: string[];
 }
 
+type FieldProvenance = 'AI' | 'SEED' | 'OPERATOR';
+
 interface SeededHome {
   id: string;
   name: string;
   description: string;
   capacity: number;
   careLevel: string[];
+  amenities: string[];
   status: string;
   address: { street: string; city: string; state: string; zipCode: string } | null;
+  // AI auto-population
+  websiteUrl: string | null;
+  autoPopulatedAt: string | null;
+  autoPopulatedFromUrl: string | null;
+  aiPopulationConfidence: string | null;
+  preFilledFields: Record<string, FieldProvenance> | null;
 }
 
 const CARE_LEVELS = [
@@ -139,6 +148,24 @@ function StepIndicator({ current }: { current: StepNum }) {
   );
 }
 
+// ─── Provenance badge ─────────────────────────────────────────────────────────
+
+function ProvenanceBadge({ provenance }: { provenance: FieldProvenance | undefined }) {
+  if (!provenance || provenance === 'OPERATOR') return null;
+  if (provenance === 'AI') {
+    return (
+      <span className="ml-1.5 inline-flex items-center gap-1 text-xs font-medium text-violet-700 bg-violet-50 border border-violet-200 px-1.5 py-0.5 rounded-full">
+        ✨ AI-suggested
+      </span>
+    );
+  }
+  return (
+    <span className="ml-1.5 inline-flex items-center gap-1 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 px-1.5 py-0.5 rounded-full">
+      📋 From OH DOH records
+    </span>
+  );
+}
+
 // ─── Main wizard ──────────────────────────────────────────────────────────────
 
 export default function OperatorOnboardingStepPage() {
@@ -166,6 +193,9 @@ export default function OperatorOnboardingStepPage() {
     careLevel: [],
   });
 
+  // Snapshot of AI-suggested values so operator can reset to them
+  const [aiOriginal, setAiOriginal] = useState<HomeForm | null>(null);
+
   // Only used on Step 3 when the operator manually enters a token
   const [manualToken, setManualToken] = useState("");
   const [claimApplied, setClaimApplied] = useState(false);
@@ -192,8 +222,7 @@ export default function OperatorOnboardingStepPage() {
         }
         if (d.seededHome) {
           setSeededHome(d.seededHome);
-          // Pre-populate Step 2 form with seeded home data
-          setHome({
+          const pre: HomeForm = {
             name: d.seededHome.name ?? "",
             description: d.seededHome.description ?? "",
             street: d.seededHome.address?.street ?? "",
@@ -202,7 +231,10 @@ export default function OperatorOnboardingStepPage() {
             zipCode: d.seededHome.address?.zipCode ?? "",
             capacity: String(d.seededHome.capacity ?? ""),
             careLevel: d.seededHome.careLevel ?? [],
-          });
+          };
+          setHome(pre);
+          // Snapshot AI values so operator can reset later
+          if (d.seededHome.autoPopulatedAt) setAiOriginal(pre);
         }
       })
       .catch(() => {});
@@ -445,154 +477,248 @@ export default function OperatorOnboardingStepPage() {
             </div>
           )}
 
-          {/* ── Step 2: First Home (or claim seeded home for founders) ── */}
-          {step === 2 && (
-            <div>
-              <h1 className="text-2xl font-bold text-neutral-900 mb-1">
-                {clevelandFounder && seededHome ? "Confirm your home" : "Add your first home"}
-              </h1>
-              <p className="text-neutral-500 text-sm mb-6">
-                {clevelandFounder && seededHome
-                  ? "We've pre-filled your seeded home. Review and confirm to claim it."
-                  : "You can add more homes later."}
-              </p>
+          {/* ── Step 2: First Home (or claim / confirm pre-populated home) ── */}
+          {step === 2 && (() => {
+            const isPrePopulated = !!(clevelandFounder && seededHome?.autoPopulatedAt);
+            const pf = seededHome?.preFilledFields ?? {};
+            const prov = (field: string): FieldProvenance | undefined => pf[field] as FieldProvenance | undefined;
+            const sourceDomain = seededHome?.autoPopulatedFromUrl
+              ? (() => { try { return new URL(seededHome.autoPopulatedFromUrl).hostname.replace(/^www\./, ''); } catch { return seededHome.autoPopulatedFromUrl; } })()
+              : null;
 
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-neutral-700 mb-1">
-                    Home name <span className="text-error-500">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    className="form-input w-full"
-                    value={home.name}
-                    onChange={(e) => setHome({ ...home, name: e.target.value })}
-                    placeholder="Sunrise East Wing"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-neutral-700 mb-1">
-                    Description <span className="text-error-500">*</span>
-                  </label>
-                  <textarea
-                    rows={2}
-                    className="form-input w-full"
-                    value={home.description}
-                    onChange={(e) => setHome({ ...home, description: e.target.value })}
-                    placeholder="Warm, community-focused assisted living…"
-                  />
-                </div>
+            return (
+              <div>
+                <h1 className="text-2xl font-bold text-neutral-900 mb-1">
+                  {isPrePopulated
+                    ? `We pre-populated your profile`
+                    : clevelandFounder && seededHome
+                    ? "Confirm your home"
+                    : "Add your first home"}
+                </h1>
+                <p className="text-neutral-500 text-sm mb-1">
+                  {isPrePopulated
+                    ? `Content pulled from ${sourceDomain ?? "your website"}.`
+                    : clevelandFounder && seededHome
+                    ? "We've pre-filled your seeded home. Review and confirm to claim it."
+                    : "You can add more homes later."}
+                </p>
+                {isPrePopulated && (
+                  <p className="text-neutral-400 text-xs mb-5">
+                    Review the fields below. Edit anything that isn't right, then continue.
+                    Nothing is committed until you click <strong>Confirm and continue</strong>.
+                  </p>
+                )}
+                {!isPrePopulated && <div className="mb-6" />}
 
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div className="sm:col-span-2">
-                    <label className="block text-sm font-medium text-neutral-700 mb-1">
-                      Street address <span className="text-error-500">*</span>
-                    </label>
-                    <input
-                      type="text"
-                      className="form-input w-full"
-                      value={home.street}
-                      onChange={(e) => setHome({ ...home, street: e.target.value })}
-                      placeholder="1234 Oak Lane"
-                    />
+                {/* Confidence banner for AI-populated homes */}
+                {isPrePopulated && seededHome?.aiPopulationConfidence && (
+                  <div className={`mb-5 rounded-lg px-4 py-3 text-sm flex items-start gap-2 ${
+                    seededHome.aiPopulationConfidence === 'HIGH'
+                      ? 'bg-violet-50 border border-violet-200 text-violet-800'
+                      : seededHome.aiPopulationConfidence === 'MEDIUM'
+                      ? 'bg-amber-50 border border-amber-200 text-amber-800'
+                      : 'bg-neutral-50 border border-neutral-200 text-neutral-600'
+                  }`}>
+                    <span className="text-base leading-none mt-0.5">✨</span>
+                    <span>
+                      <strong>AI extraction confidence: {seededHome.aiPopulationConfidence}</strong>
+                      {seededHome.aiPopulationConfidence === 'LOW' &&
+                        " — the website had limited content. Please fill in any missing fields."}
+                    </span>
                   </div>
+                )}
+
+                <div className="space-y-4">
+                  {/* Home name */}
                   <div>
                     <label className="block text-sm font-medium text-neutral-700 mb-1">
-                      City <span className="text-error-500">*</span>
+                      Home name <span className="text-error-500">*</span>
+                      <ProvenanceBadge provenance={prov('name')} />
                     </label>
                     <input
                       type="text"
                       className="form-input w-full"
-                      value={home.city}
-                      onChange={(e) => setHome({ ...home, city: e.target.value })}
+                      value={home.name}
+                      onChange={(e) => setHome({ ...home, name: e.target.value })}
+                      placeholder="Sunrise East Wing"
                     />
                   </div>
-                  <div className="grid grid-cols-2 gap-2">
-                    <div>
+
+                  {/* Description */}
+                  <div>
+                    <label className="block text-sm font-medium text-neutral-700 mb-1">
+                      Description <span className="text-error-500">*</span>
+                      <ProvenanceBadge provenance={prov('description')} />
+                    </label>
+                    <textarea
+                      rows={isPrePopulated ? 5 : 2}
+                      className="form-input w-full"
+                      value={home.description}
+                      onChange={(e) => setHome({ ...home, description: e.target.value })}
+                      placeholder="Warm, community-focused assisted living…"
+                    />
+                  </div>
+
+                  {/* Address */}
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div className="sm:col-span-2">
                       <label className="block text-sm font-medium text-neutral-700 mb-1">
-                        State <span className="text-error-500">*</span>
-                      </label>
-                      <input
-                        type="text"
-                        maxLength={2}
-                        className="form-input w-full uppercase"
-                        value={home.state}
-                        onChange={(e) =>
-                          setHome({ ...home, state: e.target.value.toUpperCase() })
-                        }
-                        placeholder="OH"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-neutral-700 mb-1">
-                        ZIP <span className="text-error-500">*</span>
+                        Street address <span className="text-error-500">*</span>
+                        <ProvenanceBadge provenance={prov('street')} />
                       </label>
                       <input
                         type="text"
                         className="form-input w-full"
-                        value={home.zipCode}
-                        onChange={(e) => setHome({ ...home, zipCode: e.target.value })}
+                        value={home.street}
+                        onChange={(e) => setHome({ ...home, street: e.target.value })}
+                        placeholder="1234 Oak Lane"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-neutral-700 mb-1">
+                        City <span className="text-error-500">*</span>
+                        <ProvenanceBadge provenance={prov('city')} />
+                      </label>
+                      <input
+                        type="text"
+                        className="form-input w-full"
+                        value={home.city}
+                        onChange={(e) => setHome({ ...home, city: e.target.value })}
+                      />
+                    </div>
+                    <div className="grid grid-cols-2 gap-2">
+                      <div>
+                        <label className="block text-sm font-medium text-neutral-700 mb-1">
+                          State <span className="text-error-500">*</span>
+                          <ProvenanceBadge provenance={prov('state')} />
+                        </label>
+                        <input
+                          type="text"
+                          maxLength={2}
+                          className="form-input w-full uppercase"
+                          value={home.state}
+                          onChange={(e) =>
+                            setHome({ ...home, state: e.target.value.toUpperCase() })
+                          }
+                          placeholder="OH"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-neutral-700 mb-1">
+                          ZIP <span className="text-error-500">*</span>
+                          <ProvenanceBadge provenance={prov('zipCode')} />
+                        </label>
+                        <input
+                          type="text"
+                          className="form-input w-full"
+                          value={home.zipCode}
+                          onChange={(e) => setHome({ ...home, zipCode: e.target.value })}
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-neutral-700 mb-1">
+                        Capacity <span className="text-error-500">*</span>
+                        <ProvenanceBadge provenance={prov('capacity')} />
+                      </label>
+                      <input
+                        type="number"
+                        min="1"
+                        className="form-input w-full"
+                        value={home.capacity}
+                        onChange={(e) => setHome({ ...home, capacity: e.target.value })}
+                        placeholder="20"
                       />
                     </div>
                   </div>
+
+                  {/* Care types */}
                   <div>
-                    <label className="block text-sm font-medium text-neutral-700 mb-1">
-                      Capacity <span className="text-error-500">*</span>
+                    <label className="block text-sm font-medium text-neutral-700 mb-2">
+                      Care types <span className="text-error-500">*</span>
+                      <ProvenanceBadge provenance={prov('careLevel')} />
                     </label>
-                    <input
-                      type="number"
-                      min="1"
-                      className="form-input w-full"
-                      value={home.capacity}
-                      onChange={(e) => setHome({ ...home, capacity: e.target.value })}
-                      placeholder="20"
-                    />
+                    <div className="flex flex-wrap gap-2">
+                      {CARE_LEVELS.map((cl) => (
+                        <button
+                          key={cl.value}
+                          type="button"
+                          onClick={() =>
+                            setHome((h) => ({
+                              ...h,
+                              careLevel: h.careLevel.includes(cl.value)
+                                ? h.careLevel.filter((v) => v !== cl.value)
+                                : [...h.careLevel, cl.value],
+                            }))
+                          }
+                          className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors ${
+                            home.careLevel.includes(cl.value)
+                              ? "bg-primary-600 text-white border-primary-600"
+                              : "bg-white text-neutral-600 border-neutral-300 hover:border-primary-400"
+                          }`}
+                        >
+                          {cl.label}
+                        </button>
+                      ))}
+                    </div>
                   </div>
+
+                  {/* AI-suggested amenities (read-only preview) */}
+                  {isPrePopulated && seededHome?.amenities && seededHome.amenities.length > 0 && (
+                    <div>
+                      <label className="block text-sm font-medium text-neutral-700 mb-2">
+                        Amenities
+                        <ProvenanceBadge provenance={prov('amenities')} />
+                        <span className="ml-2 text-xs text-neutral-400">(editable after onboarding)</span>
+                      </label>
+                      <div className="flex flex-wrap gap-1.5">
+                        {seededHome.amenities.slice(0, 10).map((a) => (
+                          <span
+                            key={a}
+                            className="px-2.5 py-1 rounded-full text-xs bg-violet-50 text-violet-700 border border-violet-200"
+                          >
+                            {a}
+                          </span>
+                        ))}
+                        {seededHome.amenities.length > 10 && (
+                          <span className="px-2.5 py-1 rounded-full text-xs bg-neutral-100 text-neutral-500">
+                            +{seededHome.amenities.length - 10} more
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </div>
 
-                <div>
-                  <label className="block text-sm font-medium text-neutral-700 mb-2">
-                    Care types <span className="text-error-500">*</span>
-                  </label>
-                  <div className="flex flex-wrap gap-2">
-                    {CARE_LEVELS.map((cl) => (
-                      <button
-                        key={cl.value}
-                        type="button"
-                        onClick={() =>
-                          setHome((h) => ({
-                            ...h,
-                            careLevel: h.careLevel.includes(cl.value)
-                              ? h.careLevel.filter((v) => v !== cl.value)
-                              : [...h.careLevel, cl.value],
-                          }))
-                        }
-                        className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors ${
-                          home.careLevel.includes(cl.value)
-                            ? "bg-primary-600 text-white border-primary-600"
-                            : "bg-white text-neutral-600 border-neutral-300 hover:border-primary-400"
-                        }`}
-                      >
-                        {cl.label}
-                      </button>
-                    ))}
+                {/* Footer: confirm + reset link */}
+                <button
+                  onClick={submitHome}
+                  disabled={saving}
+                  className="btn btn-primary w-full mt-6 flex items-center justify-center gap-2"
+                >
+                  {saving
+                    ? "Saving…"
+                    : isPrePopulated
+                    ? <>Confirm and continue <FiArrowRight /></>
+                    : clevelandFounder && seededHome
+                    ? <>Claim this home <FiArrowRight /></>
+                    : <>Continue <FiArrowRight /></>}
+                </button>
+
+                {isPrePopulated && aiOriginal && (
+                  <div className="mt-3 text-center">
+                    <button
+                      type="button"
+                      onClick={() => setHome(aiOriginal)}
+                      className="text-xs text-neutral-400 hover:text-violet-600 transition-colors underline underline-offset-2"
+                    >
+                      Reset to AI suggestions
+                    </button>
                   </div>
-                </div>
+                )}
               </div>
-
-              <button
-                onClick={submitHome}
-                disabled={saving}
-                className="btn btn-primary w-full mt-6 flex items-center justify-center gap-2"
-              >
-                {saving
-                  ? "Saving…"
-                  : clevelandFounder && seededHome
-                  ? <>Claim this home <FiArrowRight /></>
-                  : <>Continue <FiArrowRight /></>}
-              </button>
-            </div>
-          )}
+            );
+          })()}
 
           {/* ── Step 3: Claim link (Cleveland founder) ── */}
           {step === 3 && (

--- a/src/lib/operator-profile-scraper.ts
+++ b/src/lib/operator-profile-scraper.ts
@@ -1,0 +1,229 @@
+/**
+ * src/lib/operator-profile-scraper.ts
+ *
+ * Fetches HTML from an operator's facility website for AI profile extraction.
+ * - Respects robots.txt
+ * - 30-second timeout
+ * - File-based cache keyed by URL hash (CLI use only — skip cache in server context)
+ * - Categorises failures as TRANSIENT (retry) or PERMANENT (skip)
+ */
+
+import { createHash } from 'crypto';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import path from 'path';
+
+const BOT_USER_AGENT =
+  'CareLinkAI Operator Profile Bot (profyt7@gmail.com) — auto-populating claimed-listing profile';
+const FETCH_TIMEOUT_MS = 30_000;
+
+export type ScrapeErrorCategory = 'TRANSIENT' | 'PERMANENT';
+export type ScrapeFailureReason = 'BLOCKED' | 'NOT_FOUND' | 'JS_ONLY' | 'TIMEOUT' | 'INVALID_URL' | 'OTHER';
+
+export class ScrapeError extends Error {
+  constructor(
+    public readonly category: ScrapeErrorCategory,
+    message: string,
+    public readonly reason?: ScrapeFailureReason,
+  ) {
+    super(message);
+    this.name = 'ScrapeError';
+  }
+}
+
+export interface ScrapeResult {
+  url: string;
+  finalUrl: string;
+  html: string;
+  fetchedAt: string;
+  statusCode: number;
+  fromCache: boolean;
+}
+
+// ── Robots.txt ────────────────────────────────────────────────────────────────
+
+async function isAllowedByRobots(targetUrl: string): Promise<boolean> {
+  try {
+    const base = new URL(targetUrl);
+    const robotsUrl = `${base.protocol}//${base.host}/robots.txt`;
+    const res = await fetch(robotsUrl, {
+      headers: { 'User-Agent': BOT_USER_AGENT },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) return true; // missing robots.txt → allow
+    return parseRobotsTxt(await res.text(), base.pathname || '/');
+  } catch {
+    return true; // network error reading robots.txt → allow (conservative)
+  }
+}
+
+function parseRobotsTxt(content: string, urlPath: string): boolean {
+  const lines = content.split(/\r?\n/);
+  const blocks: { agents: string[]; disallow: string[]; allow: string[] }[] = [];
+  let current: { agents: string[]; disallow: string[]; allow: string[] } | null = null;
+
+  for (const raw of lines) {
+    const line = raw.split('#')[0].trim();
+    if (!line) {
+      if (current) { blocks.push(current); current = null; }
+      continue;
+    }
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim().toLowerCase();
+    const val = line.slice(colon + 1).trim();
+
+    if (key === 'user-agent') {
+      if (!current) current = { agents: [], disallow: [], allow: [] };
+      current.agents.push(val.toLowerCase());
+    } else if (key === 'disallow' && current && val) {
+      current.disallow.push(val);
+    } else if (key === 'allow' && current && val) {
+      current.allow.push(val);
+    }
+  }
+  if (current) blocks.push(current);
+
+  // Prefer our specific UA block, fall back to wildcard
+  const specific = blocks.find(b => b.agents.includes('carelinkai'));
+  const wildcard = blocks.find(b => b.agents.includes('*'));
+  const active = specific ?? wildcard;
+  if (!active) return true;
+
+  const matchesPath = (rule: string) => urlPath.startsWith(rule);
+  const denied = active.disallow.some(matchesPath);
+  const explicitly_allowed = active.allow.some(matchesPath);
+  return !denied || explicitly_allowed;
+}
+
+// ── Cache ─────────────────────────────────────────────────────────────────────
+
+function urlCacheKey(url: string): string {
+  return createHash('sha256').update(url).digest('hex').slice(0, 16);
+}
+
+function readCache(url: string, cacheDir: string): ScrapeResult | null {
+  try {
+    const file = path.join(cacheDir, `${urlCacheKey(url)}.json`);
+    if (!existsSync(file)) return null;
+    return { ...JSON.parse(readFileSync(file, 'utf-8')), fromCache: true };
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(result: Omit<ScrapeResult, 'fromCache'>, cacheDir: string): void {
+  try {
+    mkdirSync(cacheDir, { recursive: true });
+    const file = path.join(cacheDir, `${urlCacheKey(result.url)}.json`);
+    writeFileSync(file, JSON.stringify(result, null, 2));
+  } catch {
+    // non-fatal
+  }
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+export interface ScrapeOptions {
+  useCache?: boolean;
+  cacheDir?: string;
+}
+
+export async function scrapeOperatorWebsite(
+  url: string,
+  { useCache = true, cacheDir }: ScrapeOptions = {},
+): Promise<ScrapeResult> {
+  const resolvedCacheDir =
+    cacheDir ?? path.join(process.cwd(), 'scripts', 'scraped-cache');
+
+  // Validate URL
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new ScrapeError('PERMANENT', `Invalid URL: ${url}`, 'INVALID_URL');
+  }
+
+  // Cache check
+  if (useCache) {
+    const cached = readCache(url, resolvedCacheDir);
+    if (cached) return cached;
+  }
+
+  // Robots.txt check
+  const allowed = await isAllowedByRobots(url);
+  if (!allowed) {
+    throw new ScrapeError('PERMANENT', `robots.txt disallows crawling ${url}`, 'BLOCKED');
+  }
+
+  // Fetch
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        'User-Agent': BOT_USER_AGENT,
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      redirect: 'follow',
+    });
+  } catch (e: any) {
+    if (e?.name === 'AbortError' || e?.name === 'TimeoutError') {
+      throw new ScrapeError('PERMANENT', `Timeout fetching ${url}`, 'TIMEOUT');
+    }
+    throw new ScrapeError('TRANSIENT', `Network error fetching ${url}: ${e?.message ?? e}`);
+  }
+
+  const { status } = response;
+  const finalUrl = response.url || url;
+
+  if (status === 404 || status === 410) {
+    throw new ScrapeError('PERMANENT', `${status} at ${url}`, 'NOT_FOUND');
+  }
+  if (status === 403 || status === 401 || status === 429) {
+    throw new ScrapeError('PERMANENT', `Blocked (${status}) at ${url}`, 'BLOCKED');
+  }
+  if (status === 503 || status === 502) {
+    throw new ScrapeError('PERMANENT', `Anti-bot / WAF (${status}) at ${url}`, 'BLOCKED');
+  }
+  if (!response.ok) {
+    throw new ScrapeError('TRANSIENT', `HTTP ${status} at ${url}`);
+  }
+
+  const html = await response.text();
+
+  // Detect JS-only SPAs: body exists but has very little text content
+  const bodyMatch = /<body[^>]*>([\s\S]*?)<\/body>/i.exec(html);
+  const bodyContent = bodyMatch?.[1] ?? html;
+  const visibleText = bodyContent.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  if (html.length > 1_000 && visibleText.length < 200) {
+    throw new ScrapeError('PERMANENT', `JS-only SPA detected at ${url} (${visibleText.length} visible chars)`, 'JS_ONLY');
+  }
+
+  const result: Omit<ScrapeResult, 'fromCache'> = {
+    url,
+    finalUrl,
+    html,
+    fetchedAt: new Date().toISOString(),
+    statusCode: status,
+  };
+
+  if (useCache) writeCache(result, resolvedCacheDir);
+
+  return { ...result, fromCache: false };
+}
+
+// ── HTML pre-processing for AI extraction ─────────────────────────────────────
+
+const MAX_HTML_CHARS = 80_000;
+
+/** Strip scripts/styles/metadata, keep semantic text content, truncate. */
+export function prepareHtmlForExtraction(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<head[\s\S]*?<\/head>/gi, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\s{3,}/g, '  ')
+    .slice(0, MAX_HTML_CHARS);
+}

--- a/src/lib/profile-generator/home-profile-generator.ts
+++ b/src/lib/profile-generator/home-profile-generator.ts
@@ -354,6 +354,7 @@ Call the extract_profile tool with all fields you can confidently extract.`;
       },
     ],
     tool_choice: { type: 'tool', name: 'extract_profile' },
+    messages: [{ role: 'user', content: userPrompt }],
   });
 
   const tokensIn = response.usage.input_tokens;

--- a/src/lib/profile-generator/home-profile-generator.ts
+++ b/src/lib/profile-generator/home-profile-generator.ts
@@ -212,6 +212,193 @@ function generateFallbackProfile(data: HomeData): GeneratedProfile {
   return { description: description.trim(), highlights: highlights.slice(0, 5) };
 }
 
+// ── Website extraction (Task 3) ───────────────────────────────────────────────
+
+const EXTRACTION_SYSTEM_PROMPT = `You are extracting publicly-available marketing content from an assisted
+living facility's own website to pre-populate their directory listing on
+CareLinkAI.
+
+ABSOLUTE RULES — VIOLATE NONE OF THESE:
+
+1. NEVER extract names of residents, patients, families, or any
+   individuals other than the facility's leadership/management team.
+   If a testimonial includes a resident name, IGNORE that testimonial
+   entirely. Do not summarize testimonials with names removed.
+2. NEVER extract pricing or rates of any kind. Pricing is typically
+   stale on websites and gated behind tours. Set priceMin/priceMax to
+   null.
+3. NEVER extract photos. Photo handling will be added in a separate
+   consent-gated flow.
+4. NEVER extract content that appears to be outdated (e.g., "Now
+   accepting residents for 2024!"). Note in extractionNotes if you see
+   this.
+5. Only extract content suitable for a public marketing listing. If
+   content seems controversial, dated, or unflattering, omit it.
+6. If you cannot confidently extract a field, set it to null and note
+   in extractionNotes. Do not fabricate.
+
+When you see content like "Joe Smith says we changed his mother's life",
+ignore it. When you see content like "Our memory care neighborhood
+features 24-hour nursing", extract that as a service/amenity.`;
+
+const VALID_CARE_LEVELS = ['ASSISTED', 'MEMORY_CARE', 'INDEPENDENT', 'SKILLED_NURSING'] as const;
+
+export interface ExtractedProfile {
+  description: string;
+  shortDescription: string;
+  services: string[];
+  amenities: string[];
+  careLevel: string[];
+  address: {
+    streetAddress: string | null;
+    city: string | null;
+    state: string | null;
+    zip: string | null;
+  } | null;
+  phone: string | null;
+  contactEmail: string | null;
+  tagline: string | null;
+  extractionConfidence: 'HIGH' | 'MEDIUM' | 'LOW';
+  extractionNotes: string | null;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+export async function extractProfileFromWebsite(
+  homeData: HomeData,
+  preparedHtml: string,
+  websiteUrl: string,
+): Promise<ExtractedProfile> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY is required for website extraction');
+  }
+
+  const client = getAnthropicClient();
+
+  const userPrompt = `Extract a directory profile for "${homeData.name}" from the HTML below.
+
+Known seed data (from Ohio DOH records — do NOT contradict unless the site clearly shows otherwise):
+- City: ${homeData.address?.city ?? 'unknown'}
+- State: ${homeData.address?.state ?? 'OH'}
+- Capacity: ${homeData.capacity} beds
+- Website URL: ${websiteUrl}
+
+HTML content:
+---
+${preparedHtml}
+---
+
+Call the extract_profile tool with all fields you can confidently extract.`;
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 2048,
+    system: EXTRACTION_SYSTEM_PROMPT,
+    tools: [
+      {
+        name: 'extract_profile',
+        description: 'Submit the extracted facility profile data',
+        input_schema: {
+          type: 'object' as const,
+          properties: {
+            description: {
+              type: 'string',
+              description: '2-4 paragraph marketing description of the facility',
+            },
+            shortDescription: {
+              type: 'string',
+              description: '1-2 sentence summary for cards and previews',
+            },
+            services: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Services the facility offers',
+            },
+            amenities: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Physical amenities and features',
+            },
+            careLevel: {
+              type: 'array',
+              items: {
+                type: 'string',
+                enum: ['ASSISTED', 'MEMORY_CARE', 'INDEPENDENT', 'SKILLED_NURSING'],
+              },
+              description: 'Care levels offered',
+            },
+            address: {
+              type: 'object',
+              properties: {
+                streetAddress: { type: 'string' },
+                city: { type: 'string' },
+                state: { type: 'string' },
+                zip: { type: 'string' },
+              },
+            },
+            phone: { type: 'string', description: 'Main facility phone number' },
+            contactEmail: { type: 'string', description: 'Contact email address' },
+            tagline: { type: 'string', description: 'Facility tagline or motto' },
+            extractionConfidence: {
+              type: 'string',
+              enum: ['HIGH', 'MEDIUM', 'LOW'],
+              description: 'Overall confidence in the extraction quality',
+            },
+            extractionNotes: {
+              type: 'string',
+              description: "Notes on what couldn't be extracted or caveats",
+            },
+          },
+          required: ['description', 'shortDescription', 'extractionConfidence'],
+        },
+      },
+    ],
+    tool_choice: { type: 'tool', name: 'extract_profile' },
+  });
+
+  const tokensIn = response.usage.input_tokens;
+  const tokensOut = response.usage.output_tokens;
+
+  // Tool use response
+  const toolBlock = response.content.find(b => b.type === 'tool_use');
+  if (!toolBlock || toolBlock.type !== 'tool_use') {
+    throw new Error('Claude did not call extract_profile tool');
+  }
+
+  const raw = toolBlock.input as Record<string, unknown>;
+
+  // Sanitise careLevel — only accept known enum values
+  const rawCareLevel = Array.isArray(raw.careLevel) ? (raw.careLevel as string[]) : [];
+  const careLevel = rawCareLevel.filter(v => (VALID_CARE_LEVELS as readonly string[]).includes(v));
+
+  return {
+    description: String(raw.description ?? ''),
+    shortDescription: String(raw.shortDescription ?? ''),
+    services: Array.isArray(raw.services) ? (raw.services as string[]) : [],
+    amenities: Array.isArray(raw.amenities) ? (raw.amenities as string[]) : [],
+    careLevel,
+    address: raw.address && typeof raw.address === 'object'
+      ? {
+          streetAddress: (raw.address as any).streetAddress ?? null,
+          city: (raw.address as any).city ?? null,
+          state: (raw.address as any).state ?? null,
+          zip: (raw.address as any).zip ?? null,
+        }
+      : null,
+    phone: raw.phone ? String(raw.phone) : null,
+    contactEmail: raw.contactEmail ? String(raw.contactEmail) : null,
+    tagline: raw.tagline ? String(raw.tagline) : null,
+    extractionConfidence: (['HIGH', 'MEDIUM', 'LOW'].includes(String(raw.extractionConfidence))
+      ? raw.extractionConfidence
+      : 'LOW') as 'HIGH' | 'MEDIUM' | 'LOW',
+    extractionNotes: raw.extractionNotes ? String(raw.extractionNotes) : null,
+    tokensIn,
+    tokensOut,
+  };
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
 /**
  * Validate home data before generating profile
  */


### PR DESCRIPTION
## Summary

- **Task 0 finding:** The existing AI Profile Generator (`src/lib/profile-generator/home-profile-generator.ts`) uses `claude-sonnet-4-6`, is cleanly decoupled, and was extended (not replaced). New `extractProfileFromWebsite()` function added alongside the existing `generateHomeProfile()` — zero breaking changes to the existing in-wizard AI button.

- **Schema** — 6 new fields on `AssistedLivingHome`: `websiteUrl`, `autoPopulatedAt`, `autoPopulatedFromUrl`, `autoPopulatedVersion`, `preFilledFields` (Json), `aiPopulationConfidence`. Migration: `20260605000001_home_auto_populate_fields`.

- **Scraper** (`src/lib/operator-profile-scraper.ts`) — respects `robots.txt` (inline parser, no new dep), 30s timeout, file-based URL-hash cache under `scripts/scraped-cache/`, `TRANSIENT` vs `PERMANENT` error categories, JS-SPA detection, HTML pre-processing (strips scripts/styles/head, truncates to 80k chars before sending to Claude).

- **AI extraction** — `extractProfileFromWebsite()` in the existing profile generator, using `claude-sonnet-4-6` with forced tool use for strict JSON output. Safety constraints verbatim in system prompt (no resident names, no pricing, no photos, no stale content). Logs `tokensIn`/`tokensOut` for cost tracking.

- **CLI batch script** (`scripts/autopopulate-cohort.ts`) — CSV input (`homeName,homeId,websiteUrl`). Flags: `--dry-run` (default), `--force`, `--resume`, `--facility <id>`. Per-facility `✓`/`✗`/`⚠` logging with per-facility cost. Total cost summary. Safety: only processes `DRAFT` homes.

- **Wizard Step 2 UX** — When `autoPopulatedAt` is set: heading changes to "We pre-populated your profile from [domain]", confidence banner shown, each field label gets a provenance badge (`✨ AI-suggested` / `📋 From OH DOH records`), AI-extracted amenities shown as a chip preview, CTA reads "Confirm and continue", "Reset to AI suggestions" link at bottom. Falls back to today's UX when `autoPopulatedAt` is null.

- **Status endpoint** — `seededHome` now includes `websiteUrl`, `autoPopulatedAt`, `autoPopulatedFromUrl`, `aiPopulationConfidence`, `preFilledFields`, `amenities` so the wizard has everything it needs in one fetch.

- **Admin homes `[id]` page** — New "AI Auto-population" panel in the overview tab shows pipeline run date, source URL, confidence level, and run number.

## Pre-launch usage

1. Set `ANTHROPIC_API_KEY` in Render environment variables (Anthropic console → API keys).
2. Create CSV: `homeName,homeId,websiteUrl` for first 15 Cleveland facilities.
3. Run dry-run from Render shell:
   ```bash
   node_modules/.bin/tsx scripts/autopopulate-cohort.ts path/to/first_batch.csv --dry-run
   ```
4. Review output, then `--force`.
5. Generate claim links for those homes — operators will see the pre-populated wizard.

## Expected cost

~$0.05–0.10 per facility on Sonnet 4.6. 15 facilities ≈ $0.75–$1.50 total.

## Test plan

- [ ] `prisma migrate deploy` runs cleanly on prod (migration is additive, all columns nullable)
- [ ] `--dry-run` against first-batch CSV shows reasonable previews, no crash
- [ ] `--force` writes `autoPopulatedAt` and `preFilledFields` to DB correctly
- [ ] Wizard Step 2: operator with pre-populated home sees new heading + badges; operator without sees today's form unchanged
- [ ] Spot-check 3 facilities: descriptions read like marketing copy, no resident names, no pricing
- [ ] Test one facility with a testimonial containing a name — verify name absent from output
- [ ] Render shell: `ANTHROPIC_API_KEY` is set before running batch

## Action required before merge

- [ ] Set `ANTHROPIC_API_KEY` in Render env vars

https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ)_