### PR TITLE
feat(learn): role-gated How-To Guides section in the Education Hub

### DIFF
--- a/__tests__/howto.access.unit.test.ts
+++ b/__tests__/howto.access.unit.test.ts
@@ -1,0 +1,81 @@
+import {
+  visibleAudiences,
+  canViewGuide,
+  filterGuidesForRole,
+} from '@/lib/howto/access';
+import { HOWTO_GUIDES, type HowToGuide } from '@/app/learn/howto/content';
+
+const guide = (audiences: HowToGuide['audiences']): HowToGuide => ({
+  slug: 'x',
+  title: 'X',
+  audiences,
+  icon: '🧪',
+  whoFor: 'test',
+  summary: 'test',
+  readTime: '1 min',
+  steps: [],
+});
+
+describe('visibleAudiences', () => {
+  it('always includes getting-started and family for signed-out viewers', () => {
+    const set = visibleAudiences(null);
+    expect(set.has('getting-started')).toBe(true);
+    expect(set.has('family')).toBe(true);
+    expect(set.has('operator')).toBe(false);
+    expect(set.has('discharge-planner')).toBe(false);
+  });
+
+  it('adds the role-specific audience for each role', () => {
+    expect(visibleAudiences('OPERATOR').has('operator')).toBe(true);
+    expect(visibleAudiences('CAREGIVER').has('caregiver')).toBe(true);
+    expect(visibleAudiences('PROVIDER').has('provider')).toBe(true);
+    expect(visibleAudiences('DISCHARGE_PLANNER').has('discharge-planner')).toBe(true);
+  });
+
+  it('does not leak other roles to a given role', () => {
+    const operator = visibleAudiences('OPERATOR');
+    expect(operator.has('caregiver')).toBe(false);
+    expect(operator.has('discharge-planner')).toBe(false);
+  });
+
+  it('lets admin/staff see all role audiences', () => {
+    for (const a of ['operator', 'caregiver', 'provider', 'discharge-planner'] as const) {
+      expect(visibleAudiences('ADMIN').has(a)).toBe(true);
+      expect(visibleAudiences('STAFF').has(a)).toBe(true);
+    }
+  });
+
+  it('treats affiliates as shared+family only (affiliate content deferred)', () => {
+    const aff = visibleAudiences('AFFILIATE');
+    expect(aff.has('getting-started')).toBe(true);
+    expect(aff.has('family')).toBe(true);
+    expect(aff.has('operator')).toBe(false);
+  });
+});
+
+describe('canViewGuide / filterGuidesForRole', () => {
+  it('hides operator guides from families', () => {
+    expect(canViewGuide(guide(['operator']), 'FAMILY')).toBe(false);
+    expect(canViewGuide(guide(['family']), 'FAMILY')).toBe(true);
+    expect(canViewGuide(guide(['getting-started']), null)).toBe(true);
+  });
+
+  it('an operator sees shared/family + operator guides but not caregiver guides', () => {
+    const visible = filterGuidesForRole(HOWTO_GUIDES, 'OPERATOR').map((g) => g.slug);
+    // operator-only guide is visible
+    expect(visible).toContain('managing-inquiries-as-an-operator');
+    // caregiver-only guide is hidden
+    expect(visible).not.toContain('setting-up-your-caregiver-profile');
+    // shared + family always visible
+    expect(visible).toContain('creating-your-carelinkai-account');
+    expect(visible).toContain('finding-a-home-as-a-family');
+  });
+
+  it('never exposes an audience outside the catalog (no admin/affiliate guides exist)', () => {
+    const audiences = new Set(HOWTO_GUIDES.flatMap((g) => g.audiences));
+    expect(audiences.has('operator')).toBe(true);
+    // The HowToAudience type has no 'admin'/'affiliate' member, so by
+    // construction those cannot appear in the public catalog.
+    expect([...audiences].every((a) => a !== ('admin' as any))).toBe(true);
+  });
+});

