### PR TITLE
feat(autopopulate): website-match precision + verbose Places diagnostics for --addresses-only

### DIFF
--- a/scripts/autopopulate-cohort.ts
+++ b/scripts/autopopulate-cohort.ts
@@ -47,7 +47,7 @@ import Papa from 'papaparse';
 import { scrapeOperatorWebsite, prepareHtmlForExtraction, ScrapeError, ImageCandidate } from '../src/lib/operator-profile-scraper';
 import { extractProfileFromWebsite, classifyFacilityImages } from '../src/lib/profile-generator/home-profile-generator';
 import { downloadAndRehost } from '../src/lib/profile-generator/photo-rehost';
-import { findAddressViaPlaces, isPlaceLookupConfigured, type PlaceAddressResult } from '../src/lib/place-lookup';
+import { findAddressViaPlaces, lookupAddressViaPlaces, isPlaceLookupConfigured, type PlaceAddressResult } from '../src/lib/place-lookup';
 
 const prisma = new PrismaClient();
 
@@ -196,6 +196,7 @@ async function processRow(
         name: home.name,
         city: home.address?.city ?? null,
         state: home.address?.state ?? null,
+        website: websiteUrl,
       });
       if (placesAddr && placesAddr.street && placesAddr.confidence !== 'LOW') {
         console.log(
@@ -368,6 +369,7 @@ async function processRow(
  */
 async function backfillAddressViaPlaces(
   home: {
+    websiteUrl: string | null;
     preFilledFields: unknown;
     address: { id: string; city: string; state: string; street: string | null; zipCode: string | null } | null;
   },
@@ -380,18 +382,30 @@ async function backfillAddressViaPlaces(
     return { status: 'skipped', homeId, homeName, reason: 'already has a street address' };
   }
 
-  const placesAddr = await findAddressViaPlaces({
+  const lookup = await lookupAddressViaPlaces({
     name: homeName,
     city: existing?.city ?? null,
     state: existing?.state ?? null,
+    website: home.websiteUrl ?? null,
   });
 
+  // Verbose diagnostics — distinguish "no candidates" from an API/quota error.
+  console.log(
+    `  🔎 ${homeName} — Places[${lookup.status}` +
+    `${lookup.httpStatus ? ` http=${lookup.httpStatus}` : ''}] ` +
+    `candidates=${lookup.candidateCount} ` +
+    `top="${lookup.topCandidateName ?? '—'}" @ "${lookup.topCandidateAddress ?? '—'}"` +
+    `${lookup.error ? ` err=${lookup.error.replace(/\s+/g, ' ').slice(0, 160)}` : ''}`,
+  );
+
+  const placesAddr = lookup.result;
   if (!placesAddr || !placesAddr.street || placesAddr.confidence === 'LOW') {
-    console.log(
-      `  📍 ${homeName} — no usable Places address match` +
-      (placesAddr ? ` (LOW: "${placesAddr.matchedName ?? '?'}")` : ''),
-    );
-    return { status: 'skipped', homeId, homeName, reason: 'no usable Places address match' };
+    return {
+      status: 'skipped',
+      homeId,
+      homeName,
+      reason: `no usable Places address match (${lookup.status}${placesAddr ? `, ${placesAddr.confidence}` : ''})`,
+    };
   }
 
   const provenanceFields: string[] = [];

--- a/src/lib/place-lookup.ts
+++ b/src/lib/place-lookup.ts
@@ -31,6 +31,8 @@ export interface PlaceLookupInput {
   state?: string | null;
   street?: string | null;
   zip?: string | null;
+  /** The operator's known website — used to disambiguate Places candidates. */
+  website?: string | null;
 }
 
 export type LookupSource = 'places' | 'web_search';
@@ -345,17 +347,29 @@ function parsePlacesAddress(components?: PlacesAddressComponent[]) {
   };
 }
 
+export interface AddressLookupDiagnostics {
+  status: 'ok' | 'no_match' | 'no_candidates' | 'http_error' | 'network_error' | 'parse_error' | 'not_configured';
+  httpStatus?: number;
+  error?: string;
+  candidateCount: number;
+  topCandidateName: string | null;
+  topCandidateAddress: string | null;
+  result: PlaceAddressResult | null;
+}
+
 /**
  * Look up a facility's street address via Google Places (New) Text Search by
- * name + city. Returns the best name/city-matched candidate's structured
- * address (highest confidence wins), or null (not configured / network error /
- * no candidate that yields a street). Server-side only.
+ * name (+ any known city/state). Ranks candidates by name overlap, a city-match
+ * bonus, and — the strongest signal — a website-host match against
+ * `input.website` (the operator's known site). Returns rich diagnostics so
+ * callers can tell "no candidates" apart from an API/quota error. Server-side only.
  */
-export async function findAddressViaPlaces(
+export async function lookupAddressViaPlaces(
   input: PlaceLookupInput,
-): Promise<PlaceAddressResult | null> {
+): Promise<AddressLookupDiagnostics> {
+  const base = { candidateCount: 0, topCandidateName: null, topCandidateAddress: null, result: null };
   const apiKey = process.env.GOOGLE_PLACES_API_KEY;
-  if (!apiKey) return null;
+  if (!apiKey) return { status: 'not_configured', ...base };
 
   const locationParts = [input.city, input.state].filter(Boolean);
   const textQuery = `${input.name} assisted living ${locationParts.join(' ')}`.trim();
@@ -368,24 +382,41 @@ export async function findAddressViaPlaces(
         'Content-Type': 'application/json',
         'X-Goog-Api-Key': apiKey,
         'X-Goog-FieldMask':
-          'places.id,places.displayName,places.formattedAddress,places.addressComponents',
+          'places.id,places.displayName,places.formattedAddress,places.addressComponents,places.websiteUri',
       },
       body: JSON.stringify({ textQuery, maxResultCount: 5, regionCode: 'US' }),
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
-  } catch {
-    return null;
+  } catch (e: any) {
+    return { status: 'network_error', error: String(e?.message ?? e), ...base };
   }
-  if (!res.ok) return null;
+
+  if (!res.ok) {
+    let body = '';
+    try { body = (await res.text()).slice(0, 300); } catch { /* ignore */ }
+    return { status: 'http_error', httpStatus: res.status, error: body || res.statusText, ...base };
+  }
 
   let data: { places?: PlacesApiPlaceWithAddress[] };
   try {
     data = await res.json();
-  } catch {
-    return null;
+  } catch (e: any) {
+    return { status: 'parse_error', error: String(e?.message ?? e), ...base };
   }
 
   const places = Array.isArray(data.places) ? data.places : [];
+  const top = places[0];
+  const diag = {
+    candidateCount: places.length,
+    topCandidateName: top?.displayName?.text ?? null,
+    topCandidateAddress: top?.formattedAddress ?? null,
+  };
+  if (places.length === 0) {
+    return { status: 'no_candidates', ...diag, result: null };
+  }
+
+  const inputHost = input.website ? hostOf(input.website) : null;
+
   let best: PlaceAddressResult | null = null;
   for (const p of places) {
     const matchedName = p.displayName?.text ?? null;
@@ -394,9 +425,12 @@ export async function findAddressViaPlaces(
     const cityMatch =
       !!input.city && !!formattedAddress &&
       formattedAddress.toLowerCase().includes(input.city.toLowerCase());
+    const candHost = p.websiteUri ? hostOf(p.websiteUri) : null;
+    const websiteMatch = !!inputHost && !!candHost && candHost === inputHost;
 
+    // A website-host match is decisive (it's the operator's own site).
     let confidence: LookupConfidence;
-    if (score >= 0.6 && cityMatch) confidence = 'HIGH';
+    if (websiteMatch || (score >= 0.6 && cityMatch)) confidence = 'HIGH';
     else if (score >= 0.6 || (score >= 0.34 && cityMatch)) confidence = 'MEDIUM';
     else confidence = 'LOW';
 
@@ -408,5 +442,16 @@ export async function findAddressViaPlaces(
     }
     if (confidence === 'HIGH') break;
   }
-  return best;
+
+  return { status: best ? 'ok' : 'no_match', ...diag, result: best };
+}
+
+/**
+ * Convenience wrapper: the best usable address match, or null. Back-compat for
+ * callers that don't need diagnostics.
+ */
+export async function findAddressViaPlaces(
+  input: PlaceLookupInput,
+): Promise<PlaceAddressResult | null> {
+  return (await lookupAddressViaPlaces(input)).result;
 }


### PR DESCRIPTION
## Why

Re-running `--from-db --addresses-only` on the deployed fix returned **`no usable Places address match` for all 14 homes, $0.000 spend** — which could be either (a) the name-only query is too weak, or (b) the Places call is failing silently (the old code swallowed HTTP/network/parse errors as `null`, indistinguishable from "no match"). This change makes the cause observable and improves matching.

## What

**`src/lib/place-lookup.ts`**
- New `lookupAddressViaPlaces()` returns rich **diagnostics**: `status` (`ok` / `no_match` / `no_candidates` / `http_error` / `network_error` / `parse_error` / `not_configured`), `httpStatus`, `error`, `candidateCount`, and the top candidate's name + formatted address — alongside the chosen `result`.
- **Website-match ranking:** field mask now requests `places.websiteUri`; a candidate whose website host equals the home's stored `websiteUrl` host is treated as the **decisive HIGH-confidence** match. These homes were originally *discovered* via Places, so their site should match the Place — this should fix weak name-only matching.
- `findAddressViaPlaces()` is now a thin wrapper over `lookupAddressViaPlaces()` (back-compat; the normal-run fallback is unchanged behaviorally).

**`scripts/autopopulate-cohort.ts`**
- `--addresses-only` prints a per-home diagnostic line, e.g.:
  ```
  🔎 Judson Manor — Places[ok] candidates=3 top="Judson Manor" @ "1890 E 107th St, Cleveland, OH 44106"
  🔎 Foo — Places[http_error http=403] candidates=0 top="—" @ "—" err=PERMISSION_DENIED ...
  ```
  so we can immediately tell **"no candidates" apart from an API/quota/key error**.
- Passes each home's `websiteUrl` into the lookup (both `--addresses-only` and the normal-run fallback).

`npx tsc --noEmit` clean.

## Run (Render, after merge)

```
tsx scripts/autopopulate-cohort.ts --from-db --addresses-only --dry-run
```
The new `🔎 Places[...]` line will tell us exactly what's happening per home. If it shows `http_error`/`network_error`, it's a key/quota issue (likely the Places API "Places API (New)" not enabled, or referrer/IP restriction on the key); if it shows `no_candidates`/`no_match`, it's matching. Paste me the dry-run output and I'll take it from there.

https://claude.ai/code/session_01CzvVy8ZT5cGy7h33it1gmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzvVy8ZT5cGy7h33it1gmL)_