### PR TITLE
feat(autopopulate): photo extraction + Cloudinary rehost + operator review UX

### DIFF
--- a/prisma/migrations/20260607000001_photo_autopopulate/migration.sql
+++ b/prisma/migrations/20260607000001_photo_autopopulate/migration.sql
@@ -1,0 +1,12 @@
+-- Photo auto-population (scraped operator marketing photos) + image-rights acknowledgment
+
+-- Provenance fields on HomePhoto so the UI can distinguish auto-populated photos
+-- from operator-uploaded ones and show "remove" affordances.
+ALTER TABLE "HomePhoto"
+  ADD COLUMN IF NOT EXISTS "autoPopulated" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "sourceUrl"     TEXT;
+
+-- Operator acknowledgment that they have rights to use website photos/content.
+-- Recorded when a seeded listing is claimed.
+ALTER TABLE "AssistedLivingHome"
+  ADD COLUMN IF NOT EXISTS "imageRightsAcknowledgedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -526,6 +526,7 @@ model AssistedLivingHome {
   autoPopulatedVersion    Int?             @default(0)
   preFilledFields         Json?
   aiPopulationConfidence  String?
+  imageRightsAcknowledgedAt DateTime?
   address                Address?
   operator               Operator         @relation(fields: [operatorId], references: [id], onDelete: Cascade)
   bookings               Booking[]
@@ -554,15 +555,17 @@ model AssistedLivingHome {
 }
 
 model HomePhoto {
-  id        String             @id @default(cuid())
-  homeId    String
-  url       String
-  caption   String?
-  isPrimary Boolean            @default(false)
-  sortOrder Int                @default(0)
-  createdAt DateTime           @default(now())
-  updatedAt DateTime           @updatedAt
-  home      AssistedLivingHome @relation(fields: [homeId], references: [id], onDelete: Cascade)
+  id            String             @id @default(cuid())
+  homeId        String
+  url           String
+  caption       String?
+  isPrimary     Boolean            @default(false)
+  sortOrder     Int                @default(0)
+  autoPopulated Boolean            @default(false)
+  sourceUrl     String?
+  createdAt     DateTime           @default(now())
+  updatedAt     DateTime           @updatedAt
+  home          AssistedLivingHome @relation(fields: [homeId], references: [id], onDelete: Cascade)
 
   @@index([homeId])
 }

--- a/scripts/autopopulate-cohort.ts
+++ b/scripts/autopopulate-cohort.ts
@@ -16,6 +16,11 @@
  *   --dry-run          Run pipeline, show what would update, don't write (default)
  *   --force            Write results to DB
  *   --resume           Skip facilities that already have autoPopulatedAt set
+ *   --with-photos      Also extract photos: scrape <img> candidates, AI-classify,
+ *                      and (on --force) download + re-host on Cloudinary as
+ *                      auto-populated HomePhoto rows. On --dry-run, classifies
+ *                      only (no download/upload). Requires CLOUDINARY_* env vars
+ *                      on a live run.
  *   --facility <id>    Process only this homeId
  */
 
@@ -23,8 +28,9 @@ import { PrismaClient, HomeStatus } from '@prisma/client';
 import { readFileSync } from 'fs';
 import path from 'path';
 import Papa from 'papaparse';
-import { scrapeOperatorWebsite, prepareHtmlForExtraction, ScrapeError } from '../src/lib/operator-profile-scraper';
-import { extractProfileFromWebsite } from '../src/lib/profile-generator/home-profile-generator';
+import { scrapeOperatorWebsite, prepareHtmlForExtraction, ScrapeError, ImageCandidate } from '../src/lib/operator-profile-scraper';
+import { extractProfileFromWebsite, classifyFacilityImages } from '../src/lib/profile-generator/home-profile-generator';
+import { downloadAndRehost } from '../src/lib/profile-generator/photo-rehost';
 
 const prisma = new PrismaClient();
 
@@ -43,9 +49,9 @@ interface CsvRow {
 }
 
 type FacilityResult =
-  | { status: 'success'; homeId: string; homeName: string; fieldsExtracted: number; confidence: string; dollars: number }
+  | { status: 'success'; homeId: string; homeName: string; fieldsExtracted: number; confidence: string; dollars: number; photosUploaded?: number }
   | { status: 'skipped'; homeId: string; homeName: string; reason: string }
