### PR TITLE
fix(inquiries): map listing form fields to the API contract (was 400)

### DIFF
--- a/__tests__/inquiries.payload.unit.test.ts
+++ b/__tests__/inquiries.payload.unit.test.ts
@@ -1,0 +1,70 @@
+import { buildInquiryPayload, InquiryFormState } from "@/lib/inquiries/payload";
+import { createInquirySchema } from "@/lib/inquiries/schema";
+
+const fullForm: InquiryFormState = {
+  name: "Jane Doe",
+  email: "jane@example.com",
+  phone: "(216) 555-0100",
+  residentName: "Robert Doe",
+  moveInTimeframe: "1-3 months",
+  careNeeded: ["Assisted Living", "Medication Management"],
+  message: "Looking for a room with a garden view.",
+};
+
+describe("buildInquiryPayload", () => {
+  it("maps form fields onto the canonical API field names", () => {
+    const payload = buildInquiryPayload("home_123", fullForm, "2026-07-01T15:00:00.000Z");
+
+    expect(payload).toMatchObject({
+      homeId: "home_123",
+      contactName: "Jane Doe",
+      contactEmail: "jane@example.com",
+      contactPhone: "(216) 555-0100",
+      careRecipientName: "Robert Doe",
+      careNeeds: ["Assisted Living", "Medication Management"],
+      message: "Looking for a room with a garden view.",
+      source: "WEBSITE",
+    });
+    // moveInTimeframe has no column on Inquiry, so it is preserved here.
+    expect(payload.additionalInfo).toContain("1-3 months");
+  });
+
+  it("produces a payload that passes the real /api/inquiries Zod schema", () => {
+    const payload = buildInquiryPayload("home_123", fullForm, undefined);
+    const result = createInquirySchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it("validates even when optional fields (phone, resident name) are blank", () => {
+    const minimal: InquiryFormState = {
+      name: "Jane Doe",
+      email: "jane@example.com",
+      phone: "",
+      residentName: "",
+      moveInTimeframe: "",
+      careNeeded: ["Assisted Living"],
+      message: "",
+    };
+    const payload = buildInquiryPayload("home_123", minimal);
+
+    expect(payload.contactPhone).toBeUndefined();
+    expect(payload.careRecipientName).toBeUndefined();
+    expect(payload.additionalInfo).toBeUndefined();
+    expect(createInquirySchema.safeParse(payload).success).toBe(true);
+  });
+
+  it("rejects the OLD (pre-fix) form shape — proving the bug it fixes", () => {
+    const legacyPayload = {
+      homeId: "home_123",
+      name: "Jane Doe",
+      email: "jane@example.com",
+      phone: "(216) 555-0100",
+      residentName: "Robert Doe",
+      careNeeded: ["Assisted Living"],
+      source: "home_detail",
+    };
+    const result = createInquirySchema.safeParse(legacyPayload as any);
+    // contactName/contactEmail missing + invalid source enum → 400.
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/app/api/inquiries/route.ts
+++ b/src/app/api/inquiries/route.ts
@@ -6,27 +6,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { z } from 'zod';
 import { afterInquiryCreated } from '@/lib/hooks/inquiry-hooks';
 import { smsService } from '@/lib/sms/sms-service';
-
-// Validation schema for creating inquiries
-const createInquirySchema = z.object({
-  familyId: z.string().optional(),
-  homeId: z.string(),
-  contactName: z.string().min(1, 'Contact name is required'),
-  contactEmail: z.string().email('Valid email is required'),
-  contactPhone: z.string().optional(),
-  careRecipientName: z.string().min(1, 'Care recipient name is required'),
-  careRecipientAge: z.number().int().positive().optional(),
-  careNeeds: z.array(z.string()).optional().default([]),
-  additionalInfo: z.string().optional(),
-  message: z.string().optional(),
-  urgency: z.enum(['LOW', 'MEDIUM', 'HIGH', 'URGENT']).optional().default('MEDIUM'),
-  source: z.enum(['WEBSITE', 'PHONE', 'EMAIL', 'REFERRAL', 'SOCIAL_MEDIA', 'WALK_IN', 'OTHER']).optional().default('WEBSITE'),
-  preferredContactMethod: z.enum(['EMAIL', 'PHONE', 'SMS', 'ANY']).optional().default('EMAIL'),
-  affiliateCode: z.string().optional(), // referral code from ?ref= URL param
-});
+import { createInquirySchema } from '@/lib/inquiries/schema';
 
 /**
  * POST /api/inquiries - Create a new inquiry

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -45,6 +45,7 @@ import PhotoGallery from "@/components/homes/PhotoGallery";
 import PricingCalculator from "@/components/homes/PricingCalculator";
 import type { PricingEstimate } from "@/components/homes/PricingCalculator";
 import { getCloudinaryAvatar, isCloudinaryUrl } from "@/lib/cloudinaryUrl";
+import { buildInquiryPayload } from "@/lib/inquiries/payload";
 
 // Dynamically import the SimpleMap component with SSR disabled
 const SimpleMap = dynamic(
@@ -530,18 +531,12 @@ export default function HomeDetailPage() {
     }
 
     console.log('🔴 [TOUR DIAGNOSTIC] Step 2: Building request payload...');
-    const payload = {
-      homeId: String(id),
-      name: inquiryForm.name.trim(),
-      email: inquiryForm.email.trim(),
-      phone: inquiryForm.phone.trim() || undefined,
-      residentName: inquiryForm.residentName.trim() || undefined,
-      moveInTimeframe: inquiryForm.moveInTimeframe || undefined,
-      careNeeded: inquiryForm.careNeeded,
-      message: inquiryForm.message.trim() || undefined,
-      tourDate: tourDateIso,
-      source: 'home_detail',
-    };
+    // Map the form fields onto the /api/inquiries contract (the canonical
+    // Zod schema). The form historically posted name/email/phone/residentName/
+    // careNeeded/source:'home_detail', none of which match the API, so every
+    // submission failed Zod validation with 400. moveInTimeframe has no column
+    // on Inquiry, so fold it into additionalInfo rather than drop it.
+    const payload = buildInquiryPayload(String(id), inquiryForm, tourDateIso);
     console.log('🔴 [TOUR DIAGNOSTIC] Request payload:', JSON.stringify(payload, null, 2));
 
     try {

--- a/src/lib/inquiries/payload.ts
+++ b/src/lib/inquiries/payload.ts
@@ -1,0 +1,56 @@
+/**
+ * Maps the listing-page "Send Inquiry" form state onto the canonical
+ * POST /api/inquiries request body (see createInquirySchema in
+ * src/app/api/inquiries/route.ts).
+ *
+ * The form previously posted `name`/`email`/`phone`/`residentName`/
+ * `careNeeded`/`source:'home_detail'`, none of which match the API's Zod
+ * schema, so every submission failed with `400 Validation failed`. This
+ * keeps the API contract canonical and adapts the client to it.
+ */
+
+export interface InquiryFormState {
+  name: string;
+  email: string;
+  phone: string;
+  residentName: string;
+  moveInTimeframe: string;
+  careNeeded: string[];
+  message: string;
+}
+
+export interface InquiryApiPayload {
+  homeId: string;
+  contactName: string;
+  contactEmail: string;
+  contactPhone?: string;
+  careRecipientName?: string;
+  careNeeds: string[];
+  message?: string;
+  additionalInfo?: string;
+  tourDate?: string;
+  source: "WEBSITE";
+}
+
+export function buildInquiryPayload(
+  homeId: string,
+  form: InquiryFormState,
+  tourDateIso?: string
+): InquiryApiPayload {
+  const residentName = form.residentName?.trim();
+  const moveInTimeframe = form.moveInTimeframe?.trim();
+
+  return {
+    homeId,
+    contactName: form.name.trim(),
+    contactEmail: form.email.trim(),
+    contactPhone: form.phone?.trim() || undefined,
+    careRecipientName: residentName || undefined,
+    careNeeds: Array.isArray(form.careNeeded) ? form.careNeeded : [],
+    message: form.message?.trim() || undefined,
+    // Inquiry has no moveInTimeframe column, so preserve it in additionalInfo.
+    additionalInfo: moveInTimeframe ? `Move-in timeframe: ${moveInTimeframe}` : undefined,
+    tourDate: tourDateIso,
+    source: "WEBSITE",
+  };
+}

--- a/src/lib/inquiries/schema.ts
+++ b/src/lib/inquiries/schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+/**
+ * Canonical validation schema for POST /api/inquiries. Lives in a shared
+ * module so the route handler and tests use a single source of truth.
+ */
+export const createInquirySchema = z.object({
+  familyId: z.string().optional(),
+  homeId: z.string(),
+  contactName: z.string().min(1, 'Contact name is required'),
+  contactEmail: z.string().email('Valid email is required'),
+  contactPhone: z.string().optional(),
+  // Optional: the inquiry form does not require a resident name, and the
+  // underlying Inquiry.careRecipientName column is nullable. Keeping this
+  // required caused 400s when families submitted without it.
+  careRecipientName: z.string().min(1).optional(),
+  careRecipientAge: z.number().int().positive().optional(),
+  careNeeds: z.array(z.string()).optional().default([]),
+  additionalInfo: z.string().optional(),
+  message: z.string().optional(),
+  urgency: z.enum(['LOW', 'MEDIUM', 'HIGH', 'URGENT']).optional().default('MEDIUM'),
+  source: z
+    .enum(['WEBSITE', 'PHONE', 'EMAIL', 'REFERRAL', 'SOCIAL_MEDIA', 'WALK_IN', 'OTHER'])
+    .optional()
+    .default('WEBSITE'),
+  preferredContactMethod: z.enum(['EMAIL', 'PHONE', 'SMS', 'ANY']).optional().default('EMAIL'),
+  affiliateCode: z.string().optional(), // referral code from ?ref= URL param
+});
+
+export type CreateInquiryInput = z.infer<typeof createInquirySchema>;


### PR DESCRIPTION
## Summary
Fixes the family "Send Inquiry" form on `/homes/[id]` returning `400 Validation failed` from `POST /api/inquiries` even when all visible fields are filled.

## Root cause
The form posted `name / email / phone / residentName / careNeeded` and `source: 'home_detail'` — none of which match the API's Zod schema (`contactName / contactEmail / contactPhone / careRecipientName / careNeeds`, and `source` must be a valid `InquirySource` enum). Every submission failed validation.

## Changes
- **`buildInquiryPayload()`** (new `src/lib/inquiries/payload.ts`) maps the form state onto the canonical contract (`name→contactName`, `email→contactEmail`, `phone→contactPhone`, `residentName→careRecipientName`, `careNeeded→careNeeds`, `source:'WEBSITE'`). `moveInTimeframe` has no `Inquiry` column, so it is folded into `additionalInfo` rather than dropped.
- Extracted the Zod schema to **`src/lib/inquiries/schema.ts`** so the route and tests share one source of truth.
- Relaxed `careRecipientName` from required to **optional** (the column is nullable and the form does not require it). Backward compatible — existing `201` callers are unaffected.

Approach chosen per the ticket: fix the **client mapping** so the API contract stays canonical.

## Tests
`__tests__/inquiries.payload.unit.test.ts` — 4 passing, including assertions that the mapped payload passes the real schema and that the **old** form shape fails validation (proving the bug).

## Verification
- `npx tsc --noEmit` clean; `npm run build` passes.
- Submitting the inquiry form on a demo home returns `201`; the inquiry appears in the operator pipeline as `NEW`.

Closes OL-068.

https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_