### PR TITLE
feat(autopopulate): --photos-only mode to backfill photos without re-extracting text

### DIFF
--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -58,6 +58,19 @@ Each loop: what it is, why it matters, what done looks like.
   4. **Concordia at Sumner** — city/street address not resolved; MEDIUM confidence
 - **Done when:** Each record manually verified and corrected in admin panel before the facility receives a claim link.
 
+### OL-060: First-batch photo backfill (text-only June-5 run had no photos)
+- **Status:** 🟡 OPEN — code ready (#553), pending Render run
+- **What:** The June-5 pipeline run predated the photo feature (#549), so the 15 first-batch Cleveland homes have `autoPopulatedAt` set but **no photos**. `--photos-only` mode (skips text re-extraction + text writes; scrapes images → AI-classify → Cloudinary re-host → append `HomePhoto` rows; idempotent — clears prior auto-populated photos first). `--from-db` targets the auto-populated cohort without a CSV.
+- **Done when:** On Render: `tsx scripts/autopopulate-cohort.ts --from-db --photos-only --dry-run` reviewed, then `--force`. 15 homes have auto-populated photos. (Anthropic spend small — image-classify only; Cloudinary within free tier.)
+
+### OL-061: AI address extraction weak — Google Places fallback
+- **Status:** ✅ CODE MERGED (#554, 2026-06-09) — backfill of the existing 15 still pending
+- **What:** HTML extraction often misses the street (Canterbury Commons showed the `1234 Oak Lane` form placeholder). `findAddressViaPlaces()` in `src/lib/place-lookup.ts` + wired into the populator: when neither DB nor AI yields a street, look the facility up by name + city and fill street/zip from a HIGH/MEDIUM-confidence Google Places match (fill-only, never overwrite). `GOOGLE_PLACES_API_KEY` is set in Render.
+- **Done when (remaining):** Backfill the existing 15 homes' addresses via the `--addresses-only` mode (no text re-extraction) on Render.
+
+### OL-062: "Full address is required" validation doesn't name the empty sub-field
+- **Status:** ✅ CLOSED (#554, 2026-06-09) — `src/app/operator/onboarding/[step]/page.tsx` now names the missing sub-field(s), e.g. "State is required."
+
 ### OL-063: e2e suite runs ZERO tests in CI (false-green)
 - **Status:** 🔴 OPEN — discovered 2026-06-09 while wiring the claim-flow guard
 - **What:** Every Playwright config uses `testDir: './tests'`, but the CI e2e jobs (`e2e-family.yml`) run specs from `./e2e/` (`e2e/residents-*`, `e2e/family-*`). A bare `playwright test e2e/<spec>` therefore matches **nothing**, so Playwright would error "No tests found" — except the residents/family jobs pass `--shard`, which tolerates an empty shard and exits 0. Net effect: the entire `e2e/` suite (residents, family, marketplace, messages, operator, auth specs) has been **passing without executing a single test**. Confirmed via job logs (webserver boots, then jumps straight to artifact upload with no "Running N tests" line).

--- a/scripts/autopopulate-cohort.ts
+++ b/scripts/autopopulate-cohort.ts
@@ -21,6 +21,12 @@
  *                      auto-populated HomePhoto rows. On --dry-run, classifies
  *                      only (no download/upload). Requires CLOUDINARY_* env vars
  *                      on a live run.
+ *   --photos-only      Backfill photos onto records that ALREADY have their text
+ *                      profile. Skips the AI text extraction + all text-field DB
+ *                      writes entirely (no overwrite, no autoPopulatedVersion bump);
+ *                      only scrapes for <img> candidates, classifies, and appends
+ *                      auto-populated HomePhoto rows. Implies --with-photos and
+ *                      intentionally ignores the --resume "already populated" skip.
  *   --facility <id>    Process only this homeId
  */
 
@@ -66,7 +72,7 @@ function parseCsv(filePath: string): CsvRow[] {
 
 async function processRow(
   row: CsvRow,
-  { dryRun, resume, withPhotos }: { dryRun: boolean; resume: boolean; withPhotos: boolean },
+  { dryRun, resume, withPhotos, photosOnly }: { dryRun: boolean; resume: boolean; withPhotos: boolean; photosOnly: boolean },
 ): Promise<FacilityResult> {
   const { homeName, homeId, websiteUrl } = row;
 
@@ -82,11 +88,14 @@ async function processRow(
   if (home.status !== HomeStatus.DRAFT) {
     return { status: 'skipped', homeId, homeName, reason: `status=${home.status} (only DRAFT homes)` };
   }
-  if (resume && home.autoPopulatedAt) {
+  // --resume skips already-populated homes. Photos-only runs deliberately TARGET
+  // those homes (we are backfilling photos onto records that already have text),
+  // so the "already populated" skip must not apply in photos-only mode.
+  if (resume && home.autoPopulatedAt && !photosOnly) {
     return { status: 'skipped', homeId, homeName, reason: 'already auto-populated (--resume)' };
   }
 
-  // Scrape
+  // Scrape — needed for both text extraction and image candidates.
   let html: string;
   let finalUrl: string;
   let imageCandidates: ImageCandidate[] = [];
@@ -100,145 +109,153 @@ async function processRow(
     return { status: 'blocked', homeId, homeName, reason: err.message };
   }
 
-  const preparedHtml = prepareHtmlForExtraction(html);
+  let extracted: Awaited<ReturnType<typeof extractProfileFromWebsite>> | null = null;
+  let dollars = 0;
+  let fieldsExtracted = 0;
 
-  // Extract
-  let extracted;
-  try {
-    extracted = await extractProfileFromWebsite(
-      {
-        name: home.name,
-        careLevel: home.careLevel,
-        capacity: home.capacity,
-        currentOccupancy: home.currentOccupancy,
-        amenities: home.amenities,
-        address: home.address
-          ? { city: home.address.city, state: home.address.state }
-          : undefined,
-      },
-      preparedHtml,
-      websiteUrl,
-    );
-  } catch (e: any) {
-    return { status: 'blocked', homeId, homeName, reason: `Extraction failed: ${e?.message ?? e}` };
-  }
+  // ── Text extraction + field writes — skipped entirely in --photos-only mode ──
+  if (!photosOnly) {
+    const preparedHtml = prepareHtmlForExtraction(html);
 
-  const dollars = cost(extracted.tokensIn, extracted.tokensOut);
-
-  // Build update payload
-  const preFilledFields: Record<string, 'AI' | 'SEED'> = {};
-
-  const updateData: Parameters<typeof prisma.assistedLivingHome.update>[0]['data'] = {
-    websiteUrl: websiteUrl,
-    autoPopulatedAt: new Date(),
-    autoPopulatedFromUrl: finalUrl,
-    autoPopulatedVersion: (home.autoPopulatedVersion ?? 0) + 1,
-    aiPopulationConfidence: extracted.extractionConfidence,
-  };
-
-  if (extracted.description) {
-    updateData.description = extracted.description;
-    preFilledFields['description'] = 'AI';
-  }
-
-  if (extracted.amenities.length > 0) {
-    updateData.amenities = extracted.amenities;
-    preFilledFields['amenities'] = 'AI';
-  }
-
-  if (extracted.careLevel.length > 0) {
-    updateData.careLevel = extracted.careLevel as any;
-    preFilledFields['careLevel'] = 'AI';
-  }
-
-  // Address: only fill fields that are currently empty/missing.
-  const addr = extracted.address;
-  const aiStreet = addr?.streetAddress?.trim() || null;
-  const aiZip = addr?.zip?.trim() || null;
-
-  // Google Places address fallback (OL-061): the website scrape frequently
-  // misses the street address (leaving the listing showing the form's
-  // "1234 Oak Lane" placeholder). When neither the DB nor the AI gives us a
-  // street, look the facility up by name + city in Google Places — authoritative
-  // for addresses — and use a HIGH/MEDIUM-confidence match.
-  let placesAddr: PlaceAddressResult | null = null;
-  if (!home.address?.street && !aiStreet && isPlaceLookupConfigured()) {
-    placesAddr = await findAddressViaPlaces({
-      name: home.name,
-      city: home.address?.city ?? null,
-      state: home.address?.state ?? null,
-    });
-    if (placesAddr && placesAddr.street && placesAddr.confidence !== 'LOW') {
-      console.log(
-        `    📍 Places address fallback: "${placesAddr.street}"` +
-        `${placesAddr.zip ? ` ${placesAddr.zip}` : ''} ` +
-        `(${placesAddr.confidence}, matched "${placesAddr.matchedName ?? '?'}")`,
+    // Extract
+    try {
+      extracted = await extractProfileFromWebsite(
+        {
+          name: home.name,
+          careLevel: home.careLevel,
+          capacity: home.capacity,
+          currentOccupancy: home.currentOccupancy,
+          amenities: home.amenities,
+          address: home.address
+            ? { city: home.address.city, state: home.address.state }
+            : undefined,
+        },
+        preparedHtml,
+        websiteUrl,
       );
-    } else {
-      if (placesAddr) {
-        console.log(`    📍 Places address: LOW-confidence match ignored ("${placesAddr.matchedName ?? '?'}")`);
-      }
-      placesAddr = null;
+    } catch (e: any) {
+      return { status: 'blocked', homeId, homeName, reason: `Extraction failed: ${e?.message ?? e}` };
     }
-  }
 
-  // AI scrape first, then the Places fallback, for the street/zip we persist.
-  const resolvedStreet = aiStreet ?? placesAddr?.street ?? null;
-  const resolvedZip = aiZip ?? placesAddr?.zip ?? null;
+    dollars = cost(extracted.tokensIn, extracted.tokensOut);
 
-  // 'AI' provenance covers both scrape- and Places-derived auto-fill for the
-  // operator-facing badge (FieldProvenance has no 'PLACES' variant).
-  if (!home.address?.street && resolvedStreet) {
-    preFilledFields['street'] = 'AI';
-  }
-  if (!home.address?.zipCode && resolvedZip) {
-    preFilledFields['zipCode'] = 'AI';
-  }
+    // Build update payload
+    const preFilledFields: Record<string, 'AI' | 'SEED'> = {};
 
-  // Mark existing seed fields (from DOH) as SEED provenance
-  if (home.name) preFilledFields['name'] = 'SEED';
-  if (home.capacity) preFilledFields['capacity'] = 'SEED';
-  if (home.address?.city) preFilledFields['city'] = 'SEED';
-  if (home.address?.state) preFilledFields['state'] = 'SEED';
+    const updateData: Parameters<typeof prisma.assistedLivingHome.update>[0]['data'] = {
+      websiteUrl: websiteUrl,
+      autoPopulatedAt: new Date(),
+      autoPopulatedFromUrl: finalUrl,
+      autoPopulatedVersion: (home.autoPopulatedVersion ?? 0) + 1,
+      aiPopulationConfidence: extracted.extractionConfidence,
+    };
 
-  updateData.preFilledFields = preFilledFields;
+    if (extracted.description) {
+      updateData.description = extracted.description;
+      preFilledFields['description'] = 'AI';
+    }
 
-  // Count extracted fields (description + services + amenities + careLevel + address fields)
-  const fieldsExtracted = [
-    extracted.description,
-    extracted.services.length > 0,
-    extracted.amenities.length > 0,
-    extracted.careLevel.length > 0,
-    extracted.address?.streetAddress,
-    extracted.address?.zip,
-    extracted.phone,
-    extracted.contactEmail,
-    extracted.tagline,
-  ].filter(Boolean).length;
+    if (extracted.amenities.length > 0) {
+      updateData.amenities = extracted.amenities;
+      preFilledFields['amenities'] = 'AI';
+    }
 
-  const icon = extracted.extractionConfidence === 'LOW' ? '⚠' : '✓';
-  console.log(
-    `  ${icon} ${homeName} — extracted ${fieldsExtracted} fields (${extracted.extractionConfidence} confidence), $${dollars.toFixed(3)}`,
-  );
-  if (extracted.extractionNotes) {
-    console.log(`    Notes: ${extracted.extractionNotes}`);
-  }
+    if (extracted.careLevel.length > 0) {
+      updateData.careLevel = extracted.careLevel as any;
+      preFilledFields['careLevel'] = 'AI';
+    }
 
-  if (!dryRun) {
-    await prisma.assistedLivingHome.update({ where: { id: homeId }, data: updateData });
+    // Address: only fill fields that are currently empty/missing.
+    const addr = extracted.address;
+    const aiStreet = addr?.streetAddress?.trim() || null;
+    const aiZip = addr?.zip?.trim() || null;
 
-    // Upsert address — fill empty street/zip from the AI scrape or Places fallback.
-    if (home.address) {
-      const addrUpdate: Record<string, string> = {};
-      if (!home.address.street && resolvedStreet) addrUpdate.street = resolvedStreet;
-      if (!home.address.zipCode && resolvedZip) addrUpdate.zipCode = resolvedZip;
-      if (Object.keys(addrUpdate).length > 0) {
-        await prisma.address.update({ where: { id: home.address.id }, data: addrUpdate });
+    // Google Places address fallback (OL-061): the website scrape frequently
+    // misses the street address (leaving the listing showing the form's
+    // "1234 Oak Lane" placeholder). When neither the DB nor the AI gives us a
+    // street, look the facility up by name + city in Google Places —
+    // authoritative for addresses — and use a HIGH/MEDIUM-confidence match.
+    let placesAddr: PlaceAddressResult | null = null;
+    if (!home.address?.street && !aiStreet && isPlaceLookupConfigured()) {
+      placesAddr = await findAddressViaPlaces({
+        name: home.name,
+        city: home.address?.city ?? null,
+        state: home.address?.state ?? null,
+      });
+      if (placesAddr && placesAddr.street && placesAddr.confidence !== 'LOW') {
+        console.log(
+          `    📍 Places address fallback: "${placesAddr.street}"` +
+          `${placesAddr.zip ? ` ${placesAddr.zip}` : ''} ` +
+          `(${placesAddr.confidence}, matched "${placesAddr.matchedName ?? '?'}")`,
+        );
+      } else {
+        if (placesAddr) {
+          console.log(`    📍 Places address: LOW-confidence match ignored ("${placesAddr.matchedName ?? '?'}")`);
+        }
+        placesAddr = null;
       }
     }
+
+    // AI scrape first, then the Places fallback, for the street/zip we persist.
+    const resolvedStreet = aiStreet ?? placesAddr?.street ?? null;
+    const resolvedZip = aiZip ?? placesAddr?.zip ?? null;
+
+    // 'AI' provenance covers both scrape- and Places-derived auto-fill for the
+    // operator-facing badge (FieldProvenance has no 'PLACES' variant).
+    if (!home.address?.street && resolvedStreet) {
+      preFilledFields['street'] = 'AI';
+    }
+    if (!home.address?.zipCode && resolvedZip) {
+      preFilledFields['zipCode'] = 'AI';
+    }
+
+    // Mark existing seed fields (from DOH) as SEED provenance
+    if (home.name) preFilledFields['name'] = 'SEED';
+    if (home.capacity) preFilledFields['capacity'] = 'SEED';
+    if (home.address?.city) preFilledFields['city'] = 'SEED';
+    if (home.address?.state) preFilledFields['state'] = 'SEED';
+
+    updateData.preFilledFields = preFilledFields;
+
+    // Count extracted fields (description + services + amenities + careLevel + address fields)
+    fieldsExtracted = [
+      extracted.description,
+      extracted.services.length > 0,
+      extracted.amenities.length > 0,
+      extracted.careLevel.length > 0,
+      extracted.address?.streetAddress,
+      extracted.address?.zip,
+      extracted.phone,
+      extracted.contactEmail,
+      extracted.tagline,
+    ].filter(Boolean).length;
+
+    const icon = extracted.extractionConfidence === 'LOW' ? '⚠' : '✓';
+    console.log(
+      `  ${icon} ${homeName} — extracted ${fieldsExtracted} fields (${extracted.extractionConfidence} confidence), $${dollars.toFixed(3)}`,
+    );
+    if (extracted.extractionNotes) {
+      console.log(`    Notes: ${extracted.extractionNotes}`);
+    }
+
+    if (!dryRun) {
+      await prisma.assistedLivingHome.update({ where: { id: homeId }, data: updateData });
+
+      // Upsert address — fill empty street/zip from the AI scrape or Places fallback.
+      if (home.address) {
+        const addrUpdate: Record<string, string> = {};
+        if (!home.address.street && resolvedStreet) addrUpdate.street = resolvedStreet;
+        if (!home.address.zipCode && resolvedZip) addrUpdate.zipCode = resolvedZip;
+        if (Object.keys(addrUpdate).length > 0) {
+          await prisma.address.update({ where: { id: home.address.id }, data: addrUpdate });
+        }
+      }
+    }
+  } else {
+    console.log(`  📷 ${homeName} — photos-only (text extraction + text writes skipped)`);
   }
 
-  // ── Photo pipeline (Tasks 1-4) — opt-in via --with-photos ──────────────────
+  // ── Photo pipeline (Tasks 1-4) — opt-in via --with-photos / --photos-only ──
   let imageDollars = 0;
   let photosUploaded = 0;
   if (withPhotos) {
@@ -303,15 +320,26 @@ async function processRow(
 
   const totalDollars = dollars + imageDollars;
   console.log(
-    `    💵 cost: text $${dollars.toFixed(3)}` +
-    (withPhotos ? ` + images $${imageDollars.toFixed(3)} = $${totalDollars.toFixed(3)}` : '') +
+    `    💵 cost: ` +
+    (photosOnly
+      ? `images $${imageDollars.toFixed(3)}`
+      : `text $${dollars.toFixed(3)}` +
+        (withPhotos ? ` + images $${imageDollars.toFixed(3)} = $${totalDollars.toFixed(3)}` : '')) +
     (withPhotos && !dryRun ? ` | photos uploaded: ${photosUploaded}` : ''),
   );
 
-  if (extracted.extractionConfidence === 'LOW') {
+  if (extracted && extracted.extractionConfidence === 'LOW') {
     return { status: 'sparse', homeId, homeName, confidence: extracted.extractionConfidence, dollars: totalDollars, photosUploaded };
   }
-  return { status: 'success', homeId, homeName, fieldsExtracted, confidence: extracted.extractionConfidence, dollars: totalDollars, photosUploaded };
+  return {
+    status: 'success',
+    homeId,
+    homeName,
+    fieldsExtracted,
+    confidence: photosOnly ? 'PHOTOS' : (extracted ? extracted.extractionConfidence : 'N/A'),
+    dollars: totalDollars,
+    photosUploaded,
+  };
 }
 
 async function main() {
@@ -319,12 +347,14 @@ async function main() {
   const csvPath = args.find(a => !a.startsWith('--'));
   const dryRun = !args.includes('--force') && (args.includes('--dry-run') || !args.includes('--force'));
   const resume = args.includes('--resume');
-  const withPhotos = args.includes('--with-photos');
+  const photosOnly = args.includes('--photos-only');
+  // Photos-only is a photo run by definition.
+  const withPhotos = args.includes('--with-photos') || photosOnly;
   const facilityFlag = args.indexOf('--facility');
   const onlyFacilityId = facilityFlag !== -1 ? args[facilityFlag + 1] : null;
 
   if (!csvPath) {
-    console.error('Usage: autopopulate-cohort.ts <path/to/websites.csv> [--dry-run|--force] [--resume] [--with-photos] [--facility <id>]');
+    console.error('Usage: autopopulate-cohort.ts <path/to/websites.csv> [--dry-run|--force] [--resume] [--with-photos] [--photos-only] [--facility <id>]');
     process.exit(1);
   }
 
@@ -345,6 +375,7 @@ async function main() {
   }
 
   console.log(dryRun ? '=== DRY RUN — no DB writes ===' : '=== LIVE RUN ===');
+  if (photosOnly) console.log('=== PHOTOS-ONLY mode: text extraction + text writes skipped, photos appended ===');
   if (withPhotos) console.log(`=== Photo extraction ENABLED ${dryRun ? '(classify only — no download/upload on dry-run)' : '(download + Cloudinary re-host)'} ===`);
   console.log('');
 
@@ -371,7 +402,7 @@ async function main() {
 
   for (const row of rows) {
     try {
-      const result = await processRow(row, { dryRun, resume, withPhotos });
+      const result = await processRow(row, { dryRun, resume, withPhotos, photosOnly });
       results.push(result);
       if (result.status === 'success' || result.status === 'sparse') {
         totalDollars += result.dollars;

--- a/scripts/autopopulate-cohort.ts
+++ b/scripts/autopopulate-cohort.ts
@@ -30,6 +30,11 @@
  *   --from-db          Skip the CSV and target all auto-populated DRAFT homes from
  *                      the database (using each home's stored websiteUrl). Pairs
  *                      with --photos-only for a no-CSV photo backfill of the cohort.
+ *   --addresses-only   Backfill street/zip via Google Places ONLY (name + city) —
+ *                      no website scrape, no AI text call, no photos. Fills empty
+ *                      street/zip on homes that have none; never overwrites. Use
+ *                      with --from-db to fix the cohort's addresses without
+ *                      re-extracting text. Requires GOOGLE_PLACES_API_KEY.
  *   --facility <id>    Process only this homeId
  */
 
@@ -75,7 +80,7 @@ function parseCsv(filePath: string): CsvRow[] {
 
 async function processRow(
   row: CsvRow,
-  { dryRun, resume, withPhotos, photosOnly }: { dryRun: boolean; resume: boolean; withPhotos: boolean; photosOnly: boolean },
+  { dryRun, resume, withPhotos, photosOnly, addressesOnly }: { dryRun: boolean; resume: boolean; withPhotos: boolean; photosOnly: boolean; addressesOnly: boolean },
 ): Promise<FacilityResult> {
   const { homeName, homeId, websiteUrl } = row;
 
@@ -91,11 +96,16 @@ async function processRow(
   if (home.status !== HomeStatus.DRAFT) {
     return { status: 'skipped', homeId, homeName, reason: `status=${home.status} (only DRAFT homes)` };
   }
-  // --resume skips already-populated homes. Photos-only runs deliberately TARGET
-  // those homes (we are backfilling photos onto records that already have text),
-  // so the "already populated" skip must not apply in photos-only mode.
-  if (resume && home.autoPopulatedAt && !photosOnly) {
+  // --resume skips already-populated homes. Photos-only / addresses-only runs
+  // deliberately TARGET those homes (backfilling onto records that already have
+  // text), so the "already populated" skip must not apply in those modes.
+  if (resume && home.autoPopulatedAt && !photosOnly && !addressesOnly) {
     return { status: 'skipped', homeId, homeName, reason: 'already auto-populated (--resume)' };
+  }
+
+  // Address-only backfill: Google Places only — no scrape, no AI, no photos.
+  if (addressesOnly) {
+    return backfillAddressViaPlaces(home, homeName, homeId, dryRun);
   }
 
   // Scrape — needed for both text extraction and image candidates.
@@ -345,6 +355,64 @@ async function processRow(
   };
 }
 
+/**
+ * --addresses-only backfill: fill a home's empty street/zip from Google Places
+ * (name + city) without scraping the website, calling the LLM, or touching any
+ * other field. Fill-only — never overwrites an existing street.
+ */
+async function backfillAddressViaPlaces(
+  home: {
+    preFilledFields: unknown;
+    address: { id: string; city: string; state: string; street: string | null; zipCode: string | null } | null;
+  },
+  homeName: string,
+  homeId: string,
+  dryRun: boolean,
+): Promise<FacilityResult> {
+  if (!home.address) {
+    return { status: 'skipped', homeId, homeName, reason: 'no address record to update' };
+  }
+  if (home.address.street) {
+    return { status: 'skipped', homeId, homeName, reason: 'already has a street address' };
+  }
+
+  const placesAddr = await findAddressViaPlaces({
+    name: homeName,
+    city: home.address.city,
+    state: home.address.state,
+  });
+
+  if (!placesAddr || !placesAddr.street || placesAddr.confidence === 'LOW') {
+    console.log(
+      `  📍 ${homeName} — no usable Places address match` +
+      (placesAddr ? ` (LOW: "${placesAddr.matchedName ?? '?'}")` : ''),
+    );
+    return { status: 'skipped', homeId, homeName, reason: 'no usable Places address match' };
+  }
+
+  console.log(
+    `  📍 ${homeName} — ${placesAddr.street}${placesAddr.zip ? ` ${placesAddr.zip}` : ''} ` +
+    `(${placesAddr.confidence}, matched "${placesAddr.matchedName ?? '?'}")`,
+  );
+
+  if (!dryRun) {
+    const addrUpdate: Record<string, string> = { street: placesAddr.street };
+    if (placesAddr.zip && !home.address.zipCode) addrUpdate.zipCode = placesAddr.zip;
+    await prisma.address.update({ where: { id: home.address.id }, data: addrUpdate });
+
+    // Merge provenance: mark the fields we filled without clobbering existing keys.
+    const existingProv = (home.preFilledFields as Record<string, string> | null) ?? {};
+    const mergedProv: Record<string, string> = { ...existingProv, street: 'AI' };
+    if (addrUpdate.zipCode) mergedProv.zipCode = 'AI';
+    await prisma.assistedLivingHome.update({
+      where: { id: homeId },
+      data: { preFilledFields: mergedProv },
+    });
+  }
+
+  return { status: 'success', homeId, homeName, fieldsExtracted: 1, confidence: 'PLACES', dollars: 0, photosUploaded: 0 };
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const csvPath = args.find(a => !a.startsWith('--'));
@@ -354,17 +422,23 @@ async function main() {
   // Photos-only is a photo run by definition.
   const withPhotos = args.includes('--with-photos') || photosOnly;
   const fromDb = args.includes('--from-db');
+  const addressesOnly = args.includes('--addresses-only');
   const facilityFlag = args.indexOf('--facility');
   const onlyFacilityId = facilityFlag !== -1 ? args[facilityFlag + 1] : null;
 
   if (!csvPath && !fromDb) {
-    console.error('Usage: autopopulate-cohort.ts <path/to/websites.csv> [--dry-run|--force] [--resume] [--with-photos] [--photos-only] [--from-db] [--facility <id>]');
+    console.error('Usage: autopopulate-cohort.ts <path/to/websites.csv> [--dry-run|--force] [--resume] [--with-photos] [--photos-only] [--addresses-only] [--from-db] [--facility <id>]');
     console.error('  (omit the CSV path and pass --from-db to target all auto-populated DRAFT homes from the database)');
     process.exit(1);
   }
 
-  if (!process.env.ANTHROPIC_API_KEY) {
+  // Addresses-only uses Google Places, not the LLM, so it doesn't need Anthropic.
+  if (!addressesOnly && !process.env.ANTHROPIC_API_KEY) {
     console.error('ERROR: ANTHROPIC_API_KEY environment variable is not set.');
+    process.exit(1);
+  }
+  if (addressesOnly && !isPlaceLookupConfigured()) {
+    console.error('ERROR: --addresses-only requires GOOGLE_PLACES_API_KEY.');
     process.exit(1);
   }
 
@@ -380,20 +454,23 @@ async function main() {
   }
 
   console.log(dryRun ? '=== DRY RUN — no DB writes ===' : '=== LIVE RUN ===');
+  if (addressesOnly) console.log('=== ADDRESSES-ONLY mode: Google Places street/zip backfill (no scrape / AI / photos) ===');
   if (photosOnly) console.log('=== PHOTOS-ONLY mode: text extraction + text writes skipped, photos appended ===');
   if (withPhotos) console.log(`=== Photo extraction ENABLED ${dryRun ? '(classify only — no download/upload on dry-run)' : '(download + Cloudinary re-host)'} ===`);
   console.log('');
 
   let rows: CsvRow[];
   if (fromDb) {
-    // Derive the cohort from the DB: all auto-populated DRAFT homes that still
-    // have a usable website URL. This is exactly the set the photo backfill
-    // targets, so no CSV is needed.
+    // Derive the cohort from the DB: all auto-populated DRAFT homes. Address-only
+    // backfill doesn't need a website; the photo/text paths do, so require a
+    // usable URL there. No CSV needed either way.
     const homes = await prisma.assistedLivingHome.findMany({
       where: {
         status: HomeStatus.DRAFT,
         autoPopulatedAt: { not: null },
-        OR: [{ websiteUrl: { not: null } }, { autoPopulatedFromUrl: { not: null } }],
+        ...(addressesOnly
+          ? {}
+          : { OR: [{ websiteUrl: { not: null } }, { autoPopulatedFromUrl: { not: null } }] }),
       },
       select: { id: true, name: true, websiteUrl: true, autoPopulatedFromUrl: true },
       orderBy: { autoPopulatedAt: 'asc' },
@@ -402,9 +479,9 @@ async function main() {
       .map((h) => ({
         homeName: h.name,
         homeId: h.id,
-        websiteUrl: (h.websiteUrl ?? h.autoPopulatedFromUrl) as string,
+        websiteUrl: (h.websiteUrl ?? h.autoPopulatedFromUrl ?? '') as string,
       }))
-      .filter((r) => !!r.websiteUrl);
+      .filter((r) => addressesOnly || !!r.websiteUrl);
     console.log(`--from-db: selected ${rows.length} auto-populated DRAFT home(s) from the database.\n`);
   } else {
     try {
@@ -435,7 +512,7 @@ async function main() {
 
   for (const row of rows) {
     try {
-      const result = await processRow(row, { dryRun, resume, withPhotos, photosOnly });
+      const result = await processRow(row, { dryRun, resume, withPhotos, photosOnly, addressesOnly });
       results.push(result);
       if (result.status === 'success' || result.status === 'sparse') {
         totalDollars += result.dollars;

--- a/scripts/autopopulate-cohort.ts
+++ b/scripts/autopopulate-cohort.ts
@@ -27,6 +27,9 @@
  *                      only scrapes for <img> candidates, classifies, and appends
  *                      auto-populated HomePhoto rows. Implies --with-photos and
  *                      intentionally ignores the --resume "already populated" skip.
+ *   --from-db          Skip the CSV and target all auto-populated DRAFT homes from
+ *                      the database (using each home's stored websiteUrl). Pairs
+ *                      with --photos-only for a no-CSV photo backfill of the cohort.
  *   --facility <id>    Process only this homeId
  */
 
@@ -350,11 +353,13 @@ async function main() {
   const photosOnly = args.includes('--photos-only');
   // Photos-only is a photo run by definition.
   const withPhotos = args.includes('--with-photos') || photosOnly;
+  const fromDb = args.includes('--from-db');
   const facilityFlag = args.indexOf('--facility');
   const onlyFacilityId = facilityFlag !== -1 ? args[facilityFlag + 1] : null;
 
-  if (!csvPath) {
-    console.error('Usage: autopopulate-cohort.ts <path/to/websites.csv> [--dry-run|--force] [--resume] [--with-photos] [--photos-only] [--facility <id>]');
+  if (!csvPath && !fromDb) {
+    console.error('Usage: autopopulate-cohort.ts <path/to/websites.csv> [--dry-run|--force] [--resume] [--with-photos] [--photos-only] [--from-db] [--facility <id>]');
+    console.error('  (omit the CSV path and pass --from-db to target all auto-populated DRAFT homes from the database)');
     process.exit(1);
   }
 
@@ -380,19 +385,47 @@ async function main() {
   console.log('');
 
   let rows: CsvRow[];
-  try {
-    rows = parseCsv(path.resolve(csvPath));
-  } catch (e: any) {
-    console.error(`Failed to parse CSV: ${e.message}`);
-    process.exit(1);
+  if (fromDb) {
+    // Derive the cohort from the DB: all auto-populated DRAFT homes that still
+    // have a usable website URL. This is exactly the set the photo backfill
+    // targets, so no CSV is needed.
+    const homes = await prisma.assistedLivingHome.findMany({
+      where: {
+        status: HomeStatus.DRAFT,
+        autoPopulatedAt: { not: null },
+        OR: [{ websiteUrl: { not: null } }, { autoPopulatedFromUrl: { not: null } }],
+      },
+      select: { id: true, name: true, websiteUrl: true, autoPopulatedFromUrl: true },
+      orderBy: { autoPopulatedAt: 'asc' },
+    });
+    rows = homes
+      .map((h) => ({
+        homeName: h.name,
+        homeId: h.id,
+        websiteUrl: (h.websiteUrl ?? h.autoPopulatedFromUrl) as string,
+      }))
+      .filter((r) => !!r.websiteUrl);
+    console.log(`--from-db: selected ${rows.length} auto-populated DRAFT home(s) from the database.\n`);
+  } else {
+    try {
+      rows = parseCsv(path.resolve(csvPath!));
+    } catch (e: any) {
+      console.error(`Failed to parse CSV: ${e.message}`);
+      process.exit(1);
+    }
   }
 
   if (onlyFacilityId) {
     rows = rows.filter(r => r.homeId === onlyFacilityId);
     if (rows.length === 0) {
-      console.error(`No CSV row found with homeId=${onlyFacilityId}`);
+      console.error(`No ${fromDb ? 'DB home' : 'CSV row'} found with homeId=${onlyFacilityId}`);
       process.exit(1);
     }
+  }
+
+  if (rows.length === 0) {
+    console.error(fromDb ? 'No matching homes found in DB — nothing to do.' : 'CSV contained no rows.');
+    process.exit(1);
   }
 
   console.log(`Processing ${rows.length} facilit${rows.length === 1 ? 'y' : 'ies'}…\n`);


### PR DESCRIPTION
## Why

The June-5 auto-population run (the 15 first-batch Cleveland homes) **predated the photo feature (#549)**, so those homes have text profiles but **no photos** in the DB. We want to backfill photos onto them **without** touching the already-extracted text.

The existing `--with-photos` flag can't do that: `processRow` always runs the AI **text** extraction and (on `--force`) overwrites the text fields + bumps `autoPopulatedVersion`. And `--resume` skips any home that already has `autoPopulatedAt` — i.e. it would skip all 15 and upload nothing. Running `--with-photos --force` as-is would re-extract text and risk re-introducing bad placeholder addresses (e.g. Canterbury Commons → `1234 Oak Lane`).

## What

Adds two flags to `scripts/autopopulate-cohort.ts`:

**`--photos-only`**
- Skips the AI text extraction **and** all text-field DB writes (no overwrite, no `autoPopulatedVersion` bump).
- Still scrapes the page for `<img>` candidates → `classifyFacilityImages` → `downloadAndRehost` (Cloudinary) → appends `autoPopulated` `HomePhoto` rows.
- Implies `--with-photos`, and intentionally bypasses the `--resume` "already populated" skip (those records are exactly the backfill targets).
- Idempotent: clears prior auto-populated photos before writing.

**`--from-db`**
- Skips the CSV entirely and targets all auto-populated DRAFT homes from the DB (using each home's stored `websiteUrl`/`autoPopulatedFromUrl`). Added because the original `cleveland_outreach/first_batch_websites.csv` isn't committed to the repo.

Also logs three open loops from the 2026-06-08 smoke test: **OL-060** (this backfill), **OL-061** (weak AI address extraction → Google Places fallback; `GOOGLE_PLACES_API_KEY` now in Render), **OL-062** ("Full address is required" should name the empty sub-field).

## How to run (Render shell, after merge)

No CSV needed — derive the cohort from the DB:

```bash
# dry-run first (incurs only the small image-classification API cost; no writes)
node_modules/.bin/tsx scripts/autopopulate-cohort.ts --from-db --photos-only --dry-run
# then write
node_modules/.bin/tsx scripts/autopopulate-cohort.ts --from-db --photos-only --force
```

(Or pass an explicit `homeName,homeId,websiteUrl` CSV instead of `--from-db`.)

## Cost
~$0.10–$0.50 Anthropic total for the 15 (image-classification only); Cloudinary within free tier. The dry-run incurs the classification cost too (only the download/upload is skipped).

## Verification
- `npx tsc --noEmit` passes clean (0 errors project-wide).
- Not run against prod from here (no prod DB/Anthropic/Cloudinary creds) — the Render dry-run is the gate before `--force`.

https://claude.ai/code/session_01CzvVy8ZT5cGy7h33it1gmL