### PR TITLE
fix(scraper): replace em dash in User-Agent with ASCII hyphen

### DIFF
--- a/src/lib/operator-profile-scraper.ts
+++ b/src/lib/operator-profile-scraper.ts
@@ -13,7 +13,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import path from 'path';
 
 const BOT_USER_AGENT =
-  'CareLinkAI Operator Profile Bot (profyt7@gmail.com) — auto-populating claimed-listing profile';
+  'CareLinkAI Operator Profile Bot (profyt7@gmail.com) - auto-populating claimed-listing profile';
 const FETCH_TIMEOUT_MS = 30_000;
 
 export type ScrapeErrorCategory = 'TRANSIENT' | 'PERMANENT';


### PR DESCRIPTION
## Summary

One-character fix. The `BOT_USER_AGENT` constant in `src/lib/operator-profile-scraper.ts` contained an em dash (`—`, U+2014, codepoint 8212) at index 52. HTTP headers must be pure ASCII (ByteString). Node.js's native `fetch` throws `Cannot convert argument to a ByteString because the character at index 52 has a value of 8212 which is greater than 255` — causing all 15 first-batch facility scrapes to fail immediately before any network request was made.

**Fix:** em dash → ASCII hyphen `-`.

## Test plan

- [ ] CI green
- [ ] Re-run `autopopulate-cohort.ts --dry-run` against first_batch.csv after deploy — expect facilities to actually fetch now

https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZCH1EQ6xjcd1D67RSuUhQ)_