### PR TITLE
fix(ci): e2e jobs must use the ephemeral service DB, never prod (stops test-home leak)

### DIFF
--- a/.github/workflows/e2e-family.yml
+++ b/.github/workflows/e2e-family.yml
@@ -50,8 +50,12 @@ jobs:
       ALLOW_INSECURE_AUTH_COOKIE: "1"
       # Cache Playwright browsers to speed up CI
       PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
-      # DB
-      DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+      # DB — MUST be the ephemeral `postgres` service container below, NEVER a
+      # real/staging/prod database. The e2e jobs enable ALLOW_DEV_ENDPOINTS and
+      # seed via /api/dev/* , so pointing this at prod writes test data into
+      # production (this is exactly how 43 test homes leaked into prod). Do not
+      # restore secrets.E2E_DATABASE_URL here.
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/carelinkai_marketplace?schema=public
       # S3 disabled in CI by default (mock URLs)
       S3_DISABLE: "1"
 
@@ -162,8 +166,12 @@ jobs:
       ALLOW_INSECURE_AUTH_COOKIE: "1"
       # Cache Playwright browsers to speed up CI
       PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
-      # DB
-      DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+      # DB — MUST be the ephemeral `postgres` service container below, NEVER a
+      # real/staging/prod database. The e2e jobs enable ALLOW_DEV_ENDPOINTS and
+      # seed via /api/dev/* , so pointing this at prod writes test data into
+      # production (this is exactly how 43 test homes leaked into prod). Do not
+      # restore secrets.E2E_DATABASE_URL here.
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/carelinkai_marketplace?schema=public
       # S3 disabled in CI by default (mock URLs)
       S3_DISABLE: "1"
 
@@ -260,7 +268,9 @@ jobs:
       ALLOW_DEV_ENDPOINTS: "1"
       ALLOW_INSECURE_AUTH_COOKIE: "1"
       PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
-      DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+      # Ephemeral service-container DB only — NEVER prod (see note in the other
+      # e2e jobs). ALLOW_DEV_ENDPOINTS seeding must not reach a real database.
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/carelinkai_marketplace?schema=public
       S3_DISABLE: "1"
 
     steps:


### PR DESCRIPTION
## Root cause (Part 1 of 3) — CI was writing to production

Chris found **43 test homes in production** (`Founder Co Home`, `Seed Directory Co`, `Op E2E`, `claim-seed-*@test.carelinkai.com`, `Dev home for E2E`). Those fingerprints are exactly what `/api/dev/upsert-operator` creates, driven by `e2e/operator-claim-flow.spec.ts`.

**How they reached prod:** `e2e-family.yml` provisions a throwaway `postgres:15` service container per job, **but then sets `DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}`** (which points at the production DB) and enables `ALLOW_DEV_ENDPOINTS=1`. So `prisma migrate deploy`, the app server, and the `/api/dev/*` seeding all ran against **prod** during the spec's pre-parking CI runs — writing test operators/homes straight into production. The ephemeral service container was provisioned but ignored.

## Fix

Point all three e2e jobs' `DATABASE_URL` at the **local service container** (`postgresql://postgres:postgres@localhost:5432/carelinkai_marketplace`) instead of `secrets.E2E_DATABASE_URL`. CI now runs against a fresh ephemeral DB and **cannot write to any real database**, regardless of what the secret contains. Prominent comments added so it isn't reverted.

`ci.yml`'s `prisma migrate deploy` against `secrets.DATABASE_URL` on `main` is left as-is — that's the intended DDL-migration path (no test-data writes).

## ⚠️ Separate check for you (not code)
Confirm **production does NOT set `ALLOW_DEV_ENDPOINTS=1`** in Render — the `/api/dev/*` routes (seed/login) should never be reachable against the prod DB. (This PR stops CI from pointing at prod; that env check closes the other door.)

## Follow-ups (separate PRs)
- Part 2: `scripts/cleanup-e2e-test-homes.ts` to delete the 43 leaked homes + their test operators/users/photos.
- Part 3: `--include-active` so the auto-populated backfills also cover the now-ACTIVE real Canterbury Commons.

YAML validated. No app code changed.

https://claude.ai/code/session_01CzvVy8ZT5cGy7h33it1gmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzvVy8ZT5cGy7h33it1gmL)_