### PR TITLE
feat(cnos): gate household-employer lane + unaffiliated dispatch behind env flags (default off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,3 +160,15 @@ CRON_SECRET="..."
 # ------------------------------------------------------------
 # NEXT_PUBLIC_VAPID_PUBLIC_KEY="..."
 # VAPID_PRIVATE_KEY="..."
+
+# ------------------------------------------------------------
+# CNOS FEATURE FLAGS — DEFAULT OFF (see docs/SHIFT_FILL_ENGINE_AUDIT.md C1/C2)
+# Gate behaviors that conflict with the 2026-06-08 CNOS decisions (no household-
+# employer lane; unaffiliated-caregiver marketplace frozen). Leave UNSET in
+# production until the attorney consult un-gates them. Set to "1" to enable.
+# ------------------------------------------------------------
+# Household-employer lane (HouseholdShift + /api/family/household + "My Household" UI).
+# NEXT_PUBLIC so server routes and client UI agree (rebuild to flip).
+# NEXT_PUBLIC_ENABLE_HOUSEHOLD_EMPLOYER_LANE="1"
+# On-call dispatch to unaffiliated caregivers (no employer). Off = operator's own only.
+# ENABLE_UNAFFILIATED_DISPATCH="1"

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ playwright-report/
 
 # Operator website scrape cache
 scripts/scraped-cache/
+
+# Claude Code local worktrees (transient background-agent state)
+.claude/worktrees/

--- a/src/app/api/family/household/route.ts
+++ b/src/app/api/family/household/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { isHouseholdEmployerLaneEnabled } from "@/lib/feature-flags";
 import { z } from "zod";
 
 const shiftSchema = z.object({
@@ -18,6 +19,10 @@ const shiftSchema = z.object({
  * Returns all active hires for this FAMILY user, each with their HouseholdShifts.
  */
 export async function GET(req: NextRequest) {
+  // CNOS: household-employer lane is gated off pending legal review.
+  if (!isHouseholdEmployerLaneEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -57,6 +62,10 @@ export async function GET(req: NextRequest) {
  * Creates a new HouseholdShift. The hireId must belong to a listing posted by this user.
  */
 export async function POST(req: NextRequest) {
+  // CNOS: household-employer lane is gated off pending legal review.
+  if (!isHouseholdEmployerLaneEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/family/household/shifts/[id]/route.ts
+++ b/src/app/api/family/household/shifts/[id]/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { isHouseholdEmployerLaneEnabled } from "@/lib/feature-flags";
 import { z } from "zod";
 
 const patchSchema = z.object({
@@ -25,6 +26,10 @@ async function getOwnedShift(shiftId: string, userId: string) {
  * Update the status (or notes) of a shift owned by this family user.
  */
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  // CNOS: household-employer lane is gated off pending legal review.
+  if (!isHouseholdEmployerLaneEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -57,6 +62,10 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
  * Permanently remove a shift owned by this family user.
  */
 export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  // CNOS: household-employer lane is gated off pending legal review.
+  if (!isHouseholdEmployerLaneEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/marketplace/hires/page.tsx
+++ b/src/app/marketplace/hires/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { isHouseholdEmployerLaneEnabled } from "@/lib/feature-flags";
 import { format, parseISO } from "date-fns";
 import {
   FiCheckCircle, FiCalendar, FiBriefcase, FiUser, FiPlus,
@@ -277,6 +278,9 @@ export default function MyHiresPage() {
   const router = useRouter();
   const role = (session?.user as { role?: string })?.role;
   const isFamily = role === "FAMILY";
+  // CNOS: the family household-employer lane is gated off pending legal review.
+  const householdEnabled = isHouseholdEmployerLaneEnabled();
+  const householdGatedOff = isFamily && !householdEnabled;
 
   // Family state
   const [familyHires, setFamilyHires] = useState<FamilyHire[]>([]);
@@ -295,7 +299,9 @@ export default function MyHiresPage() {
     try {
       setLoading(true);
       setError(null);
-      if (isFamily) {
+      if (householdGatedOff) {
+        setFamilyHires([]);
+      } else if (isFamily) {
         const res = await fetch("/api/family/household", { cache: "no-store" });
         if (!res.ok) throw new Error("Failed to load hires");
         const json = await res.json();
@@ -311,7 +317,7 @@ export default function MyHiresPage() {
     } finally {
       setLoading(false);
     }
-  }, [status, isFamily]);
+  }, [status, isFamily, householdGatedOff]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -340,7 +346,17 @@ export default function MyHiresPage() {
         </div>
       )}
 
-      {!loading && !error && isEmpty && (
+      {householdGatedOff && !loading && (
+        <div className="rounded-lg border border-neutral-200 bg-white p-12 text-center shadow-sm">
+          <FiBriefcase size={48} className="mx-auto text-neutral-300 mb-4" />
+          <h2 className="text-lg font-semibold text-neutral-900 mb-2">Household scheduling isn’t available</h2>
+          <p className="text-neutral-500">
+            Direct household hiring &amp; shift scheduling isn’t available on CareLinkAI right now.
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && isEmpty && !householdGatedOff && (
         <div className="rounded-lg border border-neutral-200 bg-white p-12 text-center shadow-sm">
           <FiBriefcase size={48} className="mx-auto text-neutral-300 mb-4" />
           <h2 className="text-lg font-semibold text-neutral-900 mb-2">No hires yet</h2>

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,30 @@
+/**
+ * CNOS feature flags — DEFAULT OFF.
+ *
+ * These gate behaviors that conflict with the CNOS decisions ratified by Chris on
+ * 2026-06-08 (after the shift-fill engine landed 2026-05-07):
+ *   - NO household-employer lane (CareLinkAI does not place caregivers directly
+ *     with private households as employer/intermediary)
+ *   - the unaffiliated-caregiver marketplace is FROZEN
+ *
+ * The shift-fill engine implemented both (see docs/SHIFT_FILL_ENGINE_AUDIT.md, C1/C2).
+ * Until the attorney consult un-gates them, both default OFF so the frozen
+ * behaviors cannot be exercised in production. Flip to "1" only on legal sign-off.
+ */
+
+/**
+ * Household-employer lane: the family-posts-listing -> hires -> schedules-shifts
+ * flow (HouseholdShift, /api/family/household, the "My Household" UI). NEXT_PUBLIC
+ * so both server routes and client UI read the same value (rebuild to flip).
+ */
+export function isHouseholdEmployerLaneEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_ENABLE_HOUSEHOLD_EMPLOYER_LANE === '1';
+}
+
+/**
+ * On-call dispatch to UNAFFILIATED caregivers (no employment relationship).
+ * When off, the dispatcher only contacts the operator's own employed caregivers.
+ */
+export function isUnaffiliatedDispatchEnabled(): boolean {
+  return process.env.ENABLE_UNAFFILIATED_DISPATCH === '1';
+}

--- a/src/lib/oncall/dispatcher.ts
+++ b/src/lib/oncall/dispatcher.ts
@@ -3,6 +3,7 @@ import { loadRules } from './rules';
 import { rankCandidates } from './ranker';
 import { templates } from './messages';
 import { SMSService } from '@/lib/sms/sms-service';
+import { isUnaffiliatedDispatchEnabled } from '@/lib/feature-flags';
 
 const sms = new SMSService();
 
@@ -44,7 +45,9 @@ export async function dispatchWave(shiftNeedId: string): Promise<{
       id: { notIn: [...excludeIds] },
       OR: [
         { employments: { some: { operatorId: need.home.operatorId, endDate: null } } },
-        { employments: { none: {} } },
+        // CNOS: the unaffiliated-caregiver pool (no employer) is frozen — only
+        // reach into it when explicitly enabled (default off).
+        ...(isUnaffiliatedDispatchEnabled() ? [{ employments: { none: {} } as const }] : []),
       ],
     },
     include: {


### PR DESCRIPTION
## What

Enforces the **2026-06-08 CNOS decisions** (no household-employer lane; unaffiliated-caregiver marketplace frozen) against the shift-fill engine that landed *before* them (2026-05-07). See `docs/SHIFT_FILL_ENGINE_AUDIT.md` §7 **C1/C2**. Both flags **default OFF**, so the frozen behaviors can't be exercised in prod; the attorney consult decides whether to un-gate.

## Flags (`src/lib/feature-flags.ts`)
- `NEXT_PUBLIC_ENABLE_HOUSEHOLD_EMPLOYER_LANE` → `isHouseholdEmployerLaneEnabled()` (server **and** client)
- `ENABLE_UNAFFILIATED_DISPATCH` → `isUnaffiliatedDispatchEnabled()` (server only)

## Gates
- **Household lane (authoritative server gate):** `/api/family/household` (GET/POST) and `/api/family/household/shifts/[id]` (PATCH/DELETE) return **404** when disabled — the lane is fully closed regardless of UI.
- **Household UI:** the family hire/household-scheduling section on `/marketplace/hires` is hidden and replaced with an "isn't available" notice when disabled (no fetch either).
- **Dispatcher:** the `employments: { none: {} }` (unaffiliated) candidate branch is included **only** when `ENABLE_UNAFFILIATED_DISPATCH=1`; otherwise on-call auto-fill contacts the operator's **own employed** caregivers only.
- `.env.example`: both flags documented, with a "leave unset in prod until legal un-gates" note.

## Why default-off is safe / cheap
Per the audit, the engine is likely **dormant** in prod (Twilio/cron config unverified), so gating costs nothing today and prevents the lane from being switched on inadvertently. Un-gating later is a one-line env change (rebuild for the `NEXT_PUBLIC` one).

`npx tsc --noEmit` clean. No schema/migration changes.

https://claude.ai/code/session_01CzvVy8ZT5cGy7h33it1gmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzvVy8ZT5cGy7h33it1gmL)_