### PR TITLE
feat(autopopulate): Google Places address fallback (OL-061) + clearer address validation (OL-062)

### DIFF
--- a/scripts/autopopulate-cohort.ts
+++ b/scripts/autopopulate-cohort.ts
@@ -31,6 +31,7 @@ import Papa from 'papaparse';
 import { scrapeOperatorWebsite, prepareHtmlForExtraction, ScrapeError, ImageCandidate } from '../src/lib/operator-profile-scraper';
 import { extractProfileFromWebsite, classifyFacilityImages } from '../src/lib/profile-generator/home-profile-generator';
 import { downloadAndRehost } from '../src/lib/profile-generator/photo-rehost';
+import { findAddressViaPlaces, isPlaceLookupConfigured, type PlaceAddressResult } from '../src/lib/place-lookup';
 
 const prisma = new PrismaClient();
 
@@ -150,15 +151,48 @@ async function processRow(
     preFilledFields['careLevel'] = 'AI';
   }
 
-  // Address: only update fields that are currently empty or missing
+  // Address: only fill fields that are currently empty/missing.
   const addr = extracted.address;
-  if (addr) {
-    if (!home.address?.street && addr.streetAddress) {
-      preFilledFields['street'] = 'AI';
+  const aiStreet = addr?.streetAddress?.trim() || null;
+  const aiZip = addr?.zip?.trim() || null;
+
+  // Google Places address fallback (OL-061): the website scrape frequently
+  // misses the street address (leaving the listing showing the form's
+  // "1234 Oak Lane" placeholder). When neither the DB nor the AI gives us a
+  // street, look the facility up by name + city in Google Places — authoritative
+  // for addresses — and use a HIGH/MEDIUM-confidence match.
+  let placesAddr: PlaceAddressResult | null = null;
+  if (!home.address?.street && !aiStreet && isPlaceLookupConfigured()) {
+    placesAddr = await findAddressViaPlaces({
+      name: home.name,
+      city: home.address?.city ?? null,
+      state: home.address?.state ?? null,
+    });
+    if (placesAddr && placesAddr.street && placesAddr.confidence !== 'LOW') {
+      console.log(
+        `    📍 Places address fallback: "${placesAddr.street}"` +
+        `${placesAddr.zip ? ` ${placesAddr.zip}` : ''} ` +
+        `(${placesAddr.confidence}, matched "${placesAddr.matchedName ?? '?'}")`,
+      );
+    } else {
+      if (placesAddr) {
+        console.log(`    📍 Places address: LOW-confidence match ignored ("${placesAddr.matchedName ?? '?'}")`);
+      }
+      placesAddr = null;
     }
-    if (addr.zipCode && !home.address?.zipCode) {
-      preFilledFields['zipCode'] = 'AI';
-    }
+  }
+
+  // AI scrape first, then the Places fallback, for the street/zip we persist.
+  const resolvedStreet = aiStreet ?? placesAddr?.street ?? null;
+  const resolvedZip = aiZip ?? placesAddr?.zip ?? null;
+
+  // 'AI' provenance covers both scrape- and Places-derived auto-fill for the
+  // operator-facing badge (FieldProvenance has no 'PLACES' variant).
+  if (!home.address?.street && resolvedStreet) {
+    preFilledFields['street'] = 'AI';
+  }
+  if (!home.address?.zipCode && resolvedZip) {
+    preFilledFields['zipCode'] = 'AI';
   }
 
   // Mark existing seed fields (from DOH) as SEED provenance
@@ -193,11 +227,11 @@ async function processRow(
   if (!dryRun) {
     await prisma.assistedLivingHome.update({ where: { id: homeId }, data: updateData });
 
-    // Upsert address if we got street/zip from AI and home already has an address record
-    if (home.address && addr) {
+    // Upsert address — fill empty street/zip from the AI scrape or Places fallback.
+    if (home.address) {
       const addrUpdate: Record<string, string> = {};
-      if (!home.address.street && addr.streetAddress) addrUpdate.street = addr.streetAddress;
-      if (!home.address.zipCode && addr.zip) addrUpdate.zipCode = addr.zip;
+      if (!home.address.street && resolvedStreet) addrUpdate.street = resolvedStreet;
+      if (!home.address.zipCode && resolvedZip) addrUpdate.zipCode = resolvedZip;
       if (Object.keys(addrUpdate).length > 0) {
         await prisma.address.update({ where: { id: home.address.id }, data: addrUpdate });
       }

--- a/src/app/operator/onboarding/[step]/page.tsx
+++ b/src/app/operator/onboarding/[step]/page.tsx
@@ -336,8 +336,13 @@ export default function OperatorOnboardingStepPage() {
   const submitHome = async () => {
     if (!home.name.trim()) { setError("Home name is required."); return; }
     if (!home.description.trim()) { setError("A brief description is required."); return; }
-    if (!home.street.trim() || !home.city.trim() || !home.state.trim() || !home.zipCode.trim()) {
-      setError("Full address is required.");
+    const missingAddress: string[] = [];
+    if (!home.street.trim()) missingAddress.push("Street address");
+    if (!home.city.trim()) missingAddress.push("City");
+    if (!home.state.trim()) missingAddress.push("State");
+    if (!home.zipCode.trim()) missingAddress.push("ZIP code");
+    if (missingAddress.length > 0) {
+      setError(`${missingAddress.join(", ")} ${missingAddress.length === 1 ? "is" : "are"} required.`);
       return;
     }
     if (home.careLevel.length === 0) { setError("Select at least one care type."); return; }

--- a/src/lib/place-lookup.ts
+++ b/src/lib/place-lookup.ts
@@ -296,3 +296,117 @@ export async function findWebsiteViaPlaces(
   }
   return best;
 }
+
+// ── Address backfill (OL-061) ────────────────────────────────────────────────
+// The website scrape frequently misses a facility's street address. Google
+// Places is authoritative for addresses, so we look the facility up by
+// name + city and read its structured address components. Unlike the website
+// discovery above, this does NOT require the matched place to have a website.
+
+interface PlacesAddressComponent {
+  longText?: string;
+  shortText?: string;
+  types?: string[];
+}
+
+interface PlacesApiPlaceWithAddress extends PlacesApiPlace {
+  addressComponents?: PlacesAddressComponent[];
+}
+
+export interface PlaceAddressResult {
+  street: string | null;
+  city: string | null;
+  state: string | null;
+  zip: string | null;
+  formattedAddress: string | null;
+  confidence: LookupConfidence;
+  matchedName: string | null;
+}
+
+function pickComponent(
+  components: PlacesAddressComponent[] | undefined,
+  type: string,
+  prefer: 'long' | 'short' = 'long',
+): string | null {
+  const c = components?.find((x) => x.types?.includes(type));
+  if (!c) return null;
+  return (prefer === 'short' ? c.shortText : c.longText) ?? c.longText ?? c.shortText ?? null;
+}
+
+function parsePlacesAddress(components?: PlacesAddressComponent[]) {
+  const streetNumber = pickComponent(components, 'street_number');
+  const route = pickComponent(components, 'route');
+  const street = [streetNumber, route].filter(Boolean).join(' ').trim() || null;
+  return {
+    street,
+    city: pickComponent(components, 'locality') ?? pickComponent(components, 'postal_town'),
+    state: pickComponent(components, 'administrative_area_level_1', 'short'),
+    zip: pickComponent(components, 'postal_code'),
+  };
+}
+
+/**
+ * Look up a facility's street address via Google Places (New) Text Search by
+ * name + city. Returns the best name/city-matched candidate's structured
+ * address (highest confidence wins), or null (not configured / network error /
+ * no candidate that yields a street). Server-side only.
+ */
+export async function findAddressViaPlaces(
+  input: PlaceLookupInput,
+): Promise<PlaceAddressResult | null> {
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) return null;
+
+  const locationParts = [input.city, input.state].filter(Boolean);
+  const textQuery = `${input.name} assisted living ${locationParts.join(' ')}`.trim();
+
+  let res: Response;
+  try {
+    res = await fetch(PLACES_SEARCH_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Goog-Api-Key': apiKey,
+        'X-Goog-FieldMask':
+          'places.id,places.displayName,places.formattedAddress,places.addressComponents',
+      },
+      body: JSON.stringify({ textQuery, maxResultCount: 5, regionCode: 'US' }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+
+  let data: { places?: PlacesApiPlaceWithAddress[] };
+  try {
+    data = await res.json();
+  } catch {
+    return null;
+  }
+
+  const places = Array.isArray(data.places) ? data.places : [];
+  let best: PlaceAddressResult | null = null;
+  for (const p of places) {
+    const matchedName = p.displayName?.text ?? null;
+    const formattedAddress = p.formattedAddress ?? null;
+    const score = matchedName ? nameMatchScore(input.name, matchedName) : 0;
+    const cityMatch =
+      !!input.city && !!formattedAddress &&
+      formattedAddress.toLowerCase().includes(input.city.toLowerCase());
+
+    let confidence: LookupConfidence;
+    if (score >= 0.6 && cityMatch) confidence = 'HIGH';
+    else if (score >= 0.6 || (score >= 0.34 && cityMatch)) confidence = 'MEDIUM';
+    else confidence = 'LOW';
+
+    const parsed = parsePlacesAddress(p.addressComponents);
+    if (!parsed.street) continue; // only candidates that actually yield a street
+
+    if (!best || RANK[confidence] > RANK[best.confidence]) {
+      best = { ...parsed, formattedAddress, confidence, matchedName };
+    }
+    if (confidence === 'HIGH') break;
+  }
+  return best;
+}


### PR DESCRIPTION
## Why

Two data-quality items from the 2026-06-08 prod smoke test, both hurting outreach credibility:

- **OL-061** — the website scrape frequently misses a facility's **street address**, so the seeded listing shows the onboarding form's `1234 Oak Lane` *placeholder* (what was observed for Canterbury Commons). `GOOGLE_PLACES_API_KEY` is now set in Render.
- **OL-062** — "Full address is required" doesn't say *which* sub-field is empty (State, in the smoke test).

## What

**OL-061 — Google Places address fallback**
- `src/lib/place-lookup.ts`: new `findAddressViaPlaces({ name, city, state })` — reuses the existing Places API (New) Text Search + name/city scoring, requests `addressComponents`, and returns the best HIGH/MEDIUM-confidence match's structured `{ street, city, state, zip }`. (The existing lookup funcs only return places that have a *website*; this one is address-focused.)
- `scripts/autopopulate-cohort.ts`: when **neither the DB nor the AI** gives a street, look the facility up by name + city and fill `street`/`zip` from Places. Addresses are only **filled when empty — never overwritten**. LOW-confidence matches are ignored. Runs in `--dry-run` too (prints what it would fill; Places calls are within the free credit).
- Also fixes a latent bug: AI zip provenance checked `addr.zipCode` but the field is `addr.zip` (the actual DB write already used `addr.zip`).

**OL-062 — clearer validation**
- `src/app/operator/onboarding/[step]/page.tsx`: now reports e.g. `State is required.` / `Street address, ZIP code are required.`

Provenance: Places-filled fields use `'AI'` for the operator badge (`FieldProvenance` has no `'PLACES'` variant) — no UI change.

## Verification
- `npx tsc --noEmit` passes clean (0 errors project-wide).
- Not run against prod from here (no `GOOGLE_PLACES_API_KEY`/DB in this container).

## Applying to the existing 15 homes
This fills addresses on **future** populate runs. The 15 first-batch homes already populated would get their missing streets on a normal (non-`--photos-only`) `--force` re-run (addresses are fill-only, so nothing good is overwritten; cost is the text re-extraction, ~$1.44). If you'd prefer to backfill addresses **without** re-extracting text, I can add an `--addresses-only` mode (mirroring `--photos-only` in #553) — say the word.

Relates to OL-061 / OL-062 (filed in #553's open-loops update).

https://claude.ai/code/session_01CzvVy8ZT5cGy7h33it1gmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzvVy8ZT5cGy7h33it1gmL)_