-  | { status: 'sparse'; homeId: string; homeName: string; confidence: string; dollars: number }
+  | { status: 'sparse'; homeId: string; homeName: string; confidence: string; dollars: number; photosUploaded?: number }
   | { status: 'blocked'; homeId: string; homeName: string; reason: string };
 
 function parseCsv(filePath: string): CsvRow[] {
@@ -59,7 +65,7 @@ function parseCsv(filePath: string): CsvRow[] {
 
 async function processRow(
   row: CsvRow,
-  { dryRun, resume }: { dryRun: boolean; resume: boolean },
+  { dryRun, resume, withPhotos }: { dryRun: boolean; resume: boolean; withPhotos: boolean },
 ): Promise<FacilityResult> {
   const { homeName, homeId, websiteUrl } = row;
 
@@ -82,10 +88,12 @@ async function processRow(
   // Scrape
   let html: string;
   let finalUrl: string;
+  let imageCandidates: ImageCandidate[] = [];
   try {
     const scraped = await scrapeOperatorWebsite(websiteUrl);
     html = scraped.html;
     finalUrl = scraped.finalUrl;
+    imageCandidates = scraped.imageCandidates;
   } catch (e) {
     const err = e instanceof ScrapeError ? e : new ScrapeError('PERMANENT', String(e));
     return { status: 'blocked', homeId, homeName, reason: err.message };
@@ -196,10 +204,80 @@ async function processRow(
     }
   }
 
-  if (extracted.extractionConfidence === 'LOW') {
-    return { status: 'sparse', homeId, homeName, confidence: extracted.extractionConfidence, dollars };
+  // ── Photo pipeline (Tasks 1-4) — opt-in via --with-photos ──────────────────
+  let imageDollars = 0;
+  let photosUploaded = 0;
+  if (withPhotos) {
+    try {
+      const classification = await classifyFacilityImages(home.name, imageCandidates);
+      imageDollars = cost(classification.tokensIn, classification.tokensOut);
+      const keptCount = classification.kept.length;
+
+      if (dryRun) {
+        console.log(
+          `    📷 ${imageCandidates.length} candidate(s) → ${keptCount} would be kept ` +
+          `(img classify $${imageDollars.toFixed(3)})`,
+        );
+      } else if (keptCount > 0) {
+        const rehost = await downloadAndRehost(
+          homeId,
+          classification.kept.map((k) => ({ url: k.url, altText: k.altText })),
+        );
+
+        if (rehost.uploaded.length > 0) {
+          // Idempotent re-runs: clear prior auto-populated photos before writing.
+          await prisma.homePhoto.deleteMany({ where: { homeId, autoPopulated: true } });
+          const existingCount = await prisma.homePhoto.count({ where: { homeId } });
+
+          let sortOrder = 0;
+          for (const p of rehost.uploaded) {
+            await prisma.homePhoto.create({
+              data: {
+                homeId,
+                url: p.cloudinaryUrl,
+                caption: p.altText ?? null,
+                autoPopulated: true,
+                sourceUrl: p.sourceUrl,
+                sortOrder: sortOrder,
+                // Make the first photo primary only if the home has none yet.
+                isPrimary: existingCount === 0 && sortOrder === 0,
+              },
+            });
+            sortOrder += 1;
+          }
+          photosUploaded = rehost.uploaded.length;
+        }
+
+        console.log(
+          `    📷 ${imageCandidates.length} candidate(s) → ${keptCount} kept → ` +
+          `${photosUploaded} uploaded (${rehost.skipped.length} skipped) ` +
+          `[img classify $${imageDollars.toFixed(3)}]`,
+        );
+        if (rehost.skipped.length > 0) {
+          rehost.skipped.forEach((s) => console.log(`        ↳ skipped ${s.url}: ${s.reason}`));
+        }
+      } else {
+        console.log(
+          `    📷 ${imageCandidates.length} candidate(s) → 0 kept ` +
+          `[img classify $${imageDollars.toFixed(3)}]`,
+        );
+      }
+    } catch (e: any) {
+      console.log(`    📷 photo pipeline error: ${e?.message ?? e}`);
+    }
   }
-  return { status: 'success', homeId, homeName, fieldsExtracted, confidence: extracted.extractionConfidence, dollars };
+
+  const totalDollars = dollars + imageDollars;
+  console.log(
+    `    💵 cost: text $${dollars.toFixed(3)}` +
+    (withPhotos ? ` + images $${imageDollars.toFixed(3)} = $${totalDollars.toFixed(3)}` : '') +
+    (withPhotos && !dryRun ? ` | photos uploaded: ${photosUploaded}` : ''),
+  );
+
+  if (extracted.extractionConfidence === 'LOW') {
+    return { status: 'sparse', homeId, homeName, confidence: extracted.extractionConfidence, dollars: totalDollars, photosUploaded };
+  }
+  return { status: 'success', homeId, homeName, fieldsExtracted, confidence: extracted.extractionConfidence, dollars: totalDollars, photosUploaded };
 }
 
 async function main() {
@@ -207,11 +285,12 @@ async function main() {
   const csvPath = args.find(a => !a.startsWith('--'));
   const dryRun = !args.includes('--force') && (args.includes('--dry-run') || !args.includes('--force'));
   const resume = args.includes('--resume');
+  const withPhotos = args.includes('--with-photos');
   const facilityFlag = args.indexOf('--facility');
   const onlyFacilityId = facilityFlag !== -1 ? args[facilityFlag + 1] : null;
 
   if (!csvPath) {
-    console.error('Usage: autopopulate-cohort.ts <path/to/websites.csv> [--dry-run|--force] [--resume] [--facility <id>]');
+    console.error('Usage: autopopulate-cohort.ts <path/to/websites.csv> [--dry-run|--force] [--resume] [--with-photos] [--facility <id>]');
     process.exit(1);
   }
 
@@ -220,7 +299,19 @@ async function main() {
     process.exit(1);
   }
 
+  // Photo download + re-host requires Cloudinary; only enforced on a live run.
+  if (withPhotos && !dryRun) {
+    const missing = ['CLOUDINARY_CLOUD_NAME', 'CLOUDINARY_API_KEY', 'CLOUDINARY_API_SECRET'].filter(
+      (k) => !process.env[k],
+    );
+    if (missing.length > 0) {
+      console.error(`ERROR: --with-photos requires Cloudinary env vars. Missing: ${missing.join(', ')}`);
+      process.exit(1);
+    }
+  }
+
   console.log(dryRun ? '=== DRY RUN — no DB writes ===' : '=== LIVE RUN ===');
+  if (withPhotos) console.log(`=== Photo extraction ENABLED ${dryRun ? '(classify only — no download/upload on dry-run)' : '(download + Cloudinary re-host)'} ===`);
   console.log('');
 
   let rows: CsvRow[];
@@ -246,7 +337,7 @@ async function main() {
 
   for (const row of rows) {
     try {
-      const result = await processRow(row, { dryRun, resume });
+      const result = await processRow(row, { dryRun, resume, withPhotos });
       results.push(result);
       if (result.status === 'success' || result.status === 'sparse') {
         totalDollars += result.dollars;
@@ -262,10 +353,18 @@ async function main() {
   const blocked = results.filter(r => r.status === 'blocked').length;
   const skipped = results.filter(r => r.status === 'skipped').length;
 
+  const totalPhotos = results.reduce(
+    (sum, r) => sum + ((r.status === 'success' || r.status === 'sparse') ? (r.photosUploaded ?? 0) : 0),
+    0,
+  );
+
   console.log('');
   console.log('─────────────────────────────────────────────────────────');
   console.log(`${rows.length} facilities processed: ${succeeded} succeeded, ${sparse} sparse, ${blocked} blocked, ${skipped} skipped`);
   console.log(`Total Anthropic spend:  $${totalDollars.toFixed(3)}`);
+  if (withPhotos && !dryRun) {
+    console.log(`Total photos uploaded:  ${totalPhotos}`);
+  }
   if (succeeded + sparse > 0) {
     console.log(`Est. cost per facility: $${(totalDollars / (succeeded + sparse)).toFixed(3)}`);
   }

--- a/src/app/api/operator/homes/[id]/claim/route.ts
+++ b/src/app/api/operator/homes/[id]/claim/route.ts
@@ -20,12 +20,21 @@ import { UserRole } from '@prisma/client';
  *   - operator.seededHomeId → null (claimed, no longer pending)
  */
 export async function POST(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: { id: string } }
 ) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.email) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Optional body: { imageRightsAcknowledged?: boolean }
+  let imageRightsAcknowledged = false;
+  try {
+    const body = await req.json();
+    imageRightsAcknowledged = body?.imageRightsAcknowledged === true;
+  } catch {
+    // No / invalid body — treat as not acknowledged.
   }
 
   const user = await prisma.user.findUnique({ where: { email: session.user.email } });
@@ -54,17 +63,30 @@ export async function POST(
 
   const home = await prisma.assistedLivingHome.findUnique({
     where: { id: params.id },
-    include: { address: true },
+    include: { address: true, _count: { select: { photos: { where: { autoPopulated: true } } } } },
   });
   if (!home) {
     return NextResponse.json({ error: 'Home not found' }, { status: 404 });
+  }
+
+  // If the listing carries auto-populated (scraped) photos, the operator must
+  // confirm they have rights to use their website's photos/content (Task 6).
+  if (home._count.photos > 0 && !imageRightsAcknowledged) {
+    return NextResponse.json(
+      { error: 'Image rights acknowledgment is required to claim a listing with pre-populated photos.' },
+      { status: 400 }
+    );
   }
 
   // Transfer ownership in a transaction
   const [updatedHome] = await prisma.$transaction([
     prisma.assistedLivingHome.update({
       where: { id: params.id },
-      data: { operatorId: operator.id, status: 'ACTIVE' },
+      data: {
+        operatorId: operator.id,
+        status: 'ACTIVE',
+        ...(imageRightsAcknowledged ? { imageRightsAcknowledgedAt: new Date() } : {}),
+      },
       include: { address: true },
     }),
     prisma.operator.update({

--- a/src/app/api/operator/onboarding/seeded-photo/[photoId]/route.ts
+++ b/src/app/api/operator/onboarding/seeded-photo/[photoId]/route.ts
@@ -1,0 +1,83 @@
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { UserRole } from '@prisma/client';
+import { createHash } from 'crypto';
+import { deleteFromCloudinary, isCloudinaryConfigured } from '@/lib/cloudinary';
+import { captureError } from '@/lib/sentry';
+
+/**
+ * DELETE /api/operator/onboarding/seeded-photo/[photoId]
+ *
+ * Lets an operator remove an auto-populated (scraped) photo from their seeded
+ * listing during onboarding Step 2 — before the listing is claimed, when they
+ * are not yet home.operatorId. Authorized when the photo's home is the
+ * operator's assigned seeded home (or, post-claim, the operator owns it).
+ *
+ * Only auto-populated photos can be removed through this route.
+ */
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { photoId: string } }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+    if (!user || user.role !== UserRole.OPERATOR) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const operator = await prisma.operator.findUnique({ where: { userId: user.id } });
+    if (!operator) {
+      return NextResponse.json({ error: 'Operator not found' }, { status: 404 });
+    }
+
+    const photo = await prisma.homePhoto.findUnique({ where: { id: params.photoId } });
+    if (!photo) {
+      return NextResponse.json({ error: 'Photo not found' }, { status: 404 });
+    }
+    if (!photo.autoPopulated) {
+      return NextResponse.json({ error: 'Only auto-populated photos can be removed here' }, { status: 400 });
+    }
+
+    // Authorize: the photo's home must be this operator's seeded home, or one
+    // they already own.
+    const ownsViaSeed = operator.seededHomeId === photo.homeId;
+    let ownsViaListing = false;
+    if (!ownsViaSeed) {
+      const home = await prisma.assistedLivingHome.findUnique({ where: { id: photo.homeId } });
+      ownsViaListing = !!home && home.operatorId === operator.id;
+    }
+    if (!ownsViaSeed && !ownsViaListing) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Best-effort Cloudinary cleanup. public_id is deterministic from the
+    // source URL (see photo-rehost.ts), so we can reconstruct it.
+    if (photo.sourceUrl && isCloudinaryConfigured()) {
+      try {
+        const hash = createHash('sha256').update(photo.sourceUrl).digest('hex').slice(0, 16);
+        const publicId = `operator-profiles/seeded/${photo.homeId}/${hash}`;
+        await deleteFromCloudinary(publicId, 'image');
+      } catch {
+        // Orphaned Cloudinary asset is acceptable; DB row removal is what matters.
+      }
+    }
+
+    await prisma.homePhoto.delete({ where: { id: photo.id } });
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    captureError(e instanceof Error ? e : new Error(String(e)), {
+      tags: { route: 'operator:onboarding:seeded-photo:{photoId}' },
+    });
+    console.error('Delete seeded photo failed', e);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/operator/onboarding/status/route.ts
+++ b/src/app/api/operator/onboarding/status/route.ts
@@ -33,7 +33,13 @@ export async function GET() {
   if (operator.seededHomeId) {
     const home = await prisma.assistedLivingHome.findUnique({
       where: { id: operator.seededHomeId },
-      include: { address: true },
+      include: {
+        address: true,
+        photos: {
+          where: { autoPopulated: true },
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
     });
     if (home) {
       seededHome = {
@@ -58,6 +64,13 @@ export async function GET() {
         autoPopulatedFromUrl: home.autoPopulatedFromUrl ?? null,
         aiPopulationConfidence: home.aiPopulationConfidence ?? null,
         preFilledFields: home.preFilledFields ?? null,
+        imageRightsAcknowledgedAt: home.imageRightsAcknowledgedAt ?? null,
+        // Auto-populated (scraped + AI-screened) marketing photos for review
+        photos: home.photos.map((p) => ({
+          id: p.id,
+          url: p.url,
+          caption: p.caption ?? null,
+        })),
       };
     }
   }

--- a/src/app/operator/onboarding/[step]/page.tsx
+++ b/src/app/operator/onboarding/[step]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { FiCheck, FiArrowRight, FiHome, FiUser, FiZap, FiGift } from "react-icons/fi";
+import { FiCheck, FiArrowRight, FiHome, FiUser, FiZap, FiGift, FiX } from "react-icons/fi";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -27,6 +27,12 @@ interface HomeForm {
 
 type FieldProvenance = 'AI' | 'SEED' | 'OPERATOR';
 
+interface SeededPhoto {
+  id: string;
+  url: string;
+  caption: string | null;
+}
+
 interface SeededHome {
   id: string;
   name: string;
@@ -42,6 +48,8 @@ interface SeededHome {
   autoPopulatedFromUrl: string | null;
   aiPopulationConfidence: string | null;
   preFilledFields: Record<string, FieldProvenance> | null;
+  imageRightsAcknowledgedAt: string | null;
+  photos: SeededPhoto[];
 }
 
 const CARE_LEVELS = [
@@ -196,6 +204,12 @@ export default function OperatorOnboardingStepPage() {
   // Snapshot of AI-suggested values so operator can reset to them
   const [aiOriginal, setAiOriginal] = useState<HomeForm | null>(null);
 
+  // Auto-populated (scraped) photos shown for review in Step 2
+  const [photos, setPhotos] = useState<SeededPhoto[]>([]);
+  const [removingPhotoId, setRemovingPhotoId] = useState<string | null>(null);
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+  const [imageRightsAck, setImageRightsAck] = useState(false);
+
   // Only used on Step 3 when the operator manually enters a token
   const [manualToken, setManualToken] = useState("");
   const [claimApplied, setClaimApplied] = useState(false);
@@ -235,6 +249,8 @@ export default function OperatorOnboardingStepPage() {
           setHome(pre);
           // Snapshot AI values so operator can reset later
           if (d.seededHome.autoPopulatedAt) setAiOriginal(pre);
+          if (Array.isArray(d.seededHome.photos)) setPhotos(d.seededHome.photos);
+          if (d.seededHome.imageRightsAcknowledgedAt) setImageRightsAck(true);
         }
       })
       .catch(() => {});
@@ -292,6 +308,12 @@ export default function OperatorOnboardingStepPage() {
     if (home.careLevel.length === 0) { setError("Select at least one care type."); return; }
     if (!home.capacity || parseInt(home.capacity) < 1) { setError("Capacity must be at least 1."); return; }
 
+    // Claiming a listing requires confirming rights to the website's content.
+    if (clevelandFounder && seededHome && !imageRightsAck) {
+      setError("Please confirm you have rights to use your website's photos and content.");
+      return;
+    }
+
     setError(null);
     setSaving(true);
     try {
@@ -299,6 +321,8 @@ export default function OperatorOnboardingStepPage() {
         // Transfer the seeded home to this operator instead of creating a new one
         const res = await fetch(`/api/operator/homes/${seededHome.id}/claim`, {
           method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ imageRightsAcknowledged: imageRightsAck }),
         });
         if (!res.ok) {
           const errData = await res.json().catch(() => ({}));
@@ -336,6 +360,25 @@ export default function OperatorOnboardingStepPage() {
       setError(e.message || "Something went wrong.");
     } finally {
       setSaving(false);
+    }
+  };
+
+  // ── Step 2: Remove an auto-populated photo ───────────────────────────────
+  const removePhoto = async (photoId: string) => {
+    setRemovingPhotoId(photoId);
+    // Optimistic removal — restore on failure.
+    const prev = photos;
+    setPhotos((ps) => ps.filter((p) => p.id !== photoId));
+    try {
+      const res = await fetch(`/api/operator/onboarding/seeded-photo/${photoId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to remove photo.");
+    } catch {
+      setPhotos(prev); // restore
+      setError("Couldn't remove that photo — please try again.");
+    } finally {
+      setRemovingPhotoId(null);
     }
   };
 
@@ -688,13 +731,68 @@ export default function OperatorOnboardingStepPage() {
                       </div>
                     </div>
                   )}
+                  {/* Auto-populated photos (Task 5) */}
+                  {photos.length > 0 && (
+                    <div>
+                      <label className="block text-sm font-medium text-neutral-700 mb-1">
+                        Photos
+                        <ProvenanceBadge provenance={'AI'} />
+                      </label>
+                      <p className="text-xs text-neutral-500 mb-3">
+                        We pre-populated these photos from your website. Click ✕ to remove
+                        any image — only the ones you keep will appear on your public listing.
+                      </p>
+                      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+                        {photos.map((p) => (
+                          <div
+                            key={p.id}
+                            className="group relative aspect-square overflow-hidden rounded-xl shadow-sm border border-neutral-200 bg-neutral-100"
+                          >
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img
+                              src={p.url}
+                              alt={p.caption ?? "Facility photo"}
+                              loading="lazy"
+                              className="h-full w-full object-cover cursor-pointer transition-transform duration-300 group-hover:scale-105"
+                              onClick={() => setLightboxUrl(p.url)}
+                            />
+                            <button
+                              type="button"
+                              aria-label="Remove photo"
+                              disabled={removingPhotoId === p.id}
+                              onClick={() => removePhoto(p.id)}
+                              className="absolute top-1.5 right-1.5 h-7 w-7 rounded-full bg-black/55 text-white flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100 hover:bg-error-600 transition-all disabled:opacity-40"
+                            >
+                              <FiX size={15} />
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
+
+                {/* Image rights acknowledgment (Task 6) — required to claim a listing */}
+                {clevelandFounder && seededHome && (
+                  <label className="mt-6 flex items-start gap-2.5 text-sm text-neutral-600 cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      checked={imageRightsAck}
+                      onChange={(e) => setImageRightsAck(e.target.checked)}
+                      className="mt-0.5 h-4 w-4 rounded border-neutral-300 text-primary-600 focus:ring-primary-500"
+                    />
+                    <span>
+                      By claiming this listing, I confirm I have rights to use the photos
+                      and content from my website on CareLinkAI.
+                    </span>
+                  </label>
+                )}
 
                 {/* Footer: confirm + reset link */}
                 <button
                   onClick={submitHome}
                   disabled={saving}
-                  className="btn btn-primary w-full mt-6 flex items-center justify-center gap-2"
+                  className="btn btn-primary w-full mt-4 flex items-center justify-center gap-2"
                 >
                   {saving
                     ? "Saving…"
@@ -878,6 +976,30 @@ export default function OperatorOnboardingStepPage() {
           )}
         </div>
       </div>
+
+      {/* Photo lightbox */}
+      {lightboxUrl && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+          onClick={() => setLightboxUrl(null)}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={lightboxUrl}
+            alt="Facility photo"
+            className="max-h-[90vh] max-w-[90vw] rounded-lg shadow-2xl object-contain"
+            onClick={(e) => e.stopPropagation()}
+          />
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={() => setLightboxUrl(null)}
+            className="absolute top-4 right-4 h-10 w-10 rounded-full bg-white/15 text-white flex items-center justify-center hover:bg-white/30 transition-colors"
+          >
+            <FiX size={20} />
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/__tests__/operator-profile-scraper.images.test.ts
+++ b/src/lib/__tests__/operator-profile-scraper.images.test.ts
@@ -1,0 +1,78 @@
+import { extractImageCandidates } from "@/lib/operator-profile-scraper";
+
+const BASE = "https://sunshinevalleycare.example.com/about";
+
+describe("extractImageCandidates", () => {
+  it("keeps facility photos and resolves relative URLs to absolute", () => {
+    const html = `
+      <main>
+        <img src="/images/dining-room.jpg" alt="Our dining room" width="800" height="600" />
+        <img src="https://cdn.example.com/garden.jpg" alt="Garden courtyard" />
+      </main>`;
+    const out = extractImageCandidates(html, BASE);
+    const urls = out.map((c) => c.url);
+    expect(urls).toContain("https://sunshinevalleycare.example.com/images/dining-room.jpg");
+    expect(urls).toContain("https://cdn.example.com/garden.jpg");
+    expect(out.find((c) => c.url.endsWith("dining-room.jpg"))?.altText).toBe("Our dining room");
+  });
+
+  it("drops images in nav/header/footer and logos/icons/social/award", () => {
+    const html = `
+      <header><img src="/logo.png" alt="Company logo" /></header>
+      <nav><img src="/menu-icon.png" alt="menu" /></nav>
+      <main>
+        <img src="/facebook-badge.png" alt="Find us on Facebook" />
+        <img src="/award-2023.png" alt="Best of award" />
+        <img src="/real-photo.jpg" alt="Common lounge" />
+      </main>
+      <footer><img src="/footer-logo.png" alt="logo" /></footer>`;
+    const urls = extractImageCandidates(html, BASE).map((c) => c.url);
+    expect(urls).toEqual(["https://sunshinevalleycare.example.com/real-photo.jpg"]);
+  });
+
+  it("skips images explicitly smaller than 300x200 via attributes", () => {
+    const html = `
+      <main>
+        <img src="/tiny.jpg" alt="thumb" width="120" height="90" />
+        <img src="/big.jpg" alt="suite" width="1024" height="768" />
+      </main>`;
+    const urls = extractImageCandidates(html, BASE).map((c) => c.url);
+    expect(urls).toEqual(["https://sunshinevalleycare.example.com/big.jpg"]);
+  });
+
+  it("handles lazy-loading via data-src and srcset (largest)", () => {
+    const html = `
+      <main>
+        <img data-src="/lazy-suite.jpg" alt="suite" />
+        <img srcset="/small.jpg 320w, /large.jpg 1200w" alt="patio" />
+      </main>`;
+    const urls = extractImageCandidates(html, BASE).map((c) => c.url);
+    expect(urls).toContain("https://sunshinevalleycare.example.com/lazy-suite.jpg");
+    expect(urls).toContain("https://sunshinevalleycare.example.com/large.jpg");
+    expect(urls).not.toContain("https://sunshinevalleycare.example.com/small.jpg");
+  });
+
+  it("filters stock/placeholder/data hosts and data: URIs", () => {
+    const html = `
+      <main>
+        <img src="https://images.unsplash.com/photo-123.jpg" alt="stock" />
+        <img src="https://placehold.co/600x400" alt="placeholder" />
+        <img src="data:image/png;base64,iVBORw0KGgo=" alt="inline" />
+        <img src="/authentic.jpg" alt="bedroom" />
+      </main>`;
+    const urls = extractImageCandidates(html, BASE).map((c) => c.url);
+    expect(urls).toEqual(["https://sunshinevalleycare.example.com/authentic.jpg"]);
+  });
+
+  it("de-duplicates and caps at 12 candidates", () => {
+    const imgs = Array.from({ length: 20 }, (_, i) => `<img src="/p${i}.jpg" alt="room ${i}" />`).join("");
+    const dup = `<img src="/p0.jpg" alt="dup" />`;
+    const out = extractImageCandidates(`<main>${imgs}${dup}</main>`, BASE);
+    expect(out.length).toBe(12);
+    expect(new Set(out.map((c) => c.url)).size).toBe(12);
+  });
+
+  it("returns an empty array for JS-only / empty bodies", () => {
+    expect(extractImageCandidates("<div id='root'></div>", BASE)).toEqual([]);
+  });
+});

--- a/src/lib/operator-profile-scraper.ts
+++ b/src/lib/operator-profile-scraper.ts
@@ -30,6 +30,12 @@ export class ScrapeError extends Error {
   }
 }
 
+export interface ImageCandidate {
+  url: string;
+  altText: string | null;
+  contextHint: string | null;
+}
+
 export interface ScrapeResult {
   url: string;
   finalUrl: string;
@@ -37,6 +43,7 @@ export interface ScrapeResult {
   fetchedAt: string;
   statusCode: number;
   fromCache: boolean;
+  imageCandidates: ImageCandidate[];
 }
 
 // ── Robots.txt ────────────────────────────────────────────────────────────────
@@ -146,7 +153,15 @@ export async function scrapeOperatorWebsite(
   // Cache check
   if (useCache) {
     const cached = readCache(url, resolvedCacheDir);
-    if (cached) return cached;
+    if (cached) {
+      // Older cache entries (pre photo-extraction) won't have imageCandidates —
+      // recompute from the cached HTML so callers always get a populated array.
+      return {
+        ...cached,
+        imageCandidates:
+          cached.imageCandidates ?? extractImageCandidates(cached.html, cached.finalUrl),
+      };
+    }
   }
 
   // Robots.txt check
@@ -206,6 +221,7 @@ export async function scrapeOperatorWebsite(
     html,
     fetchedAt: new Date().toISOString(),
     statusCode: status,
+    imageCandidates: extractImageCandidates(html, finalUrl),
   };
 
   if (useCache) writeCache(result, resolvedCacheDir);
@@ -226,4 +242,146 @@ export function prepareHtmlForExtraction(html: string): string {
     .replace(/<!--[\s\S]*?-->/g, '')
     .replace(/\s{3,}/g, '  ')
     .slice(0, MAX_HTML_CHARS);
+}
+
+// ── Image candidate extraction (Task 1) ────────────────────────────────────────
+
+const MAX_IMAGE_CANDIDATES = 12;
+
+// Substrings in src/alt/class/id that strongly imply non-facility imagery.
+const IMG_BLOCK_KEYWORDS = [
+  'logo', 'icon', 'badge', 'award', 'favicon', 'sprite', 'spacer', 'pixel',
+  'facebook', 'twitter', 'linkedin', 'instagram', 'youtube', 'tiktok', 'pinterest',
+  'social', 'avatar', 'placeholder', 'loading', 'spinner', 'arrow', 'chevron',
+];
+
+// Domains that host stock / placeholder / tracking images, never facility photos.
+const STOCK_IMAGE_HOSTS = [
+  'placehold.co', 'placeholder.com', 'via.placeholder.com', 'placekitten.com',
+  'unsplash.com', 'images.unsplash.com', 'pexels.com', 'pixabay.com',
+  'gravatar.com', 'googletagmanager.com', 'google-analytics.com',
+  'doubleclick.net', 'facebook.com', 'fbcdn.net', 'gstatic.com',
+];
+
+/** Read an HTML attribute value from a single tag string (case-insensitive). */
+function getAttr(tag: string, name: string): string | null {
+  const re = new RegExp(`${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>]+))`, 'i');
+  const m = re.exec(tag);
+  if (!m) return null;
+  return (m[2] ?? m[3] ?? m[4] ?? '').trim() || null;
+}
+
+/** Pick the largest URL from a srcset attribute ("url 320w, url2 640w" or "url 1x, url2 2x"). */
+function pickFromSrcset(srcset: string): string | null {
+  const entries = srcset
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => {
+      const [u, descriptor] = s.split(/\s+/, 2);
+      const w = descriptor && /(\d+)w/.exec(descriptor);
+      const x = descriptor && /([\d.]+)x/.exec(descriptor);
+      const weight = w ? parseInt(w[1], 10) : x ? parseFloat(x[1]) * 1000 : 0;
+      return { url: u, weight };
+    })
+    .filter((e) => e.url);
+  if (entries.length === 0) return null;
+  entries.sort((a, b) => b.weight - a.weight);
+  return entries[0].url;
+}
+
+/** Resolve a possibly-relative URL against the page's final URL; null if unusable. */
+function resolveUrl(raw: string, baseUrl: string): string | null {
+  const src = raw.trim();
+  if (!src || src.startsWith('data:') || src.startsWith('javascript:')) return null;
+  try {
+    const resolved = new URL(src, baseUrl);
+    if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') return null;
+    return resolved.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isBlockedByKeyword(haystack: string): boolean {
+  const lower = haystack.toLowerCase();
+  return IMG_BLOCK_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+function isStockHost(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return STOCK_IMAGE_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extract candidate facility-photo URLs from raw HTML.
+ *
+ * Heuristic, regex-based (no DOM): we drop <nav>/<header>/<footer> blocks, then
+ * scan remaining <img> tags. Handles lazy-loading (data-src / srcset). Images
+ * declared smaller than 300x200 via width/height attrs are skipped as
+ * likely icons. Background-image CSS is out of scope (lower yield on those).
+ *
+ * Returns up to 12 de-duplicated candidates; downstream AI filtering trims to 8.
+ */
+export function extractImageCandidates(html: string, baseUrl: string): ImageCandidate[] {
+  // Remove chrome regions that almost never contain facility photos.
+  const body = html
+    .replace(/<nav[\s\S]*?<\/nav>/gi, '')
+    .replace(/<header[\s\S]*?<\/header>/gi, '')
+    .replace(/<footer[\s\S]*?<\/footer>/gi, '')
+    .replace(/<svg[\s\S]*?<\/svg>/gi, '');
+
+  const candidates: ImageCandidate[] = [];
+  const seen = new Set<string>();
+
+  const imgTagRe = /<img\b[^>]*>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = imgTagRe.exec(body)) !== null) {
+    const tag = match[0];
+
+    // Resolve a usable source, preferring eager src then common lazy-load attrs.
+    const srcset = getAttr(tag, 'srcset') || getAttr(tag, 'data-srcset');
+    const rawSrc =
+      getAttr(tag, 'src') ||
+      getAttr(tag, 'data-src') ||
+      getAttr(tag, 'data-lazy-src') ||
+      getAttr(tag, 'data-original') ||
+      (srcset ? pickFromSrcset(srcset) : null);
+    if (!rawSrc) continue;
+
+    const url = resolveUrl(rawSrc, baseUrl);
+    if (!url || seen.has(url)) continue;
+
+    if (isStockHost(url)) continue;
+
+    const alt = getAttr(tag, 'alt');
+    const cls = getAttr(tag, 'class') ?? '';
+    const id = getAttr(tag, 'id') ?? '';
+
+    // Keyword blocklist across src path, alt, class, id.
+    const meta = `${url} ${alt ?? ''} ${cls} ${id}`;
+    if (isBlockedByKeyword(meta)) continue;
+
+    // Dimension filter — only when explicit numeric width/height attrs exist.
+    const wAttr = getAttr(tag, 'width');
+    const hAttr = getAttr(tag, 'height');
+    const w = wAttr && /^\d+$/.test(wAttr) ? parseInt(wAttr, 10) : null;
+    const h = hAttr && /^\d+$/.test(hAttr) ? parseInt(hAttr, 10) : null;
+    if ((w !== null && w < 300) || (h !== null && h < 200)) continue;
+
+    seen.add(url);
+    candidates.push({
+      url,
+      altText: alt,
+      contextHint: (cls || id) ? `${cls} ${id}`.trim() : null,
+    });
+
+    if (candidates.length >= MAX_IMAGE_CANDIDATES) break;
+  }
+
+  return candidates;
 }

--- a/src/lib/profile-generator/home-profile-generator.ts
+++ b/src/lib/profile-generator/home-profile-generator.ts
@@ -6,6 +6,7 @@
  */
 
 import { getAnthropicClient } from '@/lib/ai/claude';
+import type { ImageCandidate } from '@/lib/operator-profile-scraper';
 
 export interface HomeData {
   name: string;
@@ -396,6 +397,169 @@ Call the extract_profile tool with all fields you can confidently extract.`;
     tokensIn,
     tokensOut,
   };
+}
+
+// ── Image classification (Task 2) ──────────────────────────────────────────────
+
+export type ImageClassification = 'FACILITY_PHOTO' | 'PROBABLY_NOT' | 'SENSITIVE';
+
+export interface ClassifiedImage extends ImageCandidate {
+  classification: ImageClassification;
+  visualQuality: number; // 1-10, classifier's best guess from URL/alt/context
+  reason: string | null;
+}
+
+export interface ImageClassificationResult {
+  /** Kept facility photos, best-first, capped at maxKeep. */
+  kept: ClassifiedImage[];
+  /** All candidates with their classification (for logging / spot-checks). */
+  all: ClassifiedImage[];
+  tokensIn: number;
+  tokensOut: number;
+}
+
+const MAX_KEPT_IMAGES = 8;
+
+const IMAGE_CLASSIFY_SYSTEM_PROMPT = `You are screening images found on an assisted living facility's own marketing
+website so they can pre-populate the facility's directory listing. You are given,
+for each image, only its URL, alt text, and a context hint (CSS classes) — NOT
+the pixels. Infer from these signals.
+
+Classify EACH image into exactly one of:
+
+- FACILITY_PHOTO: a photo of the building exterior, interior rooms, dining
+  areas, lounges/common areas, gardens/grounds, activities, or residents
+  enjoying the community. These are what we want to keep.
+- PROBABLY_NOT: logos, wordmarks, icons, award/accreditation badges, stock
+  photography, staff headshots/portraits, maps, brochures, decorative
+  graphics, or anything that isn't a genuine photo of this facility.
+- SENSITIVE: anything that looks clinically or medically sensitive — medical
+  equipment in use, bedside/hospital-bed scenes, wound/medical-treatment
+  imagery, or anything that could embarrass or expose an identifiable
+  resident in a care/medical context. Exclude these even though the operator
+  published them.
+
+ALWAYS err toward caution: if an image MIGHT show identifiable medical
+context, classify it SENSITIVE, not FACILITY_PHOTO. If you cannot tell whether
+something is a real facility photo, prefer PROBABLY_NOT over FACILITY_PHOTO.
+
+Also give each image a visualQuality score 1-10 estimating how appealing it is
+likely to be as a listing hero/gallery image (higher = better), based on the
+signals available.`;
+
+/**
+ * Classify candidate images (text-signals only — no vision) and return the best
+ * facility photos to keep. Cheap: ~$0.02-0.05 per facility.
+ */
+export async function classifyFacilityImages(
+  homeName: string,
+  candidates: ImageCandidate[],
+  maxKeep: number = MAX_KEPT_IMAGES,
+): Promise<ImageClassificationResult> {
+  if (candidates.length === 0) {
+    return { kept: [], all: [], tokensIn: 0, tokensOut: 0 };
+  }
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY is required for image classification');
+  }
+
+  const client = getAnthropicClient();
+
+  const list = candidates
+    .map((c, i) => `${i}. url: ${c.url}\n   alt: ${c.altText ?? '(none)'}\n   context: ${c.contextHint ?? '(none)'}`)
+    .join('\n');
+
+  const userPrompt = `Facility: "${homeName}"
+
+Classify each of the following ${candidates.length} candidate images.
+
+${list}
+
+Call the classify_images tool with one entry per image (by index).`;
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 2048,
+    system: IMAGE_CLASSIFY_SYSTEM_PROMPT,
+    tools: [
+      {
+        name: 'classify_images',
+        description: 'Submit a classification for every candidate image, by index.',
+        input_schema: {
+          type: 'object' as const,
+          properties: {
+            classifications: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  index: { type: 'integer', description: 'The image index from the list' },
+                  label: {
+                    type: 'string',
+                    enum: ['FACILITY_PHOTO', 'PROBABLY_NOT', 'SENSITIVE'],
+                  },
+                  visualQuality: {
+                    type: 'integer',
+                    description: 'Estimated appeal as a listing image, 1-10',
+                  },
+                  reason: { type: 'string', description: 'Brief justification' },
+                },
+                required: ['index', 'label'],
+              },
+            },
+          },
+          required: ['classifications'],
+        },
+      },
+    ],
+    tool_choice: { type: 'tool', name: 'classify_images' },
+    messages: [{ role: 'user', content: userPrompt }],
+  });
+
+  const tokensIn = response.usage.input_tokens;
+  const tokensOut = response.usage.output_tokens;
+
+  const toolBlock = response.content.find((b) => b.type === 'tool_use');
+  if (!toolBlock || toolBlock.type !== 'tool_use') {
+    throw new Error('Claude did not call classify_images tool');
+  }
+
+  const raw = toolBlock.input as { classifications?: unknown };
+  const rows = Array.isArray(raw.classifications) ? raw.classifications : [];
+
+  // Map classifications back onto candidates by index. Any candidate the model
+  // failed to classify defaults to PROBABLY_NOT (safe exclusion).
+  const byIndex = new Map<number, { label: string; visualQuality?: number; reason?: string }>();
+  for (const r of rows as Array<Record<string, unknown>>) {
+    const idx = typeof r.index === 'number' ? r.index : Number(r.index);
+    if (!Number.isInteger(idx)) continue;
+    byIndex.set(idx, {
+      label: String(r.label ?? 'PROBABLY_NOT'),
+      visualQuality: typeof r.visualQuality === 'number' ? r.visualQuality : undefined,
+      reason: r.reason ? String(r.reason) : undefined,
+    });
+  }
+
+  const VALID: ImageClassification[] = ['FACILITY_PHOTO', 'PROBABLY_NOT', 'SENSITIVE'];
+  const all: ClassifiedImage[] = candidates.map((c, i) => {
+    const row = byIndex.get(i);
+    const classification = (row && (VALID as string[]).includes(row.label)
+      ? row.label
+      : 'PROBABLY_NOT') as ImageClassification;
+    return {
+      ...c,
+      classification,
+      visualQuality: row?.visualQuality ?? 5,
+      reason: row?.reason ?? null,
+    };
+  });
+
+  const kept = all
+    .filter((c) => c.classification === 'FACILITY_PHOTO')
+    .sort((a, b) => b.visualQuality - a.visualQuality)
+    .slice(0, maxKeep);
+
+  return { kept, all, tokensIn, tokensOut };
 }
 
 // ── Validation ────────────────────────────────────────────────────────────────

--- a/src/lib/profile-generator/photo-rehost.ts
+++ b/src/lib/profile-generator/photo-rehost.ts
@@ -1,0 +1,176 @@
+/**
+ * src/lib/profile-generator/photo-rehost.ts
+ *
+ * Downloads operator marketing photos selected by the AI classifier and
+ * re-hosts them on Cloudinary so CareLinkAI never hot-links the operator's
+ * server. Used by the auto-populator (CLI) — server context, never the browser.
+ *
+ * Safety rules (Task 3):
+ *  - Skip images > 4MB
+ *  - Skip 404 / 403 silently
+ *  - Skip anything that fails a basic image magic-byte decode check
+ *  - Abort remaining downloads once the per-facility budget (90s) is exceeded
+ */
+
+import { createHash } from 'crypto';
+import { uploadToCloudinary, isCloudinaryConfigured } from '@/lib/cloudinary';
+
+const MAX_IMAGE_BYTES = 4 * 1024 * 1024; // 4MB
+const PER_IMAGE_TIMEOUT_MS = 20_000;
+const PER_FACILITY_BUDGET_MS = 90_000;
+
+const DOWNLOAD_USER_AGENT =
+  'CareLinkAI Operator Profile Bot (profyt7@gmail.com) - re-hosting operator-published marketing photos';
+
+export interface RehostCandidate {
+  url: string;
+  altText?: string | null;
+}
+
+export interface RehostedPhoto {
+  cloudinaryUrl: string;
+  publicId: string;
+  sourceUrl: string;
+  altText: string | null;
+}
+
+export interface RehostSkip {
+  url: string;
+  reason: string;
+}
+
+export interface RehostResult {
+  uploaded: RehostedPhoto[];
+  skipped: RehostSkip[];
+  attempted: number;
+}
+
+/** Validate the first bytes look like a real raster image we can serve. */
+function sniffImageType(buf: Buffer): 'jpeg' | 'png' | 'gif' | 'webp' | null {
+  if (buf.length < 12) return null;
+  // JPEG: FF D8 FF
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpeg';
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47 &&
+    buf[4] === 0x0d && buf[5] === 0x0a && buf[6] === 0x1a && buf[7] === 0x0a
+  ) return 'png';
+  // GIF: "GIF8"
+  if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38) return 'gif';
+  // WEBP: "RIFF"...."WEBP"
+  if (
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) return 'webp';
+  return null;
+}
+
+/** Stable Cloudinary public_id for a given source URL, so re-runs overwrite. */
+function deterministicPublicId(sourceUrl: string): string {
+  return createHash('sha256').update(sourceUrl).digest('hex').slice(0, 16);
+}
+
+/**
+ * Download each candidate and re-host on Cloudinary under
+ * "operator-profiles/seeded/{homeId}/". Returns successfully uploaded photos
+ * plus a list of skips with reasons. Never throws for a single bad image.
+ */
+export async function downloadAndRehost(
+  homeId: string,
+  candidates: RehostCandidate[],
+): Promise<RehostResult> {
+  if (!isCloudinaryConfigured()) {
+    throw new Error('Cloudinary is not configured — cannot re-host photos');
+  }
+
+  const folder = `operator-profiles/seeded/${homeId}`;
+  const uploaded: RehostedPhoto[] = [];
+  const skipped: RehostSkip[] = [];
+  const startedAt = Date.now();
+  let attempted = 0;
+
+  for (const candidate of candidates) {
+    if (Date.now() - startedAt > PER_FACILITY_BUDGET_MS) {
+      skipped.push({ url: candidate.url, reason: 'per-facility time budget exceeded' });
+      continue;
+    }
+
+    attempted += 1;
+
+    // Download
+    let buffer: Buffer;
+    try {
+      const res = await fetch(candidate.url, {
+        headers: { 'User-Agent': DOWNLOAD_USER_AGENT },
+        signal: AbortSignal.timeout(PER_IMAGE_TIMEOUT_MS),
+        redirect: 'follow',
+      });
+
+      if (res.status === 404 || res.status === 403 || res.status === 410 || res.status === 401) {
+        skipped.push({ url: candidate.url, reason: `HTTP ${res.status}` });
+        continue;
+      }
+      if (!res.ok) {
+        skipped.push({ url: candidate.url, reason: `HTTP ${res.status}` });
+        continue;
+      }
+
+      // Early size guard via Content-Length when present.
+      const contentLength = Number(res.headers.get('content-length') ?? '0');
+      if (contentLength && contentLength > MAX_IMAGE_BYTES) {
+        skipped.push({ url: candidate.url, reason: `too large (${contentLength} bytes)` });
+        continue;
+      }
+
+      const arrayBuf = await res.arrayBuffer();
+      buffer = Buffer.from(arrayBuf);
+
+      if (buffer.length > MAX_IMAGE_BYTES) {
+        skipped.push({ url: candidate.url, reason: `too large (${buffer.length} bytes)` });
+        continue;
+      }
+      if (buffer.length === 0) {
+        skipped.push({ url: candidate.url, reason: 'empty response' });
+        continue;
+      }
+    } catch (e: any) {
+      const reason = e?.name === 'TimeoutError' || e?.name === 'AbortError'
+        ? 'download timeout'
+        : `download error: ${e?.message ?? e}`;
+      skipped.push({ url: candidate.url, reason });
+      continue;
+    }
+
+    // Decode / magic-byte check
+    if (!sniffImageType(buffer)) {
+      skipped.push({ url: candidate.url, reason: 'not a decodable image' });
+      continue;
+    }
+
+    // Re-host on Cloudinary
+    try {
+      const publicId = deterministicPublicId(candidate.url);
+      const result: any = await uploadToCloudinary(buffer, {
+        folder,
+        resourceType: 'image',
+        publicId,
+        transformation: [{ width: 1600, height: 1600, crop: 'limit', quality: 'auto' }],
+      });
+      const cloudinaryUrl = result?.secure_url || result?.url;
+      if (!cloudinaryUrl) {
+        skipped.push({ url: candidate.url, reason: 'cloudinary returned no url' });
+        continue;
+      }
+      uploaded.push({
+        cloudinaryUrl,
+        publicId: result?.public_id ?? `${folder}/${publicId}`,
+        sourceUrl: candidate.url,
+        altText: candidate.altText ?? null,
+      });
+    } catch (e: any) {
+      skipped.push({ url: candidate.url, reason: `cloudinary upload failed: ${e?.message ?? e}` });
+    }
+  }
+
+  return { uploaded, skipped, attempted };
+}


### PR DESCRIPTION
## Why

Extends the operator auto-populator (PR #545) so a pre-populated listing also shows the operator's **actual website photos** — making the "wow when they click the claim link" moment significantly stronger.

Photo scraping was deliberately deferred in #545 over HIPAA caution. On review the exposure is materially lower: operator-published marketing photos are already licensed by depicted residents under HIPAA-compliant marketing consent, and every major directory (A Place for Mom, Caring.com, SeniorAdvisor) scrapes/displays operator photos. The real risk is copyright/likeness, mitigated here with **claim-time rights acknowledgment + one-click remove**. The classifier also hard-excludes anything clinically sensitive.

## What changed

**Schema (`Task 4`)** — reuses the existing `HomePhoto` relation rather than a new array:
- `HomePhoto.autoPopulated Boolean` + `HomePhoto.sourceUrl String?` (clean provenance)
- `AssistedLivingHome.imageRightsAcknowledgedAt DateTime?`
- Migration `20260607000001_photo_autopopulate` (idempotent `ADD COLUMN IF NOT EXISTS`)

**Task 1 — image extraction** (`src/lib/operator-profile-scraper.ts`)
`extractImageCandidates(html, baseUrl)`: parses `<img>`, resolves relative→absolute, handles lazy-load (`data-src`/`srcset`, picks largest), drops `<nav>/<header>/<footer>`/`<svg>` regions and logo/icon/award/social images, size-filters via `width`/`height` attrs (<300×200), skips stock/placeholder/tracking hosts and `data:` URIs. Returns up to 12; exposed on `ScrapeResult.imageCandidates` (recomputed for older cache entries).

**Task 2 — AI classification** (`home-profile-generator.ts`)
`classifyFacilityImages()` sends URL/alt/context (no vision) to **Claude Sonnet 4.6**, labels each `FACILITY_PHOTO` / `PROBABLY_NOT` / `SENSITIVE`, errs toward exclusion, keeps best 8 by estimated quality. ~$0.02–0.05/facility.

**Task 3 — download + rehost** (`src/lib/profile-generator/photo-rehost.ts`)
`downloadAndRehost()`: 4MB cap (Content-Length + actual), magic-byte decode check (jpeg/png/gif/webp), 20s/image + 90s/facility budget, silent 404/403 skips → uploads to `operator-profiles/seeded/{homeId}/` with a deterministic public_id (re-runs overwrite). Never throws on a single bad image.

**Task 5 — wizard Step 2 UX** (`operator/onboarding/[step]/page.tsx`)
Premium responsive photo grid (2/3/4 cols, rounded, shadow, hover-zoom), hover **✕ remove** with optimistic update, click-to-enlarge lightbox, and the requested caption. Removal hits a new `DELETE /api/operator/onboarding/seeded-photo/[photoId]` authorized via `operator.seededHomeId` (operator isn't `home.operatorId` until claim) — only `autoPopulated` photos are removable, with best-effort Cloudinary cleanup via the deterministic public_id. Status route now returns the auto-populated photos.

**Task 6 — rights acknowledgment**
Required checkbox above *Confirm and continue* when claiming a listing; the claim route now rejects the claim if pre-populated photos exist and it isn't checked, and records `imageRightsAcknowledgedAt`.

**Task 7 — CLI flag** (`scripts/autopopulate-cohort.ts`)
`--with-photos`: off = identical to #545; on = classify (+ on `--force` download/rehost/write). Per-facility logging of text cost, image-classify cost, kept/uploaded/skipped counts, total cost; run summary adds total photos uploaded. Enforces `CLOUDINARY_*` on live runs.

## Verification

- `npm run build` — green (all routes compile, no type errors).
- New unit tests `src/lib/__tests__/operator-profile-scraper.images.test.ts` — **7/7 pass**, covering relative-URL resolution, nav/logo/award/social filtering, size filtering, lazy-load/srcset, stock-host/data-URI filtering, dedupe+cap, empty/JS-only bodies.

## ⚠️ Not done in this PR (needs your environment)

**Acceptance criteria 2/3/4/7 require the live 15-facility re-run, which I can't execute here** — this sandbox has no `ANTHROPIC_API_KEY`, no `CLOUDINARY_*`, no DB, and no outbound access to the real facility sites. The CSV (`03_Execution/cleveland_outreach/first_batch_websites.csv`) also lives in the vault, not this repo. Please run, where those exist:

```bash
# dry-run: classification only, no downloads/writes
npx tsx scripts/autopopulate-cohort.ts \
  03_Execution/cleveland_outreach/first_batch_websites.csv \
  --with-photos --dry-run

# live: download + Cloudinary rehost + DB write
npx tsx scripts/autopopulate-cohort.ts \
  03_Execution/cleveland_outreach/first_batch_websites.csv \
  --with-photos --force
```

Then spot-check 3 facilities (no medical/bedside shots, no logos/awards kept) and confirm Cloudinary URLs resolve. Expected spend ~$2–3.

## Gotchas handled / out of scope
Handled: lazy-load, dedupe, size filter, sensitive-image exclusion, idempotent re-runs. Out of scope per spec: CSS background-image photos (lower yield accepted), SPA empty-HTML sites (0 photos expected), cropping/alt-gen/reordering/recurring refresh.

Do not merge — opening for review and the live re-run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzvVy8ZT5cGy7h33it1gmL)_