--- a/src/app/learn/howto/HowToImage.tsx
+++ b/src/app/learn/howto/HowToImage.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+import { howtoImageUrl } from '@/lib/howto/images';
+
+interface Props {
+  image?: string;
+  alt?: string;
+}
+
+/**
+ * Renders a how-to step image, degrading to a neutral placeholder when there
+ * is no image key OR the asset file is missing (the assets are not all
+ * captured yet). Avoids broken-image icons in the public hub.
+ */
+export default function HowToImage({ image, alt }: Props) {
+  const url = howtoImageUrl(image);
+  const [failed, setFailed] = useState(false);
+
+  if (!url || failed) {
+    return (
+      <div className="mt-3 flex h-40 w-full items-center justify-center rounded-lg border border-dashed border-neutral-300 bg-neutral-50 text-sm text-neutral-400">
+        <span>🖼️ Screenshot coming soon</span>
+      </div>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={url}
+      alt={alt || 'How-to step illustration'}
+      className="mt-3 w-full rounded-lg border border-neutral-200"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/src/app/learn/howto/[slug]/page.tsx
+++ b/src/app/learn/howto/[slug]/page.tsx
@@ -1,0 +1,163 @@
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import DashboardLayout from '@/components/layout/DashboardLayout';
+import { getHowToGuide, HOWTO_GUIDES, AUDIENCE_LABELS } from '../content';
+import { canViewGuide, filterGuidesForRole, type ViewerRole } from '@/lib/howto/access';
+import HowToImage from '../HowToImage';
+
+interface Props {
+  params: { slug: string };
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const guide = getHowToGuide(params.slug);
+  if (!guide) return {};
+  return {
+    title: `${guide.title} | How-To Guides | CareLinkAI`,
+    description: guide.summary,
+  };
+}
+
+export default async function HowToGuidePage({ params }: Props) {
+  const guide = getHowToGuide(params.slug);
+  if (!guide) notFound();
+
+  const session = await getServerSession(authOptions);
+  const role = (session?.user?.role as ViewerRole) ?? null;
+
+  // Role-gate: if the viewer is not allowed to see this guide, send them back
+  // to the hub rather than exposing role-specific content.
+  if (!canViewGuide(guide, role)) {
+    redirect('/learn');
+  }
+
+  const related = filterGuidesForRole(
+    HOWTO_GUIDES.filter((g) => g.slug !== guide.slug),
+    role
+  ).slice(0, 4);
+
+  const isLoggedIn = !!session?.user;
+
+  const content = (
+    <div className={isLoggedIn ? '' : 'min-h-screen bg-neutral-50'}>
+      <div className="bg-white border-b border-neutral-200">
+        <div className="max-w-3xl mx-auto px-6 py-10">
+          <Link
+            href="/learn"
+            className="inline-flex items-center gap-1 text-sm text-primary-600 hover:text-primary-700 mb-6"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to the Education Hub
+          </Link>
+
+          <div className="flex flex-wrap items-center gap-2 mb-3">
+            {guide.audiences.map((a) => (
+              <span
+                key={a}
+                className="text-xs font-medium px-2 py-0.5 rounded-full bg-neutral-100 text-neutral-600"
+              >
+                {AUDIENCE_LABELS[a]}
+              </span>
+            ))}
+            <span className="text-xs text-neutral-400">{guide.readTime}</span>
+          </div>
+
+          <h1 className="text-3xl font-bold text-neutral-900 mb-3">
+            {guide.icon} {guide.title}
+          </h1>
+
+          <p className="text-sm text-neutral-500 mb-4">
+            <span className="font-medium text-neutral-700">Who it&apos;s for: </span>
+            {guide.whoFor}
+          </p>
+
+          <div className="rounded-xl bg-primary-50 border border-primary-200 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-primary-700 mb-1">
+              30-second summary
+            </p>
+            <p className="text-neutral-700 leading-relaxed">{guide.summary}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-3xl mx-auto px-6 py-10">
+        {/* Steps */}
+        <ol className="space-y-8">
+          {guide.steps.map((step, i) => (
+            <li key={i} className="flex gap-4">
+              <span className="flex-shrink-0 flex h-8 w-8 items-center justify-center rounded-full bg-primary-600 text-white text-sm font-semibold">
+                {i + 1}
+              </span>
+              <div className="flex-1">
+                <p className="text-neutral-800 leading-relaxed">{step.text}</p>
+                {step.image && <HowToImage image={step.image} alt={step.imageAlt} />}
+              </div>
+            </li>
+          ))}
+        </ol>
+
+        {/* Tips */}
+        {guide.tips && guide.tips.length > 0 && (
+          <div className="mt-10 rounded-xl border border-amber-200 bg-amber-50 p-5">
+            <h2 className="text-sm font-semibold text-amber-800 mb-2">💡 Tips</h2>
+            <ul className="list-disc list-inside space-y-1 text-sm text-neutral-700">
+              {guide.tips.map((tip, i) => (
+                <li key={i}>{tip}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* FAQ */}
+        {guide.faq && guide.faq.length > 0 && (
+          <div className="mt-10">
+            <h2 className="text-lg font-semibold text-neutral-900 mb-4">FAQ</h2>
+            <div className="space-y-4">
+              {guide.faq.map((item, i) => (
+                <div key={i}>
+                  <p className="font-medium text-neutral-900">{item.q}</p>
+                  <p className="text-sm text-neutral-600 mt-1">{item.a}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* NOTE: narrationScript is intentionally NOT rendered — it is internal
+            video voiceover content, not for end users. */}
+
+        {/* Related */}
+        {related.length > 0 && (
+          <div className="mt-12">
+            <h3 className="text-lg font-semibold text-neutral-900 mb-4">More how-to guides</h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {related.map((g) => (
+                <Link
+                  key={g.slug}
+                  href={`/learn/howto/${g.slug}`}
+                  className="group p-4 bg-white border border-neutral-200 rounded-lg hover:border-primary-300 hover:shadow-sm transition-all"
+                >
+                  <span className="text-2xl mb-2 block">{g.icon}</span>
+                  <p className="text-sm font-medium text-neutral-900 group-hover:text-primary-700">
+                    {g.title}
+                  </p>
+                  <p className="text-xs text-neutral-400 mt-0.5">{g.readTime}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  if (isLoggedIn) {
+    return <DashboardLayout title={guide.title} showSearch={false}>{content}</DashboardLayout>;
+  }
+  return content;
+}

--- a/src/app/learn/howto/content.ts
+++ b/src/app/learn/howto/content.ts
@@ -1,0 +1,268 @@
+/**
+ * How-To Guides content model for the Education Hub.
+ *
+ * The shape mirrors the source guides authored in the ChrisOS vault
+ * (`04_CareLinkAI/howto/`): title, "who it's for", a 30-second summary,
+ * numbered steps (each with an optional image placeholder), tips, an FAQ,
+ * and a narration script used for video voiceover.
+ *
+ * IMPORTANT (role-gating + public exposure):
+ *  - `narrationScript` is for internal video production ONLY and is never
+ *    rendered to end users. It lives here behind the render layer.
+ *  - Admin-internal and Affiliate guides are intentionally excluded from the
+ *    public hub (see HowToAudience — there is no "admin"/"affiliate" audience).
+ *
+ * The starter guides below are authored from CareLinkAI's actual flows. The
+ * full set of 25 guides lives in the vault and should be ported into this
+ * array (the field shape already matches), excluding the internal admin
+ * overview and any affiliate guides, and stripping NARRATION SCRIPT blocks
+ * into `narrationScript`.
+ */
+
+export type HowToAudience =
+  | 'getting-started'
+  | 'family'
+  | 'operator'
+  | 'caregiver'
+  | 'provider'
+  | 'discharge-planner';
+
+export interface HowToStep {
+  /** Numbered step instruction. */
+  text: string;
+  /**
+   * Optional image placeholder key (the vault guides use `(img: …)` markers).
+   * The actual asset files are not captured yet, so the render layer must
+   * degrade gracefully when the file is missing — see howtoImageUrl().
+   */
+  image?: string;
+  imageAlt?: string;
+}
+
+export interface HowToFaq {
+  q: string;
+  a: string;
+}
+
+export interface HowToGuide {
+  slug: string;
+  title: string;
+  /** Audiences allowed to see this guide. */
+  audiences: HowToAudience[];
+  icon: string;
+  /** "Who it's for" line. */
+  whoFor: string;
+  /** 30-second summary. */
+  summary: string;
+  readTime: string;
+  steps: HowToStep[];
+  tips?: string[];
+  faq?: HowToFaq[];
+  /** Internal video voiceover script — never rendered publicly. */
+  narrationScript?: string;
+}
+
+export const AUDIENCE_LABELS: Record<HowToAudience, string> = {
+  'getting-started': 'Getting Started',
+  family: 'For Families',
+  operator: 'For Operators',
+  caregiver: 'For Caregivers',
+  provider: 'For Providers',
+  'discharge-planner': 'For Discharge Planners',
+};
+
+/** Display order for the grouped sections on the hub page. */
+export const AUDIENCE_ORDER: HowToAudience[] = [
+  'getting-started',
+  'family',
+  'operator',
+  'caregiver',
+  'provider',
+  'discharge-planner',
+];
+
+export const HOWTO_GUIDES: HowToGuide[] = [
+  {
+    slug: 'creating-your-carelinkai-account',
+    title: 'Creating Your CareLinkAI Account',
+    audiences: ['getting-started'],
+    icon: '🚀',
+    whoFor: 'Anyone new to CareLinkAI — families, operators, caregivers, and partners.',
+    summary:
+      'Sign up, verify your email, choose your role, and land on the dashboard built for how you use CareLinkAI.',
+    readTime: '2 min',
+    steps: [
+      { text: 'Go to the sign-up page and enter your name, email, and a password.', image: 'signup-form.png', imageAlt: 'Sign-up form' },
+      { text: 'Choose the role that fits you: Family, Operator, Caregiver, Provider, or Discharge Planner.' },
+      { text: 'Check your email for a verification link and confirm your address.' },
+      { text: 'Sign in — you will be taken to the dashboard tailored to your role.' },
+    ],
+    tips: [
+      'Use the email address you check most often — important updates and inquiry notifications are sent there.',
+      'You can update your profile and notification preferences any time from Settings.',
+    ],
+    faq: [
+      { q: 'Can I change my role later?', a: 'Roles are tied to how your account is set up. Contact support if you signed up under the wrong role.' },
+    ],
+    narrationScript:
+      'Welcome to CareLinkAI. In this short guide we will create your account and get you to the right dashboard...',
+  },
+  {
+    slug: 'finding-a-home-as-a-family',
+    title: 'Finding the Right Home for Your Loved One',
+    audiences: ['family'],
+    icon: '🔎',
+    whoFor: 'Families searching for assisted living, memory care, or skilled nursing.',
+    summary:
+      'Search homes by location, care level, and budget, compare your shortlist, and reach out to the homes that fit.',
+    readTime: '3 min',
+    steps: [
+      { text: 'Open Search and enter the city or area you are looking in.', image: 'search-location.png', imageAlt: 'Home search by location' },
+      { text: 'Filter by care level (assisted living, memory care, skilled nursing) and your monthly budget.' },
+      { text: 'Open a listing to see photos, amenities, pricing, and the care levels the home supports.' },
+      { text: 'Save the homes you like to build a shortlist you can compare side by side.' },
+    ],
+    tips: [
+      'Prioritize homes within a 15–20 minute drive of family who will visit — proximity meaningfully improves resident wellbeing.',
+      'Read our family guides on touring and costs before you reach out.',
+    ],
+  },
+  {
+    slug: 'sending-an-inquiry-and-booking-a-tour',
+    title: 'Sending an Inquiry and Booking a Tour',
+    audiences: ['family'],
+    icon: '📨',
+    whoFor: 'Families ready to contact a home and schedule a visit.',
+    summary:
+      'Send an inquiry from any listing, share what your loved one needs, and request a tour time — the operator is notified instantly.',
+    readTime: '2 min',
+    steps: [
+      { text: 'On a home listing, click "Send Inquiry" / "Contact".', image: 'inquiry-button.png', imageAlt: 'Contact home button' },
+      { text: 'Fill in your name, email, the resident’s name, move-in timeframe, and the care services you need.' },
+      { text: 'Optionally pick a tour date and time, then submit.' },
+      { text: 'You will see a confirmation, and the home’s operator receives your inquiry as a new lead.' },
+    ],
+    tips: [
+      'Add a short note about your situation — it helps the operator respond with relevant information.',
+    ],
+    faq: [
+      { q: 'Do I need an account to send an inquiry?', a: 'You can browse without one, but signing in lets you track your inquiries and responses in one place.' },
+    ],
+  },
+  {
+    slug: 'managing-inquiries-as-an-operator',
+    title: 'Managing Inquiries in Your Pipeline',
+    audiences: ['operator'],
+    icon: '📥',
+    whoFor: 'Operators handling incoming family inquiries and leads.',
+    summary:
+      'Every inquiry lands in your pipeline as NEW. Review it, respond, and move it through your stages to a tour or move-in.',
+    readTime: '3 min',
+    steps: [
+      { text: 'Open the Inquiries / pipeline view from your operator dashboard.', image: 'operator-pipeline.png', imageAlt: 'Operator inquiry pipeline' },
+      { text: 'Open a NEW inquiry to see the family’s contact info, the resident’s needs, and any requested tour time.' },
+      { text: 'Respond to the family and add internal notes (notes are private to your team).' },
+      { text: 'Update the inquiry status as it progresses (e.g., contacted, tour scheduled, converted).' },
+    ],
+    tips: [
+      'Respond quickly — speed of first response is the strongest predictor of converting an inquiry.',
+      'Use internal notes to keep your team aligned without exposing anything to the family.',
+    ],
+  },
+  {
+    slug: 'keeping-your-listing-current',
+    title: 'Keeping Your Listing Accurate and Attractive',
+    audiences: ['operator'],
+    icon: '🏠',
+    whoFor: 'Operators who want their homes to show up well in family searches.',
+    summary:
+      'Complete pricing, care levels, amenities, and photos so your listing ranks well and sets accurate expectations.',
+    readTime: '3 min',
+    steps: [
+      { text: 'Open your home’s profile from the operator dashboard.', image: 'operator-listing-edit.png', imageAlt: 'Edit listing' },
+      { text: 'Set the care levels you support, capacity, and current pricing range.' },
+      { text: 'Add or update amenities and upload high-quality photos.' },
+      { text: 'Publish — make sure the status is ACTIVE so families can find you in search.' },
+    ],
+    tips: [
+      'Listings with accurate pricing and several photos receive substantially more qualified inquiries.',
+    ],
+  },
+  {
+    slug: 'setting-up-your-caregiver-profile',
+    title: 'Setting Up Your Caregiver Profile',
+    audiences: ['caregiver'],
+    icon: '👩‍⚕️',
+    whoFor: 'Caregivers offering services through the CareLinkAI marketplace.',
+    summary:
+      'Build a profile that wins shifts: add your experience, certifications, availability, and the care types you specialize in.',
+    readTime: '3 min',
+    steps: [
+      { text: 'Open your caregiver profile from your dashboard.', image: 'caregiver-profile.png', imageAlt: 'Caregiver profile' },
+      { text: 'Add your experience, specialties, and upload your certifications (e.g., CNA, CPR/first aid).' },
+      { text: 'Set your availability and the areas you are willing to work in.' },
+      { text: 'Save and publish your profile so operators and families can find and hire you.' },
+    ],
+    tips: [
+      'Keep your certifications current — expired credentials can hide you from search.',
+    ],
+  },
+  {
+    slug: 'finding-and-accepting-shifts',
+    title: 'Finding and Accepting Shifts',
+    audiences: ['caregiver'],
+    icon: '🗓️',
+    whoFor: 'Caregivers looking for open shifts.',
+    summary:
+      'Browse open shifts that match your availability and specialties, accept the ones you want, and track your assignments.',
+    readTime: '2 min',
+    steps: [
+      { text: 'Open the shifts marketplace from your dashboard.', image: 'shift-list.png', imageAlt: 'Open shifts' },
+      { text: 'Filter by location, date, and care type.' },
+      { text: 'Open a shift to review the details and pay, then accept it.' },
+      { text: 'Track your accepted shifts and submit your timesheet after each one.' },
+    ],
+  },
+  {
+    slug: 'getting-started-as-a-provider',
+    title: 'Getting Started as a Service Provider',
+    audiences: ['provider'],
+    icon: '🤝',
+    whoFor: 'Service providers (transport, therapy, and other senior-care services) partnering with CareLinkAI.',
+    summary:
+      'Set up your provider profile and services so operators and families can find and request you.',
+    readTime: '3 min',
+    steps: [
+      { text: 'Complete your provider profile with your company details and service area.', image: 'provider-profile.png', imageAlt: 'Provider profile' },
+      { text: 'List the services you offer and how you price them.' },
+      { text: 'Set your availability and contact preferences.' },
+      { text: 'Publish your profile to start receiving requests.' },
+    ],
+  },
+  {
+    slug: 'ai-placement-search-for-discharge-planners',
+    title: 'Running an AI Placement Search',
+    audiences: ['discharge-planner'],
+    icon: '🏥',
+    whoFor: 'Hospital and rehab discharge planners placing patients quickly.',
+    summary:
+      'Describe the patient’s needs in plain language and let CareLinkAI parse the request and rank matching homes with available beds.',
+    readTime: '3 min',
+    steps: [
+      { text: 'Open the discharge planner search and click "Start New Search".', image: 'dp-search.png', imageAlt: 'Discharge planner search' },
+      { text: 'Describe the patient in plain language — e.g., "memory care in Boston for a 78-year-old with moderate Alzheimer’s, budget ~$6,000/month."' },
+      { text: 'Click "Search with AI". CareLinkAI extracts the care level, location, and other criteria automatically.' },
+      { text: 'Review the ranked matches with reasoning, available beds, and contact details, then reach out or create a placement request.' },
+    ],
+    tips: [
+      'Include the city and state, care level, budget, and any urgent timeline to get the most relevant matches.',
+    ],
+    faq: [
+      { q: 'What care levels can I search?', a: 'Independent living, assisted living, memory care, and skilled nursing.' },
+    ],
+  },
+];
+
+export function getHowToGuide(slug: string): HowToGuide | undefined {
+  return HOWTO_GUIDES.find((g) => g.slug === slug);
+}

--- a/src/app/learn/page.tsx
+++ b/src/app/learn/page.tsx
@@ -4,6 +4,14 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import DashboardLayout from '@/components/layout/DashboardLayout';
 import { GUIDES } from './guides/content';
+import {
+  HOWTO_GUIDES,
+  AUDIENCE_LABELS,
+  AUDIENCE_ORDER,
+  type HowToAudience,
+  type HowToGuide,
+} from './howto/content';
+import { filterGuidesForRole, type ViewerRole } from '@/lib/howto/access';
 
 export const metadata: Metadata = {
   title: 'Family Education Hub | CareLinkAI',
@@ -15,6 +23,21 @@ export const metadata: Metadata = {
 export default async function LearnPage() {
   const session = await getServerSession(authOptions);
   const isLoggedIn = !!session?.user;
+  const role = (session?.user?.role as ViewerRole) ?? null;
+
+  // Role-gated How-To guides, grouped by audience for display. Each guide can
+  // belong to more than one audience; show it under the first matching group
+  // in display order so it appears once.
+  const visibleHowTo = filterGuidesForRole(HOWTO_GUIDES, role);
+  const shownSlugs = new Set<string>();
+  const howToByAudience: Array<{ audience: HowToAudience; guides: HowToGuide[] }> = [];
+  for (const audience of AUDIENCE_ORDER) {
+    const guides = visibleHowTo.filter(
+      (g) => g.audiences.includes(audience) && !shownSlugs.has(g.slug)
+    );
+    guides.forEach((g) => shownSlugs.add(g.slug));
+    if (guides.length > 0) howToByAudience.push({ audience, guides });
+  }
 
   const content = (
     <div className={isLoggedIn ? '' : 'min-h-screen bg-neutral-50'}>
@@ -60,6 +83,48 @@ export default async function LearnPage() {
             </Link>
           ))}
         </div>
+
+        {/* How-To Guides (role-gated) */}
+        {howToByAudience.length > 0 && (
+          <div className="mt-16">
+            <div className="mb-6">
+              <h2 className="text-2xl font-bold text-neutral-900">How-To Guides</h2>
+              <p className="text-neutral-600 mt-1">
+                Step-by-step help for getting the most out of CareLinkAI.
+              </p>
+            </div>
+
+            {howToByAudience.map(({ audience, guides }) => (
+              <div key={audience} className="mb-10">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">
+                  {AUDIENCE_LABELS[audience]}
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {guides.map((guide) => (
+                    <Link
+                      key={guide.slug}
+                      href={`/learn/howto/${guide.slug}`}
+                      className="group bg-white rounded-xl border border-neutral-200 p-5 hover:border-primary-300 hover:shadow-md transition-all"
+                    >
+                      <div className="flex items-start gap-3">
+                        <span className="text-2xl">{guide.icon}</span>
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <span className="text-xs text-neutral-400">{guide.readTime}</span>
+                          </div>
+                          <h4 className="font-semibold text-neutral-900 mb-1 group-hover:text-primary-700 transition-colors">
+                            {guide.title}
+                          </h4>
+                          <p className="text-sm text-neutral-500 leading-relaxed">{guide.summary}</p>
+                        </div>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
 
         {/* Financing CTA */}
         <div className="mt-8 bg-amber-50 border border-amber-200 rounded-xl p-5 flex flex-col sm:flex-row items-start sm:items-center gap-4">

--- a/src/lib/howto/access.ts
+++ b/src/lib/howto/access.ts
@@ -1,0 +1,55 @@
+/**
+ * Role-gating for the How-To Guides section of the Education Hub.
+ *
+ * Everyone (including signed-out visitors) sees "Getting Started" and
+ * "Family" guides. Each role additionally sees the guides for their role.
+ * Admin/Staff see everything (for support). Affiliate content is deferred and
+ * never exposed here; affiliates see only the shared + family guides.
+ */
+
+import type { HowToAudience, HowToGuide } from '@/app/learn/howto/content';
+
+/** App UserRole values (kept as a string union to avoid importing Prisma here). */
+export type ViewerRole =
+  | 'FAMILY'
+  | 'OPERATOR'
+  | 'CAREGIVER'
+  | 'ADMIN'
+  | 'AFFILIATE'
+  | 'STAFF'
+  | 'PROVIDER'
+  | 'DISCHARGE_PLANNER'
+  | null
+  | undefined;
+
+const ALWAYS_VISIBLE: HowToAudience[] = ['getting-started', 'family'];
+
+const ROLE_AUDIENCE: Record<string, HowToAudience[]> = {
+  FAMILY: [],
+  OPERATOR: ['operator'],
+  CAREGIVER: ['caregiver'],
+  PROVIDER: ['provider'],
+  DISCHARGE_PLANNER: ['discharge-planner'],
+  // Affiliate content is deferred — affiliates see only shared + family.
+  AFFILIATE: [],
+  // Admin/Staff can see all role guides for support purposes.
+  ADMIN: ['operator', 'caregiver', 'provider', 'discharge-planner'],
+  STAFF: ['operator', 'caregiver', 'provider', 'discharge-planner'],
+};
+
+/** The set of audiences a viewer is allowed to see. */
+export function visibleAudiences(role: ViewerRole): Set<HowToAudience> {
+  const extra = role ? ROLE_AUDIENCE[role] ?? [] : [];
+  return new Set<HowToAudience>([...ALWAYS_VISIBLE, ...extra]);
+}
+
+/** True if the viewer may see the given guide. */
+export function canViewGuide(guide: HowToGuide, role: ViewerRole): boolean {
+  const allowed = visibleAudiences(role);
+  return guide.audiences.some((a) => allowed.has(a));
+}
+
+/** Filters a list of guides down to what the viewer may see. */
+export function filterGuidesForRole<T extends HowToGuide>(guides: T[], role: ViewerRole): T[] {
+  return guides.filter((g) => canViewGuide(g, role));
+}

--- a/src/lib/howto/images.ts
+++ b/src/lib/howto/images.ts
@@ -1,0 +1,27 @@
+/**
+ * How-To guide image handling.
+ *
+ * The guide step images (the vault `(img: …)` placeholders) are not captured
+ * yet. Until the asset files land under /public/howto/, callers should render
+ * a graceful placeholder instead of a broken image. The component using this
+ * decides whether to render an <img> or the placeholder based on whether a
+ * known asset exists.
+ */
+
+/** Where captured how-to assets live, served statically from /public. */
+export const HOWTO_IMAGE_BASE = '/howto';
+
+/**
+ * Resolves a step image key to its public URL, or null when there is no image
+ * key. Returning a URL does not guarantee the file exists — components must
+ * still degrade gracefully (e.g., onError fallback) since assets may be
+ * missing.
+ */
+export function howtoImageUrl(image?: string): string | null {
+  if (!image) return null;
+  const trimmed = image.trim();
+  if (!trimmed) return null;
+  if (/^https?:\/\//.test(trimmed)) return trimmed;
+  const clean = trimmed.replace(/^\/+/, '');
+  return `${HOWTO_IMAGE_BASE}/${clean}`;
+}


### PR DESCRIPTION
## Summary
Extends the **existing** Education Hub (`/learn`) with a role-gated "How-To Guides" section — does not build a new hub.

## Changes
- **Grouped by role:** Getting Started, Family, Operator, Caregiver, Provider, Discharge Planner. Detail pages at `/learn/howto/[slug]`.
- **Role-gating** (`src/lib/howto/access.ts`): everyone (incl. signed-out) sees Getting Started + Family; each role additionally sees its own guides; admin/staff see all role guides for support. Detail pages redirect to `/learn` if the viewer isn't permitted.
- **Admin/affiliate excluded:** the `HowToAudience` type has no `admin`/`affiliate` member, so internal/deferred content cannot appear in the public catalog by construction.
- **Narration scripts** are stored on the model but **never rendered** publicly (internal video voiceover only).
- **Graceful images:** `HowToImage` degrades to a placeholder when a step asset is missing (the `(img: …)` assets aren't captured yet). Static-only, no new paid services.
- **Content model** (`src/app/learn/howto/content.ts`) mirrors the ChrisOS vault guide format (title / who-it's-for / 30-sec summary / numbered steps with image placeholders / tips / FAQ / narration) so porting is straight data entry.

## Known limitation
The ChrisOS vault is **not present** in this environment, so the 25 source guides could not be copied — a representative starter set is seeded instead. Porting the full set is tracked as **OL-069** (exclude `admin/00_INTERNAL_admin_overview.md` + affiliate guides; move NARRATION SCRIPT blocks into `narrationScript`; capture assets into `/public/howto/`).

## Tests
`__tests__/howto.access.unit.test.ts` — 8 passing (per-role visibility, no cross-role leakage, admin/affiliate handling).

## Verification
- `npx tsc --noEmit` clean; `npm run build` passes; `/learn/howto/[slug]` route present in build output.

Part of OL-069.

https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_