### PR TITLE
fix(help): repair Getting Started links for all roles

### DIFF
--- a/__tests__/help.getting-started.unit.test.ts
+++ b/__tests__/help.getting-started.unit.test.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+import { ROLE_GUIDES } from '@/lib/help/getting-started';
+
+/**
+ * Guards the /help "Getting Started" checklists: every step href must resolve
+ * to a real app route. This catches the class of bug where a link pointed at
+ * a non-existent path (e.g. /marketplace/aides) or a role-gated portal a user
+ * can't reach (e.g. a FAMILY step pointing at /discharge-planner).
+ */
+
+const APP_DIR = path.join(process.cwd(), 'src', 'app');
+
+/** True if `src/app/<pathname>/page.tsx` (or .ts/.jsx/.js) exists. */
+function routeExists(pathname: string): boolean {
+  const segments = pathname.replace(/^\/+/, '').split('/').filter(Boolean);
+  const dir = path.join(APP_DIR, ...segments);
+  return ['page.tsx', 'page.ts', 'page.jsx', 'page.js'].some((f) =>
+    fs.existsSync(path.join(dir, f))
+  );
+}
+
+const allSteps = Object.entries(ROLE_GUIDES).flatMap(([role, guide]) =>
+  guide.steps.map((step) => ({ role, ...step }))
+);
+
+describe('help /getting-started link targets', () => {
+  it.each(allSteps)('$role → "$label" ($href) resolves to a real route', ({ href }) => {
+    const pathname = href.split(/[?#]/)[0];
+    expect(routeExists(pathname)).toBe(true);
+  });
+
+  it('covers every primary customer-facing role', () => {
+    for (const role of ['FAMILY', 'OPERATOR', 'CAREGIVER', 'PROVIDER', 'DISCHARGE_PLANNER']) {
+      expect(ROLE_GUIDES[role]).toBeDefined();
+      expect(ROLE_GUIDES[role].steps.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('never points a FAMILY step at a role-gated portal', () => {
+    const gated = ['/operator', '/discharge-planner', '/caregiver', '/affiliate', '/admin'];
+    for (const step of ROLE_GUIDES.FAMILY.steps) {
+      const pathname = step.href.split(/[?#]/)[0];
+      expect(gated.some((g) => pathname === g || pathname.startsWith(g + '/'))).toBe(false);
+    }
+  });
+});

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -4,52 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import { FiMail, FiBook, FiHelpCircle, FiVideo, FiFileText, FiChevronDown, FiChevronUp, FiCheckCircle, FiArrowRight } from 'react-icons/fi';
-
-const ROLE_GUIDES: Record<string, { title: string; steps: Array<{ label: string; href: string }> }> = {
-  OPERATOR: {
-    title: 'Getting Started as an Operator',
-    steps: [
-      { label: 'Complete your home profile', href: '/operator/homes' },
-      { label: 'Add your first resident', href: '/operator/residents' },
-      { label: 'Set up your caregiver roster', href: '/operator/caregivers' },
-      { label: 'Create your first open shift', href: '/operator/shifts' },
-      { label: 'Review marketplace applications', href: '/marketplace/listings' },
-      { label: 'Configure billing & payouts', href: '/settings/payouts/operator' },
-    ],
-  },
-  CAREGIVER: {
-    title: 'Getting Started as a Caregiver',
-    steps: [
-      { label: 'Complete your caregiver profile', href: '/settings/aide' },
-      { label: 'Upload your certifications', href: '/settings/credentials' },
-      { label: 'Get background verified', href: '/caregiver/verification' },
-      { label: 'Browse open job listings', href: '/marketplace?tab=jobs' },
-      { label: 'Apply for your first position', href: '/marketplace?tab=jobs' },
-      { label: 'Check your applications status', href: '/caregiver/applications' },
-    ],
-  },
-  FAMILY: {
-    title: 'Getting Started as a Family Member',
-    steps: [
-      { label: 'Set up your family profile', href: '/settings/family' },
-      { label: 'Browse assisted living homes', href: '/discharge-planner' },
-      { label: 'Browse caregivers', href: '/marketplace/aides' },
-      { label: 'Submit a care inquiry', href: '/marketplace/aides' },
-      { label: 'Upload care documents', href: '/family' },
-      { label: 'Set up emergency contacts', href: '/family' },
-    ],
-  },
-  PROVIDER: {
-    title: 'Getting Started as a Provider',
-    steps: [
-      { label: 'Complete your provider profile', href: '/settings/provider' },
-      { label: 'Add your service offerings', href: '/settings/provider' },
-      { label: 'Browse families and operators', href: '/marketplace?tab=providers' },
-      { label: 'Respond to care inquiries', href: '/messages' },
-      { label: 'View your reviews', href: '/marketplace/providers' },
-    ],
-  },
-};
+import { ROLE_GUIDES } from '@/lib/help/getting-started';
 
 const FAQS = [
   {

--- a/src/lib/help/getting-started.ts
+++ b/src/lib/help/getting-started.ts
@@ -1,0 +1,83 @@
+/**
+ * Role-specific "Getting Started" checklists shown on /help.
+ *
+ * Every href MUST point to a real, role-accessible route. Broken or
+ * role-gated targets (e.g. sending a FAMILY user to /discharge-planner) make
+ * the help links appear "dead." The companion test
+ * `__tests__/help.getting-started.unit.test.ts` asserts each path resolves to
+ * an app route so this can't regress.
+ */
+
+export interface GettingStartedStep {
+  label: string;
+  href: string;
+}
+
+export interface GettingStartedGuide {
+  title: string;
+  steps: GettingStartedStep[];
+}
+
+export const ROLE_GUIDES: Record<string, GettingStartedGuide> = {
+  OPERATOR: {
+    title: 'Getting Started as an Operator',
+    steps: [
+      { label: 'Complete your home profile', href: '/operator/homes' },
+      { label: 'Add your first resident', href: '/operator/residents' },
+      { label: 'Set up your caregiver roster', href: '/operator/caregivers' },
+      { label: 'Create your first open shift', href: '/operator/shifts' },
+      { label: 'Review marketplace hires & applications', href: '/marketplace/hires' },
+      { label: 'Configure billing & payouts', href: '/settings/payouts/operator' },
+    ],
+  },
+  CAREGIVER: {
+    title: 'Getting Started as a Caregiver',
+    steps: [
+      { label: 'Complete your caregiver profile', href: '/settings/profile' },
+      { label: 'Upload your certifications', href: '/settings/credentials' },
+      { label: 'Get background verified', href: '/caregiver/verification' },
+      { label: 'Browse open job listings', href: '/marketplace?tab=jobs' },
+      { label: 'Apply for your first position', href: '/marketplace?tab=jobs' },
+      { label: 'Check your applications status', href: '/caregiver/applications' },
+    ],
+  },
+  FAMILY: {
+    title: 'Getting Started as a Family Member',
+    steps: [
+      { label: 'Set up your family profile', href: '/settings/family' },
+      { label: 'Browse assisted living homes', href: '/search' },
+      { label: 'Browse caregivers', href: '/marketplace' },
+      { label: 'Find care with AI matching', href: '/dashboard/find-care' },
+      { label: 'Manage residents & care documents', href: '/family/residents' },
+      { label: 'Set up emergency contacts', href: '/family/emergency' },
+    ],
+  },
+  PROVIDER: {
+    title: 'Getting Started as a Provider',
+    steps: [
+      { label: 'Complete your provider profile', href: '/settings/provider' },
+      { label: 'Add your service offerings', href: '/settings/provider' },
+      { label: 'Browse the marketplace', href: '/marketplace' },
+      { label: 'Respond to care inquiries', href: '/messages' },
+      { label: 'View your public provider listing', href: '/marketplace/providers' },
+    ],
+  },
+  DISCHARGE_PLANNER: {
+    title: 'Getting Started as a Discharge Planner',
+    steps: [
+      { label: 'Open your discharge planner dashboard', href: '/discharge-planner' },
+      { label: 'Run an AI placement search', href: '/discharge-planner/search' },
+      { label: 'Track your placement requests', href: '/discharge-planner/requests' },
+      { label: 'Review your search history', href: '/discharge-planner/history' },
+      { label: 'View placement analytics', href: '/discharge-planner/analytics' },
+      { label: 'Manage your billing', href: '/discharge-planner/billing' },
+    ],
+  },
+  AFFILIATE: {
+    title: 'Getting Started as an Affiliate',
+    steps: [
+      { label: 'Open your affiliate dashboard', href: '/affiliate/dashboard' },
+      { label: 'Explore the Education Hub', href: '/learn' },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
Fixes the **/help "Getting Started" checklists** — reported by a logged-in family user as "none of the links work."

## Root cause
The role checklists pointed at routes that either **404** or are **role-gated** and bounce the user away:

| Role | Step | Old target | Problem |
|------|------|-----------|---------|
| FAMILY | Browse assisted living homes | `/discharge-planner` | gated to DISCHARGE_PLANNER → family bounced |
| FAMILY | Browse caregivers / Submit inquiry | `/marketplace/aides` | route does not exist (404) |
| FAMILY | Upload care docs / Emergency contacts | `/family` | landed on dashboard, not the action |
| CAREGIVER | Complete caregiver profile | `/settings/aide` | route does not exist (404) |
| OPERATOR | Review marketplace applications | `/marketplace/listings` | no index page (404) |
| DISCHARGE_PLANNER / AFFILIATE | — | *(none)* | no guide rendered at all |

## Changes
- Repointed every step at a **verified, role-accessible** route (family homes → `/search`, caregivers → `/marketplace`, AI matching → `/dashboard/find-care`, residents/docs → `/family/residents`, emergency → `/family/emergency`; caregiver profile → `/settings/profile`; operator applications → `/marketplace/hires`).
- Added **Getting Started guides for DISCHARGE_PLANNER and AFFILIATE** (previously blank).
- Extracted `ROLE_GUIDES` to `src/lib/help/getting-started.ts` (plain module, no React deps) so it's testable.

## Tests
`__tests__/help.getting-started.unit.test.ts` — **33 passing**. Asserts every step href resolves to a real `src/app/**/page.tsx` route, that all five primary customer roles have a guide, and that no FAMILY step targets a role-gated portal — so this can't silently regress.

## Verification
- `npx tsc --noEmit` clean; `npm run build` passes (`/help` compiles).

Note: this is the `/help` page (separate from the `/learn` How-To hub in #566).

https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_