### PR TITLE
feat(learn): port full 29-guide How-To set into the Education Hub (closes OL-069)

### DIFF
--- a/__tests__/howto.access.unit.test.ts
+++ b/__tests__/howto.access.unit.test.ts
@@ -63,12 +63,43 @@ describe('canViewGuide / filterGuidesForRole', () => {
   it('an operator sees shared/family + operator guides but not caregiver guides', () => {
     const visible = filterGuidesForRole(HOWTO_GUIDES, 'OPERATOR').map((g) => g.slug);
     // operator-only guide is visible
-    expect(visible).toContain('managing-inquiries-as-an-operator');
+    expect(visible).toContain('leads-and-inquiries-pipeline');
     // caregiver-only guide is hidden
-    expect(visible).not.toContain('setting-up-your-caregiver-profile');
+    expect(visible).not.toContain('profile-and-credentials');
     // shared + family always visible
-    expect(visible).toContain('creating-your-carelinkai-account');
-    expect(visible).toContain('finding-a-home-as-a-family');
+    expect(visible).toContain('signup-and-login');
+    expect(visible).toContain('search-homes');
+  });
+
+  it('a family sees only shared + family guides', () => {
+    const visible = filterGuidesForRole(HOWTO_GUIDES, 'FAMILY');
+    const audiences = new Set(visible.flatMap((g) => g.audiences));
+    expect(audiences).toEqual(new Set(['getting-started', 'family']));
+    // no operator/caregiver/provider/discharge-planner content leaks to family
+    for (const a of ['operator', 'caregiver', 'provider', 'discharge-planner'] as const) {
+      expect(audiences.has(a)).toBe(false);
+    }
+  });
+
+  it('ships the full 29-guide catalog with the expected per-role counts', () => {
+    expect(HOWTO_GUIDES).toHaveLength(29);
+    const byAudience = (a: string) => HOWTO_GUIDES.filter((g) => g.audiences.includes(a as any)).length;
+    expect(byAudience('getting-started')).toBe(3);
+    expect(byAudience('family')).toBe(6);
+    expect(byAudience('operator')).toBe(9);
+    expect(byAudience('caregiver')).toBe(6);
+    expect(byAudience('provider')).toBe(3);
+    expect(byAudience('discharge-planner')).toBe(2);
+  });
+
+  it('every guide has content (steps + summary) and a unique slug', () => {
+    const slugs = HOWTO_GUIDES.map((g) => g.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+    for (const g of HOWTO_GUIDES) {
+      expect(g.summary.length).toBeGreaterThan(0);
+      expect(g.steps.length).toBeGreaterThan(0);
+      expect(g.audiences.length).toBe(1);
+    }
   });
 
   it('never exposes an audience outside the catalog (no admin/affiliate guides exist)', () => {
@@ -77,5 +108,6 @@ describe('canViewGuide / filterGuidesForRole', () => {
     // The HowToAudience type has no 'admin'/'affiliate' member, so by
     // construction those cannot appear in the public catalog.
     expect([...audiences].every((a) => a !== ('admin' as any))).toBe(true);
+    expect([...audiences].every((a) => a !== ('affiliate' as any))).toBe(true);
   });
 });

--- a/context/CARELINKAI_TECHNICAL_STATE.md
+++ b/context/CARELINKAI_TECHNICAL_STATE.md
@@ -1,8 +1,11 @@
 # CareLinkAI — Technical State
-_Last updated: 2026-06-15_
+_Last updated: 2026-06-16_
 
 ## Active Branch
-`main` — through PR #560. Pending branch: `claude/inspiring-mayer-rvgyys` (2026-06-15: discharge-planner search fix [OL-067], inquiry-form 400 fix [OL-068], role-gated How-To Guides hub [OL-069] — 3 commits, not yet PR'd to main). Also pending: `chore/remove-non-cleveland-demo-data` (non-Cleveland demo homes cleanup, not yet a PR).
+`main` — PRs #564 (discharge-planner search fix, OL-067), #565 (inquiry-form 400, OL-068), #566 (role-gated How-To hub), #567 (/help links, OL-070) all merged 2026-06-15. Pending PR: `feat/howto-hub-full-content` (2026-06-16 — full 29-guide How-To content, closes OL-069). Also pending: `chore/remove-non-cleveland-demo-data` (not yet a PR).
+
+## How-To Guides (Education Hub) — content pipeline
+The `/learn` How-To section renders from `src/app/learn/howto/content.ts` (`HOWTO_GUIDES`), role-gated by `src/lib/howto/access.ts` (audience→role; getting-started + family visible to all). That file is **auto-generated** — do not hand-edit. Source content is authored in the ChrisOS vault (`04_CareLinkAI/howto/`), cleaned into an app bundle (`manifest.json` + `content/<role>/*.md`), and transformed by `scripts/generate-howto-content.ts` (`npx tsx scripts/generate-howto-content.ts`). Guide screenshots live under `public/howto/`; the renderer shows only files that exist (build-time `AVAILABLE_HOWTO_IMAGES`), so missing captures are text-first with no 404s. The 71 expected screenshot filenames are checklisted in `public/howto/README.md` (OL-071).
 
 ## Production URL
 https://carelinkai.onrender.com (also: https://getcarelinkai.com)

--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -1,5 +1,5 @@
 # CareLinkAI — Tech Open Loops
-_Last updated: 2026-06-15_
+_Last updated: 2026-06-16_
 
 ## Format
 Each loop: what it is, why it matters, what done looks like.
@@ -94,10 +94,20 @@ Each loop: what it is, why it matters, what done looks like.
 - **What:** The `/homes/[id]` "Send Inquiry" form posted `name/email/phone/residentName/careNeeded` + `source:'home_detail'`, none matching the API Zod schema → every submit `400 Validation failed`. Added `buildInquiryPayload()` (`src/lib/inquiries/payload.ts`) mapping to the canonical contract, extracted the schema to `src/lib/inquiries/schema.ts`, relaxed `careRecipientName` to optional (nullable column, backward compatible). Tests in `__tests__/inquiries.payload.unit.test.ts`.
 - **Note:** Committed to `claude/inspiring-mayer-rvgyys`; not yet PR'd/merged to main.
 
-### OL-069: Port the 25 How-To guides from the ChrisOS vault into the Education Hub
-- **Status:** 🟡 OPEN — infrastructure shipped 2026-06-15, content pending
-- **What:** The role-gated How-To Guides section now exists at `/learn/howto` with a content model that mirrors the vault guide format (`src/app/learn/howto/content.ts`). The 25 source guides in the vault (`04_CareLinkAI/howto/`: family/shared/operator/caregiver/provider/discharge-planner/admin) could NOT be copied because the vault is not present in this environment — only a starter set was seeded.
-- **Done when:** With the vault available, port all guides into `HOWTO_GUIDES` (exclude `admin/00_INTERNAL_admin_overview.md` and any affiliate guides; move NARRATION SCRIPT blocks into `narrationScript`), capture the `(img: …)` assets into `/public/howto/`, and verify each role sees only its guides.
+### OL-069: Port the full How-To guide set from the ChrisOS vault into the Education Hub
+- **Status:** ✅ CLOSED (2026-06-16, PR feat/howto-hub-full-content) — full content now version-controlled in-repo
+- **What:** The starter set has been replaced with all **29 cleaned, role-facing guides** (shared 3, family 6, operator 9, caregiver 6, provider 3, discharge-planner 2). Chris delivered them as an app-ready bundle (`_app_content_bundle`, via a zip dropped on `chore/howto-bundle-dropoff` since the vault isn't reachable from dev/CI). A codegen script `scripts/generate-howto-content.ts` transforms the bundle (`manifest.json` + `content/<role>/*.md`) into `src/app/learn/howto/content.ts` (role→audience mapping, `### ` step sections, Tips/FAQ, internal cross-refs stripped). Admin-internal + Affiliate guides are deliberately excluded. The raw bundle + zip were removed so nothing extra ships; the dropoff branch was deleted.
+- **Role-gating:** unchanged from #566/#567 — families see shared + family only; each role sees its own; verified by `__tests__/howto.access.unit.test.ts` (per-role counts + no cross-role leak).
+- **Image tail → see OL-071.**
+
+### OL-071: Capture the 71 How-To screenshots into the repo
+- **Status:** 🟡 OPEN — text-first guides are live; screenshots pending
+- **What:** Each guide's frontmatter lists screenshot filenames (71 total) that live in Chris's Downloads, not the repo. The hub renders **text-first**: it shows only images present under `public/howto/` (build-time `AVAILABLE_HOWTO_IMAGES` set), so missing captures render nothing — no 404s, no broken layout. The full per-guide checklist is generated at `public/howto/README.md`.
+- **Done when:** Optimized PNGs are dropped into `public/howto/` by the filenames in that README, `npx tsx scripts/generate-howto-content.ts` is re-run (rescans available images), and the guides show their screenshots. (Optional later: namespace filenames by slug, or host on Cloudinary.)
+
+### OL-070: /help "Getting Started" links broken/role-gated for all roles
+- **Status:** ✅ CLOSED (2026-06-15, PR #567, merged) — backfilled here
+- **What:** The role checklists on `/help` pointed at dead or role-gated routes (FAMILY "Browse assisted living homes" → `/discharge-planner`; `/marketplace/aides` 404; CAREGIVER `/settings/aide` 404; OPERATOR `/marketplace/listings` 404), and DISCHARGE_PLANNER/AFFILIATE had no guide. Repointed every step to a verified, role-accessible route and added the two missing guides. Extracted to `src/lib/help/getting-started.ts` + `__tests__/help.getting-started.unit.test.ts` (33 cases) that fails if any href doesn't resolve to a real `src/app/**/page.tsx` route or a FAMILY step targets a gated portal.
 
 ### OL-027: Provider listing fee ($99/mo)
 - **Status:** ✅ CLOSED (2026-05-02)

--- a/context/DEV_SESSION_SUMMARIES.md
+++ b/context/DEV_SESSION_SUMMARIES.md
@@ -1489,4 +1489,23 @@
 - **New risks/blockers:** ChrisOS vault not present in this environment → the 25 source How-To guides could not be ported (OL-067). Branch note: per harness instructions all three units were committed to `claude/inspiring-mayer-rvgyys` as three separate commits rather than three branches/PRs.
 - **Recommended next step:** When the vault is available, port the 25 guides from `04_CareLinkAI/howto/` into `src/app/learn/howto/content.ts` (excluding admin/affiliate, stripping NARRATION SCRIPT into `narrationScript`), capture the `(img: …)` assets into `/public/howto/`, and open the three PRs to main.
 
+### 2026-06-16 — Full How-To guide set ported into /learn (closes OL-069)
+- **Objective:** Replace the How-To hub's starter set with the complete, app-ready guide set as version-controlled content, rendered by the #566 hub. Close OL-069.
+- **Work completed:**
+  - Chris delivered 29 cleaned guides as a zip (`_howto_bundle.zip`) on `chore/howto-bundle-dropoff` (the ChrisOS vault isn't reachable from this dev/CI environment, and a remote session can't mount a local Windows `--add-dir` path — so git drop-off was the path in).
+  - Inspected the merged #566 hub: it renders from a TS data module (`src/app/learn/howto/content.ts` → `HOWTO_GUIDES`), role-gated via `src/lib/howto/access.ts`.
+  - Wrote `scripts/generate-howto-content.ts` (codegen) that transforms the bundle (`manifest.json` + `content/<role>/*.md`) into `content.ts`: maps role→audience, parses `### ` step sections / numbered steps / Tips / FAQ, strips internal cross-file refs and inline markdown, computes readTime, assigns per-guide icons. Generated all **29 guides** (shared 3, family 6, operator 9, caregiver 6, provider 3, discharge-planner 2).
+  - Extended the model minimally: `HowToStep.section?` (group heading), guide-level `images?`, and a build-time `AVAILABLE_HOWTO_IMAGES` set (scanned from `public/howto`). Reworked the detail page to render section-grouped steps (numbered within each group) and a Screenshots gallery that shows **only images that exist** — text-first, zero 404s for the 71 not-yet-captured screenshots.
+  - Generated `public/howto/README.md` — the per-guide checklist of all 71 expected screenshot filenames (drives OL-071).
+  - Deleted the raw `_app_content_bundle` + `_howto_bundle.zip` so neither ships; deleted the `chore/howto-bundle-dropoff` remote branch.
+  - Updated `__tests__/howto.access.unit.test.ts` to the new slugs + added catalog/gating assertions (29 guides, per-role counts, no cross-role leak, unique slugs, every guide has steps).
+- **Files changed:** `scripts/generate-howto-content.ts` (new), `src/app/learn/howto/content.ts` (regenerated, 29 guides), `src/app/learn/howto/[slug]/page.tsx` (section grouping + image gallery), `public/howto/README.md` (new), `__tests__/howto.access.unit.test.ts`, context files.
+- **Commands run:** `npx tsx scripts/generate-howto-content.ts`, `npx jest` (howto+help suites, 44 passing), `npx tsc --noEmit` (exit 0), `npm run build` (Compiled successfully), `npx next lint` (no warnings/errors).
+- **Tests/build status:** ✅ typecheck clean, build passes, 44 unit tests passing, lint clean.
+- **Deployment impact:** Content-only + a presentational detail-page change; no schema/migration. Safe on Render auto-deploy once merged. `/learn` will show all 29 guides with correct gating.
+- **New risks/blockers:** None. Screenshots still pending (OL-071, non-blocking — guides are text-first).
+- **PR / commit:** PR `feat/howto-hub-full-content` (commit hash recorded on push).
+- **Also this session:** merged PRs #564/#565/#566/#567 to main earlier; backfilled the #567 help-links fix as OL-070; closed OL-069; opened OL-071 for screenshot capture.
+- **Recommended next step:** Capture the 71 screenshots into `public/howto/` per the README and re-run the codegen (OL-071).
+
 <!-- Add new sessions above this line, newest first -->

--- a/public/howto/README.md
+++ b/public/howto/README.md
@@ -1,0 +1,126 @@
+# How-To Guide Screenshots
+
+Drop screenshot PNGs here (flat, by the exact filename below). The
+How-To hub renders only images that exist (see `AVAILABLE_HOWTO_IMAGES`
+in `src/app/learn/howto/content.ts`), so until a file lands the guide
+renders text-only — nothing 404s. After adding files, re-run:
+
+    npx tsx scripts/generate-howto-content.ts
+
+Filenames are per-guide; if two guides share a name (e.g. `01_dashboard.png`)
+they refer to different screens — capture each guide separately. (A future
+cleanup may namespace these by slug.)
+
+## Getting Started (All Roles) (`shared`)
+- **Sign Up & Log In** (`signup-and-login`):
+  - [ ] `01_register.png`
+  - [ ] `02_login.png`
+  - [ ] `03_dashboard.png`
+- **Messaging** (`messaging`):
+  - [ ] `01_inbox.png`
+  - [ ] `02_conversation.png`
+- **Settings — Profile, Account & Notifications** (`settings-profile-and-notifications`):
+  - [ ] `01_settings_hub.png`
+
+## For Families (`family`)
+- **Search for a Care Home** (`search-homes`):
+  - [ ] `01_login.png`
+  - [ ] `02_dashboard.png`
+  - [ ] `03_search_results.png`
+  - [ ] `04_listing_detail.png`
+- **Save Favorites & Compare Homes** (`save-and-compare`):
+  - [ ] `01_search_results.png`
+  - [ ] `02_heart_saved.png`
+  - [ ] `03_compare_banner.png`
+  - [ ] `04_favorites.png`
+- **Send an Inquiry to a Care Home** (`send-inquiry`):
+  - [ ] `01_listing_detail.png`
+  - [ ] `02_inquiry_form.png`
+  - [ ] `03_inquiry_filled.png`
+  - [ ] `04_my_inquiries.png`
+- **Schedule a Tour** (`schedule-tour`):
+  - [ ] `01_listing_panel.png`
+  - [ ] `02_tour_datetime.png`
+  - [ ] `03_my_tours.png`
+- **Use AI Match to Find Your Best Homes** (`ai-match`):
+  - [ ] `01_aimatch_start.png`
+  - [ ] `02_step1_budget.png`
+  - [ ] `03_step4_location.png`
+  - [ ] `04_results.png`
+- **Use the Family Portal** (`family-portal`):
+  - [ ] `01_portal_home.png`
+  - [ ] `02_documents.png`
+  - [ ] `03_activity.png`
+  - [ ] `04_members.png`
+
+## For Operators (`operator`)
+- **Claim Your Listing** — _(no screenshots)_
+- **Your Operator Dashboard** (`operator-dashboard`):
+  - [ ] `01_dashboard.png`
+  - [ ] `02_ask_ai.png`
+- **Manage Your Home & Photos** (`manage-home-and-photos`):
+  - [ ] `01_your_homes.png`
+  - [ ] `02_manage_home.png`
+  - [ ] `03_photo_upload.png`
+- **Manage Leads & the Inquiries Pipeline** (`leads-and-inquiries-pipeline`):
+  - [ ] `01_pipeline.png`
+  - [ ] `02_kanban_cards.png`
+- **Manage Tour Requests** (`tour-management`):
+  - [ ] `01_tour_management.png`
+  - [ ] `02_tour_request.png`
+- **Manage Residents** (`residents`):
+  - [ ] `01_residents.png`
+  - [ ] `02_resident_row.png`
+- **Shifts & On-Call AI Coverage** (`shifts-and-oncall-ai`):
+  - [ ] `01_shifts.png`
+  - [ ] `02_oncall.png`
+- **Compliance Document Kits** (`compliance-kits`):
+  - [ ] `01_compliance_kits.png`
+- **Analytics & Billing** (`analytics-and-billing`):
+  - [ ] `01_analytics.png`
+  - [ ] `02_billing.png`
+
+## For Caregivers (`caregiver`)
+- **Your Caregiver Dashboard** (`caregiver-dashboard`):
+  - [ ] `01_dashboard.png`
+  - [ ] `02_status_tiles.png`
+- **Build Your Profile & Add Credentials** (`profile-and-credentials`):
+  - [ ] `01_profile.png`
+  - [ ] `02_skills.png`
+  - [ ] `03_rate.png`
+  - [ ] `04_credentials.png`
+- **Find Jobs & Track Applications** (`marketplace-jobs-and-applications`):
+  - [ ] `01_jobs.png`
+  - [ ] `02_job_card.png`
+  - [ ] `03_applications.png`
+- **Pick Up Shifts & Track Your Hours** (`shifts-and-timesheets`):
+  - [ ] `01_open_shifts.png`
+  - [ ] `02_my_shifts.png`
+- **Earn Reliability Points & Rewards** (`reliability-points`):
+  - [ ] `01_points.png`
+  - [ ] `02_tier.png`
+- **Your Public Profile & Background Checks** (`public-profile-and-background-checks`):
+  - [ ] `01_public_profile.png`
+  - [ ] `02_background_checks.png`
+
+## For Providers (`provider`)
+- **Your Provider Dashboard & Getting Listed** (`provider-dashboard-and-onboarding`):
+  - [ ] `01_dashboard.png`
+  - [ ] `02_onboarding_checklist.png`
+- **Set Up Your Provider Profile, Services & Pricing** (`profile-services-and-pricing`):
+  - [ ] `01_profile.png`
+  - [ ] `02_services.png`
+  - [ ] `03_transport.png`
+  - [ ] `04_pricing.png`
+- **Your Marketplace Listing & Public Presence** (`marketplace-listing-and-presence`):
+  - [ ] `01_listing_billing.png`
+  - [ ] `02_public_profile.png`
+
+## For Discharge Planners (`discharge-planner`)
+- **AI Placement Search** (`placement-search`):
+  - [ ] `01_dashboard.png`
+  - [ ] `02_search.png`
+  - [ ] `03_results.png`
+- **Refer & Inquire on Behalf of a Patient** — _(no screenshots)_
+
+**Total screenshots referenced: 71**

--- a/scripts/generate-howto-content.ts
+++ b/scripts/generate-howto-content.ts
@@ -1,0 +1,422 @@
+/**
+ * Codegen: transform the cleaned How-To guide bundle into the data module the
+ * /learn How-To hub renders (src/app/learn/howto/content.ts).
+ *
+ * Source of truth: _app_content_bundle/manifest.json + content/<role>/*.md
+ * (frontmatter + a "## Steps / ## Tips / ## FAQ" body). Re-run after the
+ * bundle changes:
+ *
+ *   npx tsx scripts/generate-howto-content.ts
+ *
+ * Images: each guide's frontmatter lists screenshot filenames, but the PNGs
+ * are not in the repo yet. We emit the full desired list on each guide AND a
+ * build-time AVAILABLE_HOWTO_IMAGES set (scanned from public/howto). The
+ * renderer only shows images that actually exist, so nothing 404s today and
+ * screenshots light up automatically once dropped into public/howto.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO = path.resolve(__dirname, '..');
+const BUNDLE = path.join(REPO, '_app_content_bundle');
+const OUT = path.join(REPO, 'src', 'app', 'learn', 'howto', 'content.ts');
+const PUBLIC_HOWTO = path.join(REPO, 'public', 'howto');
+
+type Audience =
+  | 'getting-started'
+  | 'family'
+  | 'operator'
+  | 'caregiver'
+  | 'provider'
+  | 'discharge-planner';
+
+const ROLE_TO_AUDIENCE: Record<string, Audience> = {
+  shared: 'getting-started',
+  family: 'family',
+  operator: 'operator',
+  caregiver: 'caregiver',
+  provider: 'provider',
+  'discharge-planner': 'discharge-planner',
+};
+
+// Per-guide icons (fall back to a role default).
+const ROLE_DEFAULT_ICON: Record<string, string> = {
+  shared: '🚀',
+  family: '🏠',
+  operator: '🏢',
+  caregiver: '🧑‍⚕️',
+  provider: '🤝',
+  'discharge-planner': '🏥',
+};
+const SLUG_ICON: Record<string, string> = {
+  'signup-and-login': '🔐',
+  messaging: '💬',
+  'settings-profile-and-notifications': '⚙️',
+  'search-homes': '🔎',
+  'save-and-compare': '💛',
+  'send-inquiry': '📨',
+  'schedule-tour': '📅',
+  'ai-match': '✨',
+  'family-portal': '👨‍👩‍👧',
+  'claim-your-listing': '🏷️',
+  'operator-dashboard': '📊',
+  'manage-home-and-photos': '🏠',
+  'leads-and-inquiries-pipeline': '📥',
+  'tour-management': '🗓️',
+  residents: '🧑‍🦳',
+  'shifts-and-oncall-ai': '📞',
+  'compliance-kits': '📋',
+  'analytics-and-billing': '💳',
+  'caregiver-dashboard': '📊',
+  'profile-and-credentials': '🪪',
+  'marketplace-jobs-and-applications': '🧰',
+  'shifts-and-timesheets': '⏱️',
+  'reliability-points': '🏆',
+  'public-profile-and-background-checks': '🛡️',
+  'provider-dashboard-and-onboarding': '🤝',
+  'profile-services-and-pricing': '🧾',
+  'marketplace-listing-and-presence': '📣',
+  'placement-search': '🏥',
+  'refer-and-inquire-on-behalf': '📨',
+};
+
+interface Manifest {
+  roles: { role: string; label: string; guides: { slug: string; order: number; file: string }[] }[];
+}
+
+interface Frontmatter {
+  title: string;
+  role: string;
+  slug: string;
+  order: number;
+  audience: string;
+  summary: string;
+  images: string[];
+  source: string;
+}
+
+interface OutStep {
+  section?: string;
+  text: string;
+}
+interface OutFaq {
+  q: string;
+  a: string;
+}
+interface OutGuide {
+  slug: string;
+  title: string;
+  audiences: Audience[];
+  icon: string;
+  whoFor: string;
+  summary: string;
+  readTime: string;
+  steps: OutStep[];
+  tips: string[];
+  faq: OutFaq[];
+  images: string[];
+}
+
+/** Strip inline markdown + internal cross-file references to clean reader text. */
+function cleanInline(s: string): string {
+  return s
+    // drop "*(See `xx.md`.)*" style internal cross-refs
+    .replace(/\*?\(See[^)]*\)\*?/gi, '')
+    // drop bare `something.md` code refs
+    .replace(/`[^`]*\.md`/g, '')
+    // markdown links -> link text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    // bold/italic markers
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    // inline code -> text
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\s{2,}/g, ' ')
+    // tidy stray space before punctuation left by removed cross-refs
+    .replace(/\s+([.,;:!?])/g, '$1')
+    .trim();
+}
+
+function parseFrontmatter(raw: string): { fm: Frontmatter; body: string } {
+  const m = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!m) throw new Error('missing frontmatter');
+  const block = m[1];
+  const body = m[2];
+  const get = (key: string): string => {
+    const line = block.match(new RegExp(`^${key}:\\s*(.*)$`, 'm'));
+    return line ? line[1].trim() : '';
+  };
+  const unquote = (v: string) => v.replace(/^"(.*)"$/s, '$1');
+  const imagesRaw = get('images') || '[]';
+  let images: string[] = [];
+  try {
+    images = JSON.parse(imagesRaw);
+  } catch {
+    images = [];
+  }
+  return {
+    fm: {
+      title: unquote(get('title')),
+      role: get('role'),
+      slug: get('slug'),
+      order: parseInt(get('order') || '0', 10),
+      audience: unquote(get('audience')),
+      summary: unquote(get('summary')),
+      images,
+      source: unquote(get('source')),
+    },
+    body,
+  };
+}
+
+/** Split the body into its "## Section" blocks. */
+function sections(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const parts = body.split(/^##\s+/m).slice(1);
+  for (const p of parts) {
+    const nl = p.indexOf('\n');
+    const name = p.slice(0, nl).trim().toLowerCase();
+    out[name] = p.slice(nl + 1);
+  }
+  return out;
+}
+
+function parseSteps(stepsBody: string): OutStep[] {
+  const steps: OutStep[] = [];
+  let currentSection: string | undefined;
+  let sectionUsed = false;
+  const lines = stepsBody.split('\n');
+  for (const line of lines) {
+    const h3 = line.match(/^###\s+(.*)$/);
+    if (h3) {
+      currentSection = cleanInline(h3[1]);
+      sectionUsed = false;
+      continue;
+    }
+    const num = line.match(/^\s*\d+\.\s+(.*)$/);
+    if (num) {
+      const text = cleanInline(num[1]);
+      if (!text) continue;
+      const step: OutStep = { text };
+      if (currentSection && !sectionUsed) {
+        step.section = currentSection;
+        sectionUsed = true;
+      }
+      steps.push(step);
+    }
+  }
+  return steps;
+}
+
+function parseTips(tipsBody = ''): string[] {
+  return tipsBody
+    .split('\n')
+    .map((l) => l.match(/^[-*]\s+(.*)$/))
+    .filter((m): m is RegExpMatchArray => !!m)
+    .map((m) => cleanInline(m[1]))
+    .filter(Boolean);
+}
+
+function parseFaq(faqBody = ''): OutFaq[] {
+  const out: OutFaq[] = [];
+  for (const line of faqBody.split('\n')) {
+    const m = line.match(/^[-*]\s+(.*)$/);
+    if (!m) continue;
+    // "**Question?** Answer text" — bold lead is the question.
+    const qm = m[1].match(/^\*\*(.+?)\*\*\s*(.*)$/);
+    if (qm) {
+      out.push({ q: cleanInline(qm[1]), a: cleanInline(qm[2]) });
+    } else {
+      const text = cleanInline(m[1]);
+      const qi = text.indexOf('?');
+      if (qi > -1 && qi < text.length - 1) {
+        out.push({ q: text.slice(0, qi + 1).trim(), a: text.slice(qi + 1).trim() });
+      } else {
+        out.push({ q: text, a: '' });
+      }
+    }
+  }
+  return out;
+}
+
+function readTime(body: string): string {
+  const words = body.split(/\s+/).filter(Boolean).length;
+  return `${Math.max(2, Math.round(words / 180))} min`;
+}
+
+function buildGuide(fm: Frontmatter, body: string): OutGuide {
+  const secs = sections(body);
+  return {
+    slug: fm.slug,
+    title: fm.title,
+    audiences: [ROLE_TO_AUDIENCE[fm.role]],
+    icon: SLUG_ICON[fm.slug] || ROLE_DEFAULT_ICON[fm.role] || '📘',
+    whoFor: fm.audience,
+    summary: fm.summary,
+    readTime: readTime(body),
+    steps: parseSteps(secs['steps'] || ''),
+    tips: parseTips(secs['tips']),
+    faq: parseFaq(secs['faq']),
+    images: fm.images,
+  };
+}
+
+function availableImages(): string[] {
+  if (!fs.existsSync(PUBLIC_HOWTO)) return [];
+  return fs
+    .readdirSync(PUBLIC_HOWTO)
+    .filter((f) => /\.(png|jpe?g|webp|gif)$/i.test(f))
+    .sort();
+}
+
+function emit(guides: OutGuide[]): string {
+  const header = `/**
+ * AUTO-GENERATED — do not edit by hand.
+ * Source: _app_content_bundle (manifest.json + content/<role>/*.md).
+ * Regenerate: npx tsx scripts/generate-howto-content.ts
+ *
+ * How-To Guides content model for the Education Hub (/learn).
+ *
+ *  - Role-gating lives in src/lib/howto/access.ts (audiences -> roles).
+ *  - 'getting-started' + 'family' are visible to everyone; each role also sees
+ *    its own audience. Admin-internal and Affiliate content are intentionally
+ *    NOT part of HowToAudience, so they can never appear in the public hub.
+ *  - 'images' lists the screenshots a guide wants. The actual files may not be
+ *    in the repo yet; AVAILABLE_HOWTO_IMAGES (scanned from public/howto at
+ *    codegen time) lets the renderer show only images that exist — text-first,
+ *    no broken links.
+ */
+
+export type HowToAudience =
+  | 'getting-started'
+  | 'family'
+  | 'operator'
+  | 'caregiver'
+  | 'provider'
+  | 'discharge-planner';
+
+export interface HowToStep {
+  /** Optional group heading (a "### ..." section in the source guide). */
+  section?: string;
+  text: string;
+  /** Optional per-step image (unused for now — images render as a gallery). */
+  image?: string;
+  imageAlt?: string;
+}
+
+export interface HowToFaq {
+  q: string;
+  a: string;
+}
+
+export interface HowToGuide {
+  slug: string;
+  title: string;
+  audiences: HowToAudience[];
+  icon: string;
+  /** "Who it's for" line. */
+  whoFor: string;
+  /** 30-second summary. */
+  summary: string;
+  readTime: string;
+  steps: HowToStep[];
+  tips?: string[];
+  faq?: HowToFaq[];
+  /** Screenshot filenames this guide wants (may not be in the repo yet). */
+  images?: string[];
+  /** Internal video voiceover script — never rendered publicly. */
+  narrationScript?: string;
+}
+
+export const AUDIENCE_LABELS: Record<HowToAudience, string> = {
+  'getting-started': 'Getting Started',
+  family: 'For Families',
+  operator: 'For Operators',
+  caregiver: 'For Caregivers',
+  provider: 'For Providers',
+  'discharge-planner': 'For Discharge Planners',
+};
+
+/** Display order for the grouped sections on the hub page. */
+export const AUDIENCE_ORDER: HowToAudience[] = [
+  'getting-started',
+  'family',
+  'operator',
+  'caregiver',
+  'provider',
+  'discharge-planner',
+];
+
+/**
+ * Screenshot filenames that actually exist under public/howto at build time.
+ * The renderer only shows images in this set, so missing screenshots never
+ * 404 or break layout. Re-run the codegen after adding files to public/howto.
+ */
+export const AVAILABLE_HOWTO_IMAGES: ReadonlySet<string> = new Set(${JSON.stringify(
+    availableImages()
+  )});
+
+export const HOWTO_GUIDES: HowToGuide[] = ${serializeGuides(guides)};
+
+export function getHowToGuide(slug: string): HowToGuide | undefined {
+  return HOWTO_GUIDES.find((g) => g.slug === slug);
+}
+`;
+  return header;
+}
+
+function serializeGuides(guides: OutGuide[]): string {
+  const lines: string[] = ['['];
+  for (const g of guides) {
+    lines.push('  {');
+    lines.push(`    slug: ${JSON.stringify(g.slug)},`);
+    lines.push(`    title: ${JSON.stringify(g.title)},`);
+    lines.push(`    audiences: ${JSON.stringify(g.audiences)},`);
+    lines.push(`    icon: ${JSON.stringify(g.icon)},`);
+    lines.push(`    whoFor: ${JSON.stringify(g.whoFor)},`);
+    lines.push(`    summary: ${JSON.stringify(g.summary)},`);
+    lines.push(`    readTime: ${JSON.stringify(g.readTime)},`);
+    lines.push(`    steps: [`);
+    for (const s of g.steps) {
+      const parts = [`text: ${JSON.stringify(s.text)}`];
+      if (s.section) parts.unshift(`section: ${JSON.stringify(s.section)}`);
+      lines.push(`      { ${parts.join(', ')} },`);
+    }
+    lines.push(`    ],`);
+    if (g.tips.length) {
+      lines.push(`    tips: ${JSON.stringify(g.tips)},`);
+    }
+    if (g.faq.length) {
+      lines.push(`    faq: [`);
+      for (const f of g.faq) {
+        lines.push(`      { q: ${JSON.stringify(f.q)}, a: ${JSON.stringify(f.a)} },`);
+      }
+      lines.push(`    ],`);
+    }
+    if (g.images.length) {
+      lines.push(`    images: ${JSON.stringify(g.images)},`);
+    }
+    lines.push('  },');
+  }
+  lines.push(']');
+  return lines.join('\n');
+}
+
+function main() {
+  const manifest: Manifest = JSON.parse(fs.readFileSync(path.join(BUNDLE, 'manifest.json'), 'utf8'));
+  const guides: OutGuide[] = [];
+  for (const role of manifest.roles) {
+    const ordered = [...role.guides].sort((a, b) => a.order - b.order);
+    for (const g of ordered) {
+      const raw = fs.readFileSync(path.join(BUNDLE, g.file), 'utf8');
+      const { fm, body } = parseFrontmatter(raw);
+      guides.push(buildGuide(fm, body));
+    }
+  }
+  fs.writeFileSync(OUT, emit(guides));
+  console.log(`Wrote ${guides.length} guides to ${path.relative(REPO, OUT)}`);
+  console.log(`Available images: ${availableImages().length}`);
+}
+
+main();

--- a/src/app/learn/howto/[slug]/page.tsx
+++ b/src/app/learn/howto/[slug]/page.tsx
@@ -4,9 +4,22 @@ import type { Metadata } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import DashboardLayout from '@/components/layout/DashboardLayout';
-import { getHowToGuide, HOWTO_GUIDES, AUDIENCE_LABELS } from '../content';
+import { getHowToGuide, HOWTO_GUIDES, AUDIENCE_LABELS, AVAILABLE_HOWTO_IMAGES, type HowToStep } from '../content';
 import { canViewGuide, filterGuidesForRole, type ViewerRole } from '@/lib/howto/access';
 import HowToImage from '../HowToImage';
+
+/** Group consecutive steps under their optional section heading. */
+function groupSteps(steps: HowToStep[]): { section?: string; steps: HowToStep[] }[] {
+  const groups: { section?: string; steps: HowToStep[] }[] = [];
+  for (const step of steps) {
+    if (step.section || groups.length === 0) {
+      groups.push({ section: step.section, steps: [step] });
+    } else {
+      groups[groups.length - 1].steps.push(step);
+    }
+  }
+  return groups;
+}
 
 interface Props {
   params: { slug: string };
@@ -86,20 +99,32 @@ export default async function HowToGuidePage({ params }: Props) {
       </div>
 
       <div className="max-w-3xl mx-auto px-6 py-10">
-        {/* Steps */}
-        <ol className="space-y-8">
-          {guide.steps.map((step, i) => (
-            <li key={i} className="flex gap-4">
-              <span className="flex-shrink-0 flex h-8 w-8 items-center justify-center rounded-full bg-primary-600 text-white text-sm font-semibold">
-                {i + 1}
-              </span>
-              <div className="flex-1">
-                <p className="text-neutral-800 leading-relaxed">{step.text}</p>
-                {step.image && <HowToImage image={step.image} alt={step.imageAlt} />}
-              </div>
-            </li>
+        {/* Steps — grouped under their optional section headings, numbered
+            within each group. */}
+        <div className="space-y-8">
+          {groupSteps(guide.steps).map((group, gi) => (
+            <div key={gi}>
+              {group.section && (
+                <h2 className="text-lg font-semibold text-neutral-900 mb-4">{group.section}</h2>
+              )}
+              <ol className="space-y-5">
+                {group.steps.map((step, i) => (
+                  <li key={i} className="flex gap-4">
+                    <span className="flex-shrink-0 flex h-8 w-8 items-center justify-center rounded-full bg-primary-600 text-white text-sm font-semibold">
+                      {i + 1}
+                    </span>
+                    <div className="flex-1">
+                      <p className="text-neutral-800 leading-relaxed">{step.text}</p>
+                      {step.image && AVAILABLE_HOWTO_IMAGES.has(step.image) && (
+                        <HowToImage image={step.image} alt={step.imageAlt} />
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </div>
           ))}
-        </ol>
+        </div>
 
         {/* Tips */}
         {guide.tips && guide.tips.length > 0 && (
@@ -127,6 +152,24 @@ export default async function HowToGuidePage({ params }: Props) {
             </div>
           </div>
         )}
+
+        {/* Screenshots — only renders images actually present under
+            public/howto (text-first; missing captures render nothing, never a
+            broken link). See AVAILABLE_HOWTO_IMAGES. */}
+        {(() => {
+          const present = (guide.images ?? []).filter((img) => AVAILABLE_HOWTO_IMAGES.has(img));
+          if (present.length === 0) return null;
+          return (
+            <div className="mt-10">
+              <h2 className="text-lg font-semibold text-neutral-900 mb-4">Screenshots</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {present.map((img) => (
+                  <HowToImage key={img} image={img} alt={`${guide.title} screenshot`} />
+                ))}
+              </div>
+            </div>
+          );
+        })()}
 
         {/* NOTE: narrationScript is intentionally NOT rendered — it is internal
             video voiceover content, not for end users. */}

--- a/src/app/learn/howto/content.ts
+++ b/src/app/learn/howto/content.ts
@@ -1,22 +1,18 @@
 /**
- * How-To Guides content model for the Education Hub.
+ * AUTO-GENERATED — do not edit by hand.
+ * Source: _app_content_bundle (manifest.json + content/<role>/*.md).
+ * Regenerate: npx tsx scripts/generate-howto-content.ts
  *
- * The shape mirrors the source guides authored in the ChrisOS vault
- * (`04_CareLinkAI/howto/`): title, "who it's for", a 30-second summary,
- * numbered steps (each with an optional image placeholder), tips, an FAQ,
- * and a narration script used for video voiceover.
+ * How-To Guides content model for the Education Hub (/learn).
  *
- * IMPORTANT (role-gating + public exposure):
- *  - `narrationScript` is for internal video production ONLY and is never
- *    rendered to end users. It lives here behind the render layer.
- *  - Admin-internal and Affiliate guides are intentionally excluded from the
- *    public hub (see HowToAudience — there is no "admin"/"affiliate" audience).
- *
- * The starter guides below are authored from CareLinkAI's actual flows. The
- * full set of 25 guides lives in the vault and should be ported into this
- * array (the field shape already matches), excluding the internal admin
- * overview and any affiliate guides, and stripping NARRATION SCRIPT blocks
- * into `narrationScript`.
+ *  - Role-gating lives in src/lib/howto/access.ts (audiences -> roles).
+ *  - 'getting-started' + 'family' are visible to everyone; each role also sees
+ *    its own audience. Admin-internal and Affiliate content are intentionally
+ *    NOT part of HowToAudience, so they can never appear in the public hub.
+ *  - 'images' lists the screenshots a guide wants. The actual files may not be
+ *    in the repo yet; AVAILABLE_HOWTO_IMAGES (scanned from public/howto at
+ *    codegen time) lets the renderer show only images that exist — text-first,
+ *    no broken links.
  */
 
 export type HowToAudience =
@@ -28,13 +24,10 @@ export type HowToAudience =
   | 'discharge-planner';
 
 export interface HowToStep {
-  /** Numbered step instruction. */
+  /** Optional group heading (a "### ..." section in the source guide). */
+  section?: string;
   text: string;
-  /**
-   * Optional image placeholder key (the vault guides use `(img: …)` markers).
-   * The actual asset files are not captured yet, so the render layer must
-   * degrade gracefully when the file is missing — see howtoImageUrl().
-   */
+  /** Optional per-step image (unused for now — images render as a gallery). */
   image?: string;
   imageAlt?: string;
 }
@@ -47,7 +40,6 @@ export interface HowToFaq {
 export interface HowToGuide {
   slug: string;
   title: string;
-  /** Audiences allowed to see this guide. */
   audiences: HowToAudience[];
   icon: string;
   /** "Who it's for" line. */
@@ -58,6 +50,8 @@ export interface HowToGuide {
   steps: HowToStep[];
   tips?: string[];
   faq?: HowToFaq[];
+  /** Screenshot filenames this guide wants (may not be in the repo yet). */
+  images?: string[];
   /** Internal video voiceover script — never rendered publicly. */
   narrationScript?: string;
 }
@@ -81,184 +75,660 @@ export const AUDIENCE_ORDER: HowToAudience[] = [
   'discharge-planner',
 ];
 
+/**
+ * Screenshot filenames that actually exist under public/howto at build time.
+ * The renderer only shows images in this set, so missing screenshots never
+ * 404 or break layout. Re-run the codegen after adding files to public/howto.
+ */
+export const AVAILABLE_HOWTO_IMAGES: ReadonlySet<string> = new Set([]);
+
 export const HOWTO_GUIDES: HowToGuide[] = [
   {
-    slug: 'creating-your-carelinkai-account',
-    title: 'Creating Your CareLinkAI Account',
-    audiences: ['getting-started'],
-    icon: '🚀',
-    whoFor: 'Anyone new to CareLinkAI — families, operators, caregivers, and partners.',
-    summary:
-      'Sign up, verify your email, choose your role, and land on the dashboard built for how you use CareLinkAI.',
-    readTime: '2 min',
+    slug: "signup-and-login",
+    title: "Sign Up & Log In",
+    audiences: ["getting-started"],
+    icon: "🔐",
+    whoFor: "Anyone creating a CareLinkAI account or signing in — families, operators, caregivers, providers, and partners.",
+    summary: "Create an account by choosing your role and entering your email and a password, verify your email, then sign in at the login page. Forgot your password? Reset it from the same page.",
+    readTime: "2 min",
     steps: [
-      { text: 'Go to the sign-up page and enter your name, email, and a password.', image: 'signup-form.png', imageAlt: 'Sign-up form' },
-      { text: 'Choose the role that fits you: Family, Operator, Caregiver, Provider, or Discharge Planner.' },
-      { text: 'Check your email for a verification link and confirm your address.' },
-      { text: 'Sign in — you will be taken to the dashboard tailored to your role.' },
+      { section: "Create an account", text: "Go to getcarelinkai.com and choose Sign Up / Get Started." },
+      { text: "Select the role that fits you — Family, Operator, Caregiver/Aide, Provider, or partner role. Your role shapes the dashboard and tools you'll see." },
+      { text: "Enter your email and a password, then submit to create the account." },
+      { text: "Verify your email: open the verification email CareLinkAI sends and click the confirmation link. This activates your account." },
+      { section: "Log in", text: "Go to getcarelinkai.com/auth/login." },
+      { text: "Enter your email and password and click Sign in." },
+      { text: "You'll land on My Dashboard, tailored to your role." },
+      { section: "Reset a forgotten password", text: "On the login page, click Forgot password?" },
+      { text: "Enter your account email; CareLinkAI sends a reset link." },
+      { text: "Open the email, click the link, and set a new password. Then sign in normally." },
     ],
-    tips: [
-      'Use the email address you check most often — important updates and inquiry notifications are sent there.',
-      'You can update your profile and notification preferences any time from Settings.',
-    ],
+    tips: ["Your dashboard's Quick Links (e.g., Search Homes, My Inquiries, Saved Homes for families) are the fastest way into common tasks.","Use the email address you check most often — verification and password-reset links go there.","If a sign-in doesn't seem to \"take,\" confirm both fields are filled and try again; make sure your email is verified."],
     faq: [
-      { q: 'Can I change my role later?', a: 'Roles are tied to how your account is set up. Contact support if you signed up under the wrong role.' },
+      { q: "Do I have to verify my email?", a: "Yes — verification activates the account before you can fully use it." },
+      { q: "Can I change my role later?", a: "Roles drive your tools; contact support if you signed up under the wrong one." },
     ],
-    narrationScript:
-      'Welcome to CareLinkAI. In this short guide we will create your account and get you to the right dashboard...',
+    images: ["01_register.png","02_login.png","03_dashboard.png"],
   },
   {
-    slug: 'finding-a-home-as-a-family',
-    title: 'Finding the Right Home for Your Loved One',
-    audiences: ['family'],
-    icon: '🔎',
-    whoFor: 'Families searching for assisted living, memory care, or skilled nursing.',
-    summary:
-      'Search homes by location, care level, and budget, compare your shortlist, and reach out to the homes that fit.',
-    readTime: '3 min',
+    slug: "messaging",
+    title: "Messaging",
+    audiences: ["getting-started"],
+    icon: "💬",
+    whoFor: "Anyone communicating through CareLinkAI — families talking to homes and caregivers, operators replying to leads, providers responding to inquiries.",
+    summary: "Open **Messages** to see all your conversations in one inbox. Pick a conversation to read and reply, search to find an old thread, or start a fresh one with **New message**.",
+    readTime: "2 min",
     steps: [
-      { text: 'Open Search and enter the city or area you are looking in.', image: 'search-location.png', imageAlt: 'Home search by location' },
-      { text: 'Filter by care level (assisted living, memory care, skilled nursing) and your monthly budget.' },
-      { text: 'Open a listing to see photos, amenities, pricing, and the care levels the home supports.' },
-      { text: 'Save the homes you like to build a shortlist you can compare side by side.' },
+      { text: "Sign in and open Messages (in the left menu, or Residents & Family → Messages for families)." },
+      { text: "Your conversations list on the left shows each contact, the latest message preview, and the date. Unread threads are marked." },
+      { text: "Click a conversation to open it on the right, read the full history, and type your reply at the bottom." },
+      { text: "Use Search messages to find a thread by name or keyword." },
+      { text: "Click New message to start a conversation with a new contact." },
     ],
-    tips: [
-      'Prioritize homes within a 15–20 minute drive of family who will visit — proximity meaningfully improves resident wellbeing.',
-      'Read our family guides on touring and costs before you reach out.',
-    ],
-  },
-  {
-    slug: 'sending-an-inquiry-and-booking-a-tour',
-    title: 'Sending an Inquiry and Booking a Tour',
-    audiences: ['family'],
-    icon: '📨',
-    whoFor: 'Families ready to contact a home and schedule a visit.',
-    summary:
-      'Send an inquiry from any listing, share what your loved one needs, and request a tour time — the operator is notified instantly.',
-    readTime: '2 min',
-    steps: [
-      { text: 'On a home listing, click "Send Inquiry" / "Contact".', image: 'inquiry-button.png', imageAlt: 'Contact home button' },
-      { text: 'Fill in your name, email, the resident’s name, move-in timeframe, and the care services you need.' },
-      { text: 'Optionally pick a tour date and time, then submit.' },
-      { text: 'You will see a confirmation, and the home’s operator receives your inquiry as a new lead.' },
-    ],
-    tips: [
-      'Add a short note about your situation — it helps the operator respond with relevant information.',
-    ],
+    tips: ["Replies to your inquiries and tour requests land here, so check Messages after reaching out to a home.","Keep care decisions and quotes in Messages so there's a written record; store sensitive documents in the Family Portal's Documents tab instead.","The \"Select a conversation\" panel on the right is just a prompt — click any thread on the left to begin."],
     faq: [
-      { q: 'Do I need an account to send an inquiry?', a: 'You can browse without one, but signing in lets you track your inquiries and responses in one place.' },
+      { q: "Where do home/caregiver replies appear?", a: "Right here in Messages, with a notification." },
+      { q: "Can I start a conversation cold?", a: "Yes, via New message — or it starts automatically when you send an inquiry." },
     ],
+    images: ["01_inbox.png","02_conversation.png"],
   },
   {
-    slug: 'managing-inquiries-as-an-operator',
-    title: 'Managing Inquiries in Your Pipeline',
-    audiences: ['operator'],
-    icon: '📥',
-    whoFor: 'Operators handling incoming family inquiries and leads.',
-    summary:
-      'Every inquiry lands in your pipeline as NEW. Review it, respond, and move it through your stages to a tour or move-in.',
-    readTime: '3 min',
+    slug: "settings-profile-and-notifications",
+    title: "Settings — Profile, Account & Notifications",
+    audiences: ["getting-started"],
+    icon: "⚙️",
+    whoFor: "Any user managing their profile, account security, notification preferences, or app setup.",
+    summary: "**Settings** is the hub for your personal info, password and security, notification preferences, billing/payouts, and app/device setup. Open the card you need, make your changes, and save.",
+    readTime: "2 min",
     steps: [
-      { text: 'Open the Inquiries / pipeline view from your operator dashboard.', image: 'operator-pipeline.png', imageAlt: 'Operator inquiry pipeline' },
-      { text: 'Open a NEW inquiry to see the family’s contact info, the resident’s needs, and any requested tour time.' },
-      { text: 'Respond to the family and add internal notes (notes are private to your team).' },
-      { text: 'Update the inquiry status as it progresses (e.g., contacted, tour scheduled, converted).' },
+      { text: "Sign in and open Settings (left menu → Settings → Settings). The hub shows cards for each area." },
+      { text: "Choose the card you need:" },
+      { text: "Update your profile: open Profile, edit your name, contact info, and photo, then Save." },
+      { text: "Manage notifications: open Notifications, toggle which email and in-app alerts you want (e.g., inquiry replies, tour confirmations), then Save." },
+      { text: "Change your password: open Account, enter your current and new password, and save." },
     ],
-    tips: [
-      'Respond quickly — speed of first response is the strongest predictor of converting an inquiry.',
-      'Use internal notes to keep your team aligned without exposing anything to the family.',
-    ],
-  },
-  {
-    slug: 'keeping-your-listing-current',
-    title: 'Keeping Your Listing Accurate and Attractive',
-    audiences: ['operator'],
-    icon: '🏠',
-    whoFor: 'Operators who want their homes to show up well in family searches.',
-    summary:
-      'Complete pricing, care levels, amenities, and photos so your listing ranks well and sets accurate expectations.',
-    readTime: '3 min',
-    steps: [
-      { text: 'Open your home’s profile from the operator dashboard.', image: 'operator-listing-edit.png', imageAlt: 'Edit listing' },
-      { text: 'Set the care levels you support, capacity, and current pricing range.' },
-      { text: 'Add or update amenities and upload high-quality photos.' },
-      { text: 'Publish — make sure the status is ACTIVE so families can find you in search.' },
-    ],
-    tips: [
-      'Listings with accurate pricing and several photos receive substantially more qualified inquiries.',
-    ],
-  },
-  {
-    slug: 'setting-up-your-caregiver-profile',
-    title: 'Setting Up Your Caregiver Profile',
-    audiences: ['caregiver'],
-    icon: '👩‍⚕️',
-    whoFor: 'Caregivers offering services through the CareLinkAI marketplace.',
-    summary:
-      'Build a profile that wins shifts: add your experience, certifications, availability, and the care types you specialize in.',
-    readTime: '3 min',
-    steps: [
-      { text: 'Open your caregiver profile from your dashboard.', image: 'caregiver-profile.png', imageAlt: 'Caregiver profile' },
-      { text: 'Add your experience, specialties, and upload your certifications (e.g., CNA, CPR/first aid).' },
-      { text: 'Set your availability and the areas you are willing to work in.' },
-      { text: 'Save and publish your profile so operators and families can find and hire you.' },
-    ],
-    tips: [
-      'Keep your certifications current — expired credentials can hide you from search.',
-    ],
-  },
-  {
-    slug: 'finding-and-accepting-shifts',
-    title: 'Finding and Accepting Shifts',
-    audiences: ['caregiver'],
-    icon: '🗓️',
-    whoFor: 'Caregivers looking for open shifts.',
-    summary:
-      'Browse open shifts that match your availability and specialties, accept the ones you want, and track your assignments.',
-    readTime: '2 min',
-    steps: [
-      { text: 'Open the shifts marketplace from your dashboard.', image: 'shift-list.png', imageAlt: 'Open shifts' },
-      { text: 'Filter by location, date, and care type.' },
-      { text: 'Open a shift to review the details and pay, then accept it.' },
-      { text: 'Track your accepted shifts and submit your timesheet after each one.' },
-    ],
-  },
-  {
-    slug: 'getting-started-as-a-provider',
-    title: 'Getting Started as a Service Provider',
-    audiences: ['provider'],
-    icon: '🤝',
-    whoFor: 'Service providers (transport, therapy, and other senior-care services) partnering with CareLinkAI.',
-    summary:
-      'Set up your provider profile and services so operators and families can find and request you.',
-    readTime: '3 min',
-    steps: [
-      { text: 'Complete your provider profile with your company details and service area.', image: 'provider-profile.png', imageAlt: 'Provider profile' },
-      { text: 'List the services you offer and how you price them.' },
-      { text: 'Set your availability and contact preferences.' },
-      { text: 'Publish your profile to start receiving requests.' },
-    ],
-  },
-  {
-    slug: 'ai-placement-search-for-discharge-planners',
-    title: 'Running an AI Placement Search',
-    audiences: ['discharge-planner'],
-    icon: '🏥',
-    whoFor: 'Hospital and rehab discharge planners placing patients quickly.',
-    summary:
-      'Describe the patient’s needs in plain language and let CareLinkAI parse the request and rank matching homes with available beds.',
-    readTime: '3 min',
-    steps: [
-      { text: 'Open the discharge planner search and click "Start New Search".', image: 'dp-search.png', imageAlt: 'Discharge planner search' },
-      { text: 'Describe the patient in plain language — e.g., "memory care in Boston for a 78-year-old with moderate Alzheimer’s, budget ~$6,000/month."' },
-      { text: 'Click "Search with AI". CareLinkAI extracts the care level, location, and other criteria automatically.' },
-      { text: 'Review the ranked matches with reasoning, available beds, and contact details, then reach out or create a placement request.' },
-    ],
-    tips: [
-      'Include the city and state, care level, budget, and any urgent timeline to get the most relevant matches.',
-    ],
+    tips: ["Families: filling in the Family Profile (care context) sharpens AI Match results — it's worth a few minutes.","Turn on notifications for inquiry replies and tour confirmations so you never miss a response from a home.","The role badge under your name (e.g., FAMILY) in the top-right confirms which account type you're in."],
     faq: [
-      { q: 'What care levels can I search?', a: 'Independent living, assisted living, memory care, and skilled nursing.' },
+      { q: "What's in Notifications?", a: "Email and in-app toggles for the events that matter to you." },
+      { q: "Is CareLinkAI Plus required?", a: "No — it's an optional upgrade for priority matching and unlimited saved homes." },
+    ],
+    images: ["01_settings_hub.png"],
+  },
+  {
+    slug: "search-homes",
+    title: "Search for a Care Home",
+    audiences: ["family"],
+    icon: "🔎",
+    whoFor: "Families looking for assisted living, memory care, independent living, or skilled nursing for a loved one.",
+    summary: "Sign in, open Search Homes, filter by care level / budget / location, compare options, and open any listing to see details, photos, pricing, and contact options.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in at getcarelinkai.com with your family account." },
+      { text: "From My Dashboard, click Search Homes in the Quick Links (or \"Listings → Search Homes\" in the left menu)." },
+      { text: "The search page lists available homes. Use the Filters panel on the left: care level (Independent / Assisted / Memory Care / Skilled Nursing), monthly budget, location + radius, and gender preference. You can also type natural language into the search bar — e.g., \"Memory care near Cleveland\" or \"Assisted living under $5000.\"" },
+      { text: "Toggle Grid / List / Map views (top right). Click Personalize to tune results to your needs." },
+      { text: "Each card shows a Match %, availability, care types, and starting price. Click the heart to save a home to your shortlist, Compare to evaluate side-by-side, or View Listing for full details." },
+      { text: "On a listing page you'll see capacity, availability, monthly cost, staffing, photo gallery, amenities, pricing, location map, and contact info. From here you can Schedule a Tour or Send Inquiry — no obligation or fees." },
+    ],
+    tips: ["Saved homes live under My Saved; inquiries you send are tracked under My Inquiries.","\"Contact us\" pricing means the facility quotes per care needs — sending an inquiry is the fastest way to get a number.","The Ask a Care Advisor bubble (bottom right) is available on every page."],
+    images: ["01_login.png","02_dashboard.png","03_search_results.png","04_listing_detail.png"],
+  },
+  {
+    slug: "save-and-compare",
+    title: "Save Favorites & Compare Homes",
+    audiences: ["family"],
+    icon: "💛",
+    whoFor: "Families narrowing a long list of care homes down to a short list of real contenders.",
+    summary: "Tap the heart on any home to save it, switch on Compare to evaluate two or more side-by-side, then review everything you've shortlisted under My Favorites — organized by Homes, Caregivers, Providers, and Jobs.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Search Homes (Listings → Search Homes)." },
+      { text: "On any result card, click the heart icon to save the home to your shortlist. The heart fills in and the saved counter in the top bar updates." },
+      { text: "To compare options, click Compare on two or more cards. A banner appears at the top: \"X homes selected for comparison — select at least 2.\" Click Compare in that banner to open the side-by-side view." },
+      { text: "Open My Favorites (the heart icon in the top bar, or Listings → My Saved). Everything you've saved lives here, grouped into tabs: All, Homes, Caregivers, Providers, Jobs." },
+      { text: "Each saved card shows the home name, location, monthly price range, and a short description. Click a card to reopen the full listing, or tap the filled heart again to remove it from your list." },
+    ],
+    tips: ["The saved counter (heart badge) in the top navigation bar follows you on every page, so you always know how many homes are on your shortlist.","Compare is the fastest way to weigh price, care level, and availability across your top contenders without flipping between tabs.","Favorites are organized by type — if you also save caregivers or providers later, they file themselves under the right tab automatically."],
+    faq: [
+      { q: "Do saved homes expire?", a: "No — they stay on your list until you remove them." },
+      { q: "Is there a limit?", a: "Free accounts can save homes; CareLinkAI Plus adds unlimited saved homes plus priority matching." },
+    ],
+    images: ["01_search_results.png","02_heart_saved.png","03_compare_banner.png","04_favorites.png"],
+  },
+  {
+    slug: "send-inquiry",
+    title: "Send an Inquiry to a Care Home",
+    audiences: ["family"],
+    icon: "📨",
+    whoFor: "Families ready to reach out to a specific community to ask about availability, pricing, or care services.",
+    summary: "Open any listing, click **Send Inquiry**, fill in your contact details, who the care is for, your move-in timeframe, and the care services you need, then submit. The home receives it instantly and it shows up in your inquiry tracker.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open a listing page for the home you're interested in." },
+      { text: "In the \"Interested in [Home]?\" panel, click Send Inquiry. A contact form titled \"Contact [Home]\" slides in." },
+      { text: "Fill in the form:" },
+      { text: "Click Send / Submit Request. You'll get a confirmation, and the home's team is notified right away." },
+      { text: "Track the status anytime under Leads & Inquiries → My Inquiries. Each inquiry shows the home, your contact info, the inquiry date, current status (e.g., New), and the next action the home should take." },
+    ],
+    tips: ["\"Contact us\" pricing means the home quotes based on care needs — an inquiry is the fastest way to get a real number.","There's no obligation or fee to inquire. You can reach out to several homes and compare responses.","After a home replies, the conversation continues in Messages."],
+    faq: [
+      { q: "Required fields:", a: "name, email, and the care recipient's name must be filled in or the form won't submit." },
+      { q: "Where do replies go?", a: "Into your in-app Messages, and you'll see a notification." },
+    ],
+    images: ["01_listing_detail.png","02_inquiry_form.png","03_inquiry_filled.png","04_my_inquiries.png"],
+  },
+  {
+    slug: "schedule-tour",
+    title: "Schedule a Tour",
+    audiences: ["family"],
+    icon: "📅",
+    whoFor: "Families who want to visit a community in person (or virtually) before making a decision.",
+    summary: "On any listing, click **Schedule a Tour**, pick a preferred date and time, submit the request, and track it under My Tours. The home confirms and you'll see the status update from Pending to confirmed.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open the listing page for the home you want to visit." },
+      { text: "In the \"Interested in [Home]?\" panel, click Schedule a Tour." },
+      { text: "Provide your contact details if prompted, then the Schedule Your Tour step appears with:" },
+      { text: "Click Submit Request. (Use Back if you need to fix your details first.)" },
+      { text: "View and manage everything under Leads & Inquiries → My Tours. Tabs show All Tours / Upcoming / Past, and each tour card lists the home, address, requested time slot(s), and a status badge (Pending until the home confirms). From here you can View Details or Cancel Tour." },
+    ],
+    tips: ["You can request more than one time slot to give the home options.","Tour tips on the page remind you to arrive 10–15 minutes early and bring a list of questions.","Pending means the request is in — the home will confirm the slot that works for them."],
+    faq: [
+      { q: "Can I cancel?", a: "Yes — each tour card has a Cancel Tour link." },
+      { q: "In-person or virtual?", a: "Request the slot here; confirm the format with the home in Messages." },
+    ],
+    images: ["01_listing_panel.png","02_tour_datetime.png","03_my_tours.png"],
+  },
+  {
+    slug: "ai-match",
+    title: "Use AI Match to Find Your Best Homes",
+    audiences: ["family"],
+    icon: "✨",
+    whoFor: "Families who'd rather answer a few questions and get a ranked, personalized shortlist than browse listings one by one.",
+    summary: "Open AI Match, answer a short 4-step questionnaire (budget & care level, medical conditions, lifestyle preferences, location & timeline), and CareLinkAI returns your **Top 4 Matches** — each with a match score, a category-by-category breakdown, and a plain-English explanation of *why* it fits.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open AI Tools → AI Match (also reachable from the dashboard as \"Find Care\"). The wizard is titled Find Your Perfect Care Home." },
+      { text: "Step 1 — Budget & Care Level: enter a minimum and maximum monthly budget, then select the required care level (Independent Living, Assisted Living, Memory Care, or Skilled Nursing). Click Next." },
+      { text: "Step 2 — Medical Conditions: select any relevant conditions so matches account for them. Click Next." },
+      { text: "Step 3 — Preferences (Lifestyle): choose lifestyle preferences and amenities that matter to you. Click Next." },
+      { text: "Step 4 — Location & Timeline: enter a ZIP code, a maximum search distance, and a move-in timeline (Immediate, 1–3 Months, 3–6 Months, Just Exploring). Click Find My Perfect Match." },
+      { text: "Review your Top 4 Matches. Each result shows a match %, a \"Why This Match\" write-up, and per-category scores for Budget, Condition, Care Level, Location, and Amenities, plus the amenity list, price range, and availability. From each match you can View Full Profile or Schedule Tour." },
+    ],
+    tips: ["The \"Why This Match\" explanation is written in plain language — it tells you what's strong about the fit and flags the one trade-off to consider (for example, distance).","Per-category scores let you see *where* a home wins: a 100 on Care Level with a 90 on Budget tells you it's a strong clinical fit that's also affordable.","You can rerun the questionnaire anytime as your needs or budget change."],
+    faq: [
+      { q: "How many results?", a: "Up to four ranked matches per run." },
+      { q: "Is my info shared?", a: "The page notes your information is used only to find care options. Use only demo data in demo accounts." },
+    ],
+    images: ["01_aimatch_start.png","02_step1_budget.png","03_step4_location.png","04_results.png"],
+  },
+  {
+    slug: "family-portal",
+    title: "Use the Family Portal",
+    audiences: ["family"],
+    icon: "👨‍👩‍👧",
+    whoFor: "Families coordinating a loved one's care who want documents, updates, photos, and conversations in one shared place.",
+    summary: "The Family Portal (**Residents & Family → Family**) is your loved one's care hub. Upload and store documents, follow a running activity timeline, share photos, keep notes, message the care team, manage who has access, view billing, and store emergency info.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Residents & Family → Family. The header reads \"Family Portal — Stay connected with your loved one's care journey.\"" },
+      { text: "Use the tabs across the top to move between sections:" },
+      { text: "To add a document, click Upload Document, choose the file, and it appears in Documents and on the Activity timeline." },
+      { text: "To give a relative access, open Members → Invite Member and assign a role; each role carries its own permissions (shown under Role Permissions)." },
+    ],
+    tips: ["The Activity timeline doubles as an audit trail — you can see who uploaded what and when.","Sensitive files (medical records, insurance) belong in Documents, where they're stored securely — not in chat.","Use Members roles to give siblings or a power-of-attorney the right level of access without handing over your login."],
+    faq: [
+      { q: "Who can see this?", a: "Only the members you invite, according to their assigned role." },
+      { q: "What documents should I add?", a: "Care plans, medical records, insurance cards, and anything the care team may need." },
+    ],
+    images: ["01_portal_home.png","02_documents.png","03_activity.png","04_members.png"],
+  },
+  {
+    slug: "claim-your-listing",
+    title: "Claim Your Listing",
+    audiences: ["operator"],
+    icon: "🏷️",
+    whoFor: "Owners and administrators of an assisted living community, memory care unit, or care home whose facility already appears on CareLinkAI and who want to take ownership of the listing.",
+    summary: "Find your facility on CareLinkAI, claim it to prove you're the operator, and once verified the listing becomes yours to manage — moving from a CareLinkAI-seeded draft to an operator-owned, editable listing.",
+    readTime: "2 min",
+    steps: [
+      { text: "Find your facility. Search CareLinkAI for your community by name and location. Many Cleveland/Ohio facilities are already pre-listed as unclaimed." },
+      { text: "Start the claim. On the listing (or via the link in your outreach email), choose Claim this listing. You'll confirm you represent the facility." },
+      { text: "Verify ownership. Provide the requested verification details so the CareLinkAI team can confirm you're the legitimate operator. The listing moves to Pending Review." },
+      { text: "Get approved. Once CareLinkAI approves the claim, the listing is transferred to your operator account and its status becomes editable by you." },
+      { text: "Take over management. The home now appears under Listings → Your Homes, where you can edit details, add photos, set availability, and start receiving inquiries and tours." },
+    ],
+    tips: ["If you received a claim link in a CareLinkAI outreach email, that's the fastest path — it ties the claim straight to your facility.","Claiming is free; it's how you convert a pre-populated directory entry into a listing you control.","After approval, complete your profile and add photos right away — listings with real photos and accurate availability convert far more family inquiries."],
+    faq: [
+      { q: "My facility isn't listed.", a: "Use Add Home from Your Homes to create it." },
+      { q: "Someone else claimed it.", a: "Contact CareLinkAI support to resolve ownership." },
+    ],
+  },
+  {
+    slug: "operator-dashboard",
+    title: "Your Operator Dashboard",
+    audiences: ["operator"],
+    icon: "📊",
+    whoFor: "Operators who want a single at-a-glance command center for their community's occupancy, inquiries, and daily tasks.",
+    summary: "The operator dashboard shows your headline metrics (Homes, Open Inquiries, Active Residents, Occupancy Rate), an **Ask AI About Your Dashboard** assistant you can query in plain English, Quick Actions, and a Recent Activity feed.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in with your operator account. You land on the Operator dashboard." },
+      { text: "Read your headline metrics across the top: Homes, Open Inquiries, Active Residents, and Occupancy Rate." },
+      { text: "Use Ask AI About Your Dashboard — type a question like \"How many residents do I have?\", \"Show me caregivers with reliability below 60\", \"What shifts are unassigned this week?\", or \"How is my occupancy rate?\" and get an instant answer drawn from your own data." },
+      { text: "Use Quick Actions to jump straight into common tasks: Add Resident (onboard a new resident) or View Inquiries (manage leads)." },
+      { text: "Scroll Recent Activity to see the latest events — new inquiries, status changes (e.g., Converted, Closed Lost, Tour Completed) — and click View all for the full history." },
+    ],
+    tips: ["The Ask-AI box is the fastest way to answer operational questions without digging through menus — it understands residents, caregivers, shifts, and occupancy.","Occupancy Rate is your north-star number; if it dips, check the Inquiry pipeline and Tour requests next.","Recent Activity is a quick daily standup — skim it each morning to see what needs attention."],
+    faq: [
+      { q: "Where does the AI get its answers?", a: "From your own facility's data in CareLinkAI (residents, shifts, inquiries)." },
+      { q: "Can I customize the metrics?", a: "The four headline tiles are standard; deeper cuts live in Analytics and Reports." },
+    ],
+    images: ["01_dashboard.png","02_ask_ai.png"],
+  },
+  {
+    slug: "manage-home-and-photos",
+    title: "Manage Your Home & Photos",
+    audiences: ["operator"],
+    icon: "🏠",
+    whoFor: "Operators keeping a listing accurate and attractive — updating availability, amenities, description, and photos.",
+    summary: "Open **Listings → Your Homes**, click **Manage** on a home, and edit its status, current occupancy, and amenities, review the AI-Enhanced Profile and Key Highlights, and upload photos (mark one as Primary). Save to publish your changes.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Listings → Your Homes. Each home shows its name, location, open-inquiry count, and status, with a Manage link. Use Add Home to create a new listing." },
+      { text: "Click Manage to open the home editor." },
+      { text: "In Quick Actions (right side), update:" },
+      { text: "Review the AI-Enhanced Profile — a polished, AI-written description of your community — and the Key Highlights bullets that families see." },
+      { text: "Add photos: under the gallery, click Choose File, select an image, optionally check Primary to make it the cover photo, then click Upload." },
+      { text: "Check Alerts & Notifications lower on the page for anything needing attention." },
+    ],
+    tips: ["Keep Current Occupancy accurate — it drives the \"spots available\" families see and the occupancy rate on your dashboard.","The first/Primary photo is your cover image; choose your most inviting, well-lit shot.","The AI-Enhanced Profile gives you a strong starting description; tweak amenities and highlights so they match your community exactly."],
+    faq: [
+      { q: "No photos yet?", a: "New/seeded listings start empty — adding real photos significantly lifts inquiry rates." },
+      { q: "How do I take a listing offline?", a: "Change Status away from ACTIVE and Save." },
+    ],
+    images: ["01_your_homes.png","02_manage_home.png","03_photo_upload.png"],
+  },
+  {
+    slug: "leads-and-inquiries-pipeline",
+    title: "Manage Leads & the Inquiries Pipeline",
+    audiences: ["operator"],
+    icon: "📥",
+    whoFor: "Operators tracking family inquiries from first contact through tour to placement.",
+    summary: "The **Pipeline Dashboard** is a Kanban board that moves each inquiry through stages — New → Contacted → Tour Scheduled → Tour Completed → Qualified — with KPIs across the top (Total Inquiries, New This Week, Requires Attention, Conversion Rate, Pending Follow-ups). Switch to List view, filter, or open any card for details.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Leads & Inquiries → Pipeline (/operator/inquiries/pipeline)." },
+      { text: "Read the KPI tiles: Total Inquiries, New This Week, Requires Attention, Conversion Rate, Pending Follow-ups." },
+      { text: "Work the Kanban columns left to right — New, Contacted, Tour Scheduled, Tour Completed, Qualified. Each card shows the contact, care recipient, home, source (e.g., Website), priority (e.g., Medium), date, and any scheduled tour." },
+      { text: "Move an inquiry forward by dragging its card to the next stage as you make progress." },
+      { text: "Toggle Kanban / List (top right) for a sortable table view, use Filters to narrow the board, or click New Inquiry to log one manually." },
+      { text: "Click any card to open the full inquiry — contact details, notes, and the next recommended action." },
+    ],
+    tips: ["Requires Attention and Pending Follow-ups are your daily to-do list — clear those first.","Conversion Rate tells you how well inquiries turn into placements; watch the trend over time.","Keep cards moving — an inquiry sitting in \"Contacted\" too long is a follow-up waiting to happen."],
+    faq: [
+      { q: "Where do website inquiries land?", a: "Automatically in New, tagged with their source." },
+      { q: "Difference between Leads and Inquiries?", a: "Both feed this pipeline; the board is the single place to manage them." },
+    ],
+    images: ["01_pipeline.png","02_kanban_cards.png"],
+  },
+  {
+    slug: "tour-management",
+    title: "Manage Tour Requests",
+    audiences: ["operator"],
+    icon: "🗓️",
+    whoFor: "Operators responding to family tour requests and keeping their visit schedule organized.",
+    summary: "**Tour Management** lists every tour request with its status (Pending / Confirmed / Completed) and counters at the top. Open a request to respond and confirm a time, or decline — and search/filter to find any visit fast.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Leads & Inquiries → Tours (/operator/tours)." },
+      { text: "Read the counters: Pending Requests, Confirmed Tours, Completed." },
+      { text: "Each request card shows the home, the family's name and email, the address, how many time slots they requested, and any note they left." },
+      { text: "Click View & Respond to open the request, pick a time that works, and confirm it — the family is notified and the tour moves to Confirmed." },
+      { text: "If you can't host it, click Decline." },
+      { text: "Use the search bar (by family name or home) and the status filter (All Statuses) to find specific tours." },
+    ],
+    tips: ["Respond to Pending requests quickly — fast confirmations are a major trust signal for families choosing a community.","When a family offers multiple time slots, pick the one that fits your staffing and confirm it in one step.","Completed tours flow into your pipeline as Tour Completed, keeping your conversion tracking accurate."],
+    faq: [
+      { q: "Can I propose a different time?", a: "Use View & Respond to coordinate the slot, then confirm." },
+      { q: "Where do confirmations go?", a: "To the family via notification and Messages." },
+    ],
+    images: ["01_tour_management.png","02_tour_request.png"],
+  },
+  {
+    slug: "residents",
+    title: "Manage Residents",
+    audiences: ["operator"],
+    icon: "🧑‍🦳",
+    whoFor: "Operators maintaining resident profiles and care information for their community.",
+    summary: "The **Residents** page is your roster — search and filter residents, view or edit each profile, onboard a new resident, switch to an Analytics view, and export the list.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Residents & Family → Residents (/operator/residents)." },
+      { text: "Search by name, room, or ID, and filter by Status or Home. Check Show Archived to include past residents." },
+      { text: "The roster table shows each resident's name + home, Age, Room, Status (e.g., Inquiry, Active), and Admission date, with View and Edit actions." },
+      { text: "Click New Resident to onboard someone — fill in their profile and care information. *(also reachable from the dashboard Quick Action \"Add Resident\")*" },
+      { text: "Switch to the Analytics view for resident-level insights, or click Export to download the roster." },
+    ],
+    tips: ["Status flows from Inquiry to Active as a prospect becomes a resident — keep it current so occupancy and reporting stay accurate.","Use Show Archived when you need history without cluttering the active roster.","Export is handy for audits, state surveys, or sharing with your team offline."],
+    faq: [
+      { q: "Where do new residents come from?", a: "Either onboard manually via New Resident, or convert a qualified inquiry." },
+      { q: "Can I store care details?", a: "Yes — each resident profile holds care information; keep sensitive records handled per your compliance policies." },
+    ],
+    images: ["01_residents.png","02_resident_row.png"],
+  },
+  {
+    slug: "shifts-and-oncall-ai",
+    title: "Shifts & On-Call AI Coverage",
+    audiences: ["operator"],
+    icon: "📞",
+    whoFor: "Operators scheduling caregivers and filling open or last-minute shifts.",
+    summary: "Use **Shifts** to create and assign caregiver shifts (with an **AI Shift Auto-fill** option), and **On-Call AI** to automatically text and call your caregivers to fill an open shift — the first to reply YES gets it, and everyone else is told it's filled.",
+    readTime: "2 min",
+    steps: [
+      { section: "Shifts", text: "Sign in and open Operations → Shifts (/operator/shifts)." },
+      { text: "Click Create Shift to schedule a caregiver — set the home, time, and assignment. New accounts start with \"No shifts scheduled yet.\"" },
+      { text: "Use AI Shift Auto-fill to let CareLinkAI propose assignments for open shifts." },
+      { text: "Switch to the Calendar view (top right) to see shifts laid out by day/week." },
+      { section: "On-Call AI (open-shift coverage)", text: "Open Operations → On-Call AI (/operator/oncall). The banner explains: CareLinkAI automatically texts and calls your caregivers to fill open shifts; the first to reply YES gets the shift and the rest are notified it's filled." },
+      { text: "The On-Call AI Queue lists active coverage needs — each shows the home, status (e.g., FILLING, which Wave it's on), the role (e.g., memory care), how many contacts were sent, and when it was created." },
+      { text: "Controls per item: Send Next Wave (reach more caregivers), View Attempts, and Cancel. Start a new one with + New Coverage Need." },
+    ],
+    tips: ["On-Call AI works in waves — it contacts a first group, and if no one accepts, Send Next Wave expands the outreach.","View Attempts is your audit trail of who was reached and how they responded.","Reliability scoring helps prioritize which caregivers get contacted first."],
+    faq: [
+      { q: "What if nobody replies?", a: "Use Send Next Wave to widen the pool, or fall back to manual assignment in Shifts." },
+      { q: "How does a caregiver claim a shift?", a: "By replying YES to the text/call — first response wins." },
+    ],
+    images: ["01_shifts.png","02_oncall.png"],
+  },
+  {
+    slug: "compliance-kits",
+    title: "Compliance Document Kits",
+    audiences: ["operator"],
+    icon: "📋",
+    whoFor: "Ohio assisted living operators who need ready-made, regulation-aware compliance templates.",
+    summary: "**Compliance Document Kits** are one-time-purchase bundles of Ohio ALF compliance templates — startup policies, state-survey prep, and memory-care-unit documentation — reviewed against ODH regulations and yours to keep forever.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Operations → Compliance Kits (/operator/compliance-kits)." },
+      { text: "Review the available kits, each with its contents listed and a one-time price:" },
+      { text: "Click Buy Now on the kit you need to purchase it (one-time). Purchased kits are yours to keep." },
+    ],
+    tips: ["The Startup Kit is built for opening a new licensed ALF; the Survey Prep Kit is for staying audit-ready year-round.","Templates are a strong starting point — the page notes they're provided as-is for reference; consult a licensed attorney or Ohio ALF consultant before submitting to ODH.","One-time purchase means no recurring cost — buy once, reuse across surveys."],
+    faq: [
+      { q: "Are these legal advice?", a: "No — they're reference templates reviewed against ODH regulations; have a professional review before official use." },
+      { q: "Do they expire?", a: "No — once purchased, they're yours forever." },
+    ],
+    images: ["01_compliance_kits.png"],
+  },
+  {
+    slug: "analytics-and-billing",
+    title: "Analytics & Billing",
+    audiences: ["operator"],
+    icon: "💳",
+    whoFor: "Operators tracking performance metrics and managing their CareLinkAI subscription and invoices.",
+    summary: "**Analytics** shows your occupancy and inquiry funnel with a CSV export; **Billing** shows your current plan, invoice history, MRR/volume, and recent payments, with controls to change plan or manage billing.",
+    readTime: "2 min",
+    steps: [
+      { section: "Analytics", text: "Sign in and open Analytics (/operator/analytics)." },
+      { text: "Read the Occupancy donut (occupied % against capacity and number of homes)." },
+      { text: "Review the Inquiry Funnel chart — inquiries by stage (New → Contacted → Tour Scheduled → Tour Completed → Placement Offered → Placement Accepted → Closed Lost) over a selectable range (e.g., 30 days)." },
+      { text: "Click Export Inquiries CSV to download the underlying data." },
+      { text: "For deeper cuts, open Reports in the left menu." },
+      { section: "Billing", text: "Open Billing (/operator/billing)." },
+      { text: "Your Subscription shows your current plan (e.g., Professional — $249/mo, up to 3 homes), status, and next billing date." },
+      { text: "Invoice History lists each period, amount, status (e.g., Paid), and a View / PDF action for each invoice." },
+      { text: "Review the 30-day Volume, MRR, and Recent Payments panels." },
+      { text: "Use Change Plan to switch tiers or Manage Billing to update payment details (opens the secure billing portal)." },
+    ],
+    tips: ["The Inquiry Funnel shows exactly where prospects drop off — a narrowing between Tour Scheduled and Completed means tighten your tour follow-up.","Download the CSV for board updates, investor reports, or your own spreadsheets.","Keep an eye on the next billing date so renewals are never a surprise."],
+    faq: [
+      { q: "Where do invoices download?", a: "Each row in Invoice History has a PDF link." },
+      { q: "Can I see revenue?", a: "MRR and 30-day Volume panels summarize it; Reports has more detail." },
+    ],
+    images: ["01_analytics.png","02_billing.png"],
+  },
+  {
+    slug: "caregiver-dashboard",
+    title: "Your Caregiver Dashboard",
+    audiences: ["caregiver"],
+    icon: "📊",
+    whoFor: "Caregivers and aides who want one place to see their marketplace status, rating, requests, and next actions.",
+    summary: "The caregiver dashboard shows your **Profile Visibility**, **Background Check** status, **Active Requests**, and **My Rating**, plus Quick Actions (Applications, Edit Profile, Upload Documents, Messages), your reviews, and recent inquiries.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in with your caregiver account — you land on the Caregiver dashboard (\"Welcome back, [name]\")." },
+      { text: "Check your status tiles:" },
+      { text: "Use Quick Actions: My Applications (track job applications), Edit Profile (bio, skills, availability), Upload Documents (certifications/credentials), Messages (conversations)." },
+      { text: "Scroll My Reviews to read recent family feedback, and View public profile to see what families see." },
+      { text: "Review Recent Inquiries for new family interest." },
+    ],
+    tips: ["A cleared Background Check badge is one of the strongest trust signals families look for — keep it current.","Respond to Active Requests quickly; fast replies win placements.","Your rating and reviews are your reputation — every completed shift and kind review compounds."],
+    faq: [
+      { q: "What makes my profile visible?", a: "The marketplace-visibility toggle in your profile settings." },
+      { q: "Where do inquiries come from?", a: "Families browsing the caregiver marketplace and job applicants you've matched with." },
+    ],
+    images: ["01_dashboard.png","02_status_tiles.png"],
+  },
+  {
+    slug: "profile-and-credentials",
+    title: "Build Your Profile & Add Credentials",
+    audiences: ["caregiver"],
+    icon: "🪪",
+    whoFor: "Caregivers setting up the profile families see — bio, skills, rate, availability in the marketplace, and professional credentials.",
+    summary: "In **Profile Settings** add your photo, bio, specialties, settings, and care types, set your experience and hourly rate, toggle marketplace visibility, and upload licenses/certifications under **Credentials**.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Settings → Profile (/settings/profile)." },
+      { text: "Basic Information: upload a photo and confirm your name and phone. (Email is fixed — contact support to change it.)" },
+      { text: "Professional Bio: write a short, warm summary of your experience and approach." },
+      { text: "Skills & Tags — these power marketplace search, so be thorough:" },
+      { text: "Marketplace Visibility: toggle \"Show my profile in marketplace search\" on to appear to families (pause anytime without deleting your account)." },
+      { text: "Set Years of Experience and Hourly Rate ($)." },
+      { text: "Credentials: add licenses/certifications either in the embedded section or the full page (Settings → Credentials, /settings/credentials). For each: Credential Type (e.g., CPR, CNA License), Issue Date, Expiration Date, and a document upload. Click Add Credential." },
+    ],
+    tips: ["The more accurate your specialties and care types, the better you match the families and jobs that fit you.","Keep credentials current — expired certifications weaken the trust your profile signals.","Your hourly rate and experience show on your public profile, so set them deliberately."],
+    faq: [
+      { q: "Will I show up in search immediately?", a: "Yes, once marketplace visibility is on and your profile is filled out." },
+      { q: "Where do uploaded credentials appear?", a: "Under Your Credentials, and they support your verified status." },
+    ],
+    images: ["01_profile.png","02_skills.png","03_rate.png","04_credentials.png"],
+  },
+  {
+    slug: "marketplace-jobs-and-applications",
+    title: "Find Jobs & Track Applications",
+    audiences: ["caregiver"],
+    icon: "🧰",
+    whoFor: "Caregivers looking for work — browsing open jobs, applying, and tracking where each application stands.",
+    summary: "Open the **Marketplace → Jobs** tab to browse recommended jobs with an AI match score, filter by setting/care type/location, and apply. Track every application under **My Applications**.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Marketplace (/marketplace), then the Jobs tab." },
+      { text: "Browse Recommended Jobs — each card shows the role, location, pay range (e.g., $26–$40/hr), a short description, and an AI match % with an Explain button that tells you *why* it fits you." },
+      { text: "Narrow results with the filters: Search, City/State, ZIP + Radius, Setting (In-home, Assisted Living, Memory Care, Skilled Nursing, Hospice…), Care Types, and Sort (Most recent, etc.)." },
+      { text: "Click View on a job to see full details and apply." },
+      { text: "Track everything under My Applications (/caregiver/applications) — applied positions and their status. New caregivers see \"No applications yet\" with a Browse Jobs button." },
+    ],
+    tips: ["The match % and Explain save you time — focus on the jobs the system already thinks fit your skills.","A complete profile (specialties, care types, rate) directly improves your match scores.","Use ZIP + Radius to keep your commute realistic."],
+    faq: [
+      { q: "How many jobs are there?", a: "The Jobs tab shows the live count (e.g., \"Jobs (26)\")." },
+      { q: "Who posts these?", a: "Families and operators using Post a Job; you apply directly." },
+    ],
+    images: ["01_jobs.png","02_job_card.png","03_applications.png"],
+  },
+  {
+    slug: "shifts-and-timesheets",
+    title: "Pick Up Shifts & Track Your Hours",
+    audiences: ["caregiver"],
+    icon: "⏱️",
+    whoFor: "Caregivers who want to claim open per-diem shifts and keep track of the shifts they've worked.",
+    summary: "The **Shifts** page has two tabs — **Open Shifts** (available shifts you can claim) and **My Shifts** (shifts you've claimed and your hours). Browse open shifts, claim the ones that fit, and they move to My Shifts.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Operations → Shifts (/shifts)." },
+      { text: "Open Shifts lists available shifts with a count (\"X shifts available\"). When there are none, it shows \"No open shifts available at this time.\"" },
+      { text: "Claim a shift that fits your availability — it then appears under My Shifts." },
+      { text: "Switch to the My Shifts tab to see everything you've claimed and track your hours. New caregivers see \"You haven't claimed any shifts yet\" with a Browse Open Shifts button." },
+    ],
+    tips: ["Check Open Shifts regularly — operators post coverage needs here, and good shifts get claimed fast.","Reliability matters: completing shifts and arriving on time builds your reliability points and your rating.","Keep your profile's availability and rate current so the shifts you see are the right fit."],
+    faq: [
+      { q: "How do I get offered shifts directly?", a: "Operators' On-Call AI can text/call you when a shift opens — reply YES to claim it first." },
+      { q: "Where are my worked hours?", a: "Under My Shifts." },
+    ],
+    images: ["01_open_shifts.png","02_my_shifts.png"],
+  },
+  {
+    slug: "reliability-points",
+    title: "Earn Reliability Points & Rewards",
+    audiences: ["caregiver"],
+    icon: "🏆",
+    whoFor: "Caregivers who want to build their reputation, climb tiers, and earn rewards for dependable, high-quality work.",
+    summary: "**My Points & Rewards** tracks the points you earn for reliability, great reviews, and consistent work, shows your current tier (Bronze → up), and lists exactly how to earn more.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open My Points & Rewards (/caregiver/points)." },
+      { text: "See Your Tier (e.g., 🥉 Bronze), your Available Points, your lifetime points, and how many points until the next tier (e.g., \"100 for next tier\")." },
+      { text: "Review How to Earn Points:" },
+    ],
+    tips: ["The biggest single boost is 30 days with no call-off (+20) — reliability is the fastest path up the tiers.","Stack a 5-shift streak (+10) with on-time arrivals (+5 each) to climb quickly.","Great care earns great reviews — and every 4+ star review is +15 points."],
+    faq: [
+      { q: "What do tiers unlock?", a: "Higher tiers reflect proven reliability, which strengthens your standing with families and operators." },
+      { q: "Do points reset?", a: "You have available points and lifetime points; lifetime points track your overall standing." },
+    ],
+    images: ["01_points.png","02_tier.png"],
+  },
+  {
+    slug: "public-profile-and-background-checks",
+    title: "Your Public Profile & Background Checks",
+    audiences: ["caregiver"],
+    icon: "🛡️",
+    whoFor: "Caregivers who want to understand what families see on their public profile and how background checks strengthen it.",
+    summary: "Your **public profile** shows your rating, badges, rate, experience, bio, specialties, per-diem booking, and a **Safety & Background Checks** panel (powered by Checkr). Families can Request Care or Message you from here.",
+    readTime: "2 min",
+    steps: [
+      { text: "From your dashboard, click View public profile (or open your marketplace caregiver page)." },
+      { text: "The header shows your name, star rating + review count, and trust badges (e.g., Background Checked, Experienced), plus your Hourly Rate and Experience." },
+      { text: "About shows your bio; Specialties shows your tagged skills (e.g., Alzheimer's Care, Dementia Care, Medication Management, Companionship)." },
+      { text: "Safety & Background Checks (Verified, powered by Checkr) lists check types and their status:" },
+      { text: "Families use Request Care (starts an inquiry) or Message to reach you; a Book a per-diem shift / Request Shift option lets them book you directly." },
+    ],
+    tips: ["A Basic Check on file earns your \"Background Checked\" badge — a top trust signal for families.","Adding higher-tier checks (Enhanced, MVR) can make you eligible for more roles, especially transportation-related care.","Keep your bio and specialties polished — this page is your first impression."],
+    faq: [
+      { q: "Who runs the checks?", a: "Checkr; results are shared with you and shown on your profile." },
+      { q: "Do I have to buy the higher checks?", a: "No — Basic establishes your badge; the others are optional upgrades." },
+    ],
+    images: ["01_public_profile.png","02_background_checks.png"],
+  },
+  {
+    slug: "provider-dashboard-and-onboarding",
+    title: "Your Provider Dashboard & Getting Listed",
+    audiences: ["provider"],
+    icon: "🤝",
+    whoFor: "Home-care agencies, transportation/NEMT providers, and other care-service organizations setting up and running their CareLinkAI presence.",
+    summary: "The provider dashboard shows a **\"Get listed on the marketplace\"** onboarding checklist (with % complete), key metrics (New/Active Inquiries, Marketplace Listing status, Dispatch Reliability), and Quick Actions to manage your profile, credentials, billing, and rides.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in with your provider account — you land on the Provider dashboard (\"Welcome back, [name]\" with your business name)." },
+      { text: "Work the \"Get listed on the marketplace\" checklist to 100%. Steps include: Business name set, Bio written, Service types selected, Coverage area set, Rate set, 1+ credential uploaded, 3 credentials (Certified), Listing activated. Each incomplete item has a Fix → link." },
+      { text: "Review your metric tiles: New Inquiries (last 7 days), Active Inquiries (open conversations), Marketplace Listing (Active = visible in search), Dispatch Reliability (completion + on-time %)." },
+      { text: "Use Quick Actions: Messages, Edit Profile, Credentials, Listing & Billing, View Marketplace (your public profile), Ride Dispatch (manage today's runs)." },
+    ],
+    tips: ["Finish the onboarding checklist — items like uploaded/certified credentials unlock your verified status and stronger marketplace placement.","Dispatch Reliability is your operational reputation (completion and on-time rate) — protect it.","Use View Marketplace to see your public profile the way families do."],
+    faq: [
+      { q: "Why is my listing only partially complete?", a: "Uploading credentials (1+, then 3 certified) are the common remaining steps." },
+      { q: "What is Ride Dispatch?", a: "For transportation providers, it manages the day's scheduled rides." },
+    ],
+    images: ["01_dashboard.png","02_onboarding_checklist.png"],
+  },
+  {
+    slug: "profile-services-and-pricing",
+    title: "Set Up Your Provider Profile, Services & Pricing",
+    audiences: ["provider"],
+    icon: "🧾",
+    whoFor: "Providers configuring the business info, services, transportation capabilities, and pricing that families see in the marketplace.",
+    summary: "In **Provider Profile** enter your business information and bio, select the **services you offer**, fill in **transportation capabilities** (if applicable), set your **service radius** and **instant-booking pricing**, then **Save Profile**.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in and open Settings → Provider Profile (/settings/provider)." },
+      { text: "Business Information: Business Name, Contact Name, Contact Phone, Contact Email, Website, License Number, Years in Business, and a Bio/Description." },
+      { text: "Services Offered: check all that apply — Home Care, Personal Care, Companionship, Skilled Nursing, Transportation/NEMT, Hospice Support, Memory Care, Adult Day Services." },
+      { text: "Transportation Capabilities (for transport/NEMT providers): vehicle/ride types (Sedan, SUV, Van, Wheelchair Van, Stretcher Transport), Wheelchair Accessible Vehicles, Accepts Medicaid/Medicaid Waiver, Accepts Recurring Ride Schedules, and Service Radius (miles)." },
+      { text: "Vehicle & Capacity: Max Passengers per run." },
+      { text: "Instant Booking Pricing: set Base Fare ($), Per Mile Rate ($/mi), and Wait Rate ($/hr), then toggle Enable Instant Booking so families can see the fare upfront and pay at booking — no back-and-forth." },
+      { text: "Click Save Profile." },
+    ],
+    tips: ["Accurate services and transportation capabilities drive the marketplace filters families use (e.g., wheelchair, Medicaid) — complete them fully.","Instant Booking turns lookers into confirmed, paid rides; it requires a base fare and per-mile rate.","A clear bio and a valid license number boost trust and verified eligibility."],
+    faq: [
+      { q: "Do I need transportation fields?", a: "Only if you offer Transportation/NEMT; otherwise focus on care services." },
+      { q: "Where do these details show?", a: "On your public marketplace profile and in family search filters." },
+    ],
+    images: ["01_profile.png","02_services.png","03_transport.png","04_pricing.png"],
+  },
+  {
+    slug: "marketplace-listing-and-presence",
+    title: "Your Marketplace Listing & Public Presence",
+    audiences: ["provider"],
+    icon: "📣",
+    whoFor: "Providers who want to be discoverable by families — understanding the marketplace listing subscription and how their public profile appears.",
+    summary: "A **Provider Marketplace Listing** subscription ($99/mo) makes you visible to families searching for care, with inquiries delivered to your dashboard, capability filters, and verified-badge eligibility. Your **public profile** shows your verified badge, services, reviews, and contact options.",
+    readTime: "2 min",
+    steps: [
+      { section: "Marketplace listing subscription", text: "Sign in and open Listing & Billing (/settings/provider/billing)." },
+      { text: "Review the Provider Marketplace Listing plan — $99/month — which includes: listed in the provider marketplace, visible to searching families, inquiries delivered to your dashboard, transportation capability filters (wheelchair, Medicaid), verified badge eligibility, and priority support." },
+      { text: "Click Subscribe for $99/mo to activate (secured by Stripe; cancel anytime from the billing portal)." },
+      { section: "Your public profile (what families see)", text: "Open View Marketplace from your dashboard, or your public provider page (/marketplace/providers/[id])." },
+      { text: "It shows your business name + Verified badge, contact, years in business, Visit Website, Reviews (with Write a Review), About, Services Offered, an About This Listing summary (verified credentials count, services offered), and a Safety & Background Checks panel." },
+      { text: "Families reach you via Request Care (starts an inquiry) or Send Message." },
+    ],
+    tips: ["Your listing's capability filters (wheelchair, Medicaid) only help you if your profile's services/transportation fields are complete — fill those first.","A Verified badge and uploaded credentials lift you in family trust and search.","Gather reviews — they're social proof that converts."],
+    faq: [
+      { q: "What happens if I don't subscribe?", a: "Your visibility in the provider marketplace depends on an active listing subscription." },
+      { q: "How do inquiries reach me?", a: "Directly to your provider dashboard (and Messages)." },
+    ],
+    images: ["01_listing_billing.png","02_public_profile.png"],
+  },
+  {
+    slug: "placement-search",
+    title: "AI Placement Search",
+    audiences: ["discharge-planner"],
+    icon: "🏥",
+    whoFor: "Hospital and SNF discharge planners, case managers, and social workers placing patients into senior care quickly.",
+    summary: "From your **Discharge Planner Dashboard**, click **Start New Search**, describe your patient's needs in plain language, and let the AI surface suitable assisted living / memory care / skilled nursing homes. Track searches, placement requests, and responses from the dashboard.",
+    readTime: "2 min",
+    steps: [
+      { text: "Sign in with your discharge-planner account — you land on the Discharge Planner Dashboard." },
+      { text: "Read your metrics: Total Searches, Placement Requests, Pending Responses, Successful Placements (each with a \"this month\" count). Your Recent Searches and Pending Requests are listed below." },
+      { text: "Click Start New Search to open AI-Powered Placement Search." },
+      { text: "In \"Describe your patient's needs,\" type a natural-language request — for example, *\"I need a memory care facility in Boston for a 78-year-old with moderate Alzheimer's, budget around $6,000/month.\"* Tap an Example search to prefill one." },
+      { text: "Click Search with AI. Matching homes appear under Search Results with a Refresh Availability option." },
+      { text: "Open a result to review the home and, when ready, send a placement request / inquiry on behalf of your patient." },
+    ],
+    tips: ["Be specific: include location, care level, budget, and key needs (e.g., 24/7 nursing, Medicaid, speech therapy) — the AI uses all of it.","Use Recent Searches to re-run or reference prior placements.","Refresh Availability re-checks bed availability before you reach out."],
+    faq: [
+      { q: "What care types are covered?", a: "Assisted living, memory care, skilled nursing, and more." },
+      { q: "Does it send anything automatically?", a: "No — searching only finds homes; you choose when to send a placement request." },
+    ],
+    images: ["01_dashboard.png","02_search.png","03_results.png"],
+  },
+  {
+    slug: "refer-and-inquire-on-behalf",
+    title: "Refer & Inquire on Behalf of a Patient",
+    audiences: ["discharge-planner"],
+    icon: "📨",
+    whoFor: "Discharge planners ready to contact a home and request placement for a specific patient.",
+    summary: "After running a placement search, open a matching home and send a **placement request / inquiry on the patient's behalf** — capturing the patient's needs and timeline. Track every request's status (pending → responded → placed) from your dashboard.",
+    readTime: "2 min",
+    steps: [
+      { text: "Run an AI Placement Search and review the Search Results." },
+      { text: "Open a home that fits and choose to send a placement request / inquiry on behalf of your patient." },
+      { text: "Provide the patient's placement details — care needs, timeframe, budget, and any clinical notes the home needs to evaluate the fit. (Handle PHI per your facility's policies; share only what's necessary.)" },
+      { text: "Submit. The home is notified, and the request appears under Placement Requests / Pending Responses on your dashboard." },
+      { text: "Track the response: as homes reply, the request moves toward Successful Placement. Your dashboard counters update accordingly." },
+    ],
+    tips: ["Send to more than one home when timelines are tight — compare responses and place into the first confirmed fit.","Keep notes factual and minimal — share only the clinical detail a home needs to assess suitability.","Use the dashboard's Pending Responses tile as your follow-up queue."],
+    faq: [
+      { q: "Is the patient's family involved?", a: "You're acting on the patient's behalf; coordinate consent and family involvement per your facility's process." },
+      { q: "Where do responses appear?", a: "On your Discharge Planner dashboard (and in messaging)." },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
Replaces the How-To hub's **starter set** with the **complete 29-guide set** Chris authored in the ChrisOS vault, as version-controlled content rendered by the `/learn` hub from #566. **Closes OL-069.**

Counts: shared 3, family 6, operator 9, caregiver 6, provider 3, discharge-planner 2 = **29**. Admin-internal and Affiliate guides are deliberately excluded.

## How it works (codegen, not hand-copy)
- `scripts/generate-howto-content.ts` transforms the app bundle (`manifest.json` + `content/<role>/*.md`) into `src/app/learn/howto/content.ts` — maps `role → audience`, parses `### ` step sections / numbered steps / Tips / FAQ, strips internal cross-file refs + inline markdown, computes `readTime`, assigns per-guide icons. **`content.ts` is now auto-generated** (banner + re-run instructions at the top).
- The raw bundle (`_app_content_bundle`) and `_howto_bundle.zip` were **removed** so neither ships; the `chore/howto-bundle-dropoff` branch is being deleted.

## Role-gating (unchanged from #566/#567)
`src/lib/howto/access.ts`: everyone sees **Getting Started + Family**; each role additionally sees its own; operator/caregiver/provider/discharge-planner stay hidden from family. Verified by tests below.

## Images — text-first, zero 404s
The 71 screenshots referenced in frontmatter aren't in the repo yet. Model gained a build-time **`AVAILABLE_HOWTO_IMAGES`** set (scanned from `public/howto/`); the renderer shows **only images that exist**, so missing captures render nothing — no broken links, no layout breakage. The full checklist of expected filenames is generated at `public/howto/README.md`. Capture is tracked as **OL-071** (non-blocking).

## Rendering
Detail page now renders **section-grouped steps** (numbered within each `###` group) and a **Screenshots gallery** (gated by `AVAILABLE_HOWTO_IMAGES`).

## Tests / verification
- `__tests__/howto.access.unit.test.ts` updated to the new slugs + added catalog/gating assertions (29 guides, exact per-role counts, no cross-role leak to family, unique slugs, every guide has steps).
- ✅ `npx tsc --noEmit` clean · `npm run build` passes (`/learn/howto/[slug]` present) · `npx next lint` clean · **44** unit tests passing (howto + help suites).

## Docs
Closes **OL-069**; opens **OL-071** (screenshot capture); backfills **OL-070** (the #567 `/help` links fix); `DEV_SESSION_SUMMARIES.md` + `CARELINKAI_TECHNICAL_STATE.md` updated.

https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_