### PR TITLE
fix(family): repair /family/emergency crash (error boundary on load)

### DIFF
--- a/__tests__/family.emergency.normalize.unit.test.ts
+++ b/__tests__/family.emergency.normalize.unit.test.ts
@@ -1,0 +1,56 @@
+import { normalizePreference, EMPTY_PREFERENCE } from '@/lib/family/emergency';
+
+/**
+ * Guards the data-contract bug that crashed /family/emergency: the API returns
+ * { preferences } (null when none exist) with a free-form JSON escalationChain,
+ * and the page used to dereference it directly, throwing in render.
+ */
+describe('normalizePreference', () => {
+  it('returns an empty preference for null/undefined (no prefs yet)', () => {
+    expect(normalizePreference(null)).toEqual(EMPTY_PREFERENCE);
+    expect(normalizePreference(undefined)).toEqual(EMPTY_PREFERENCE);
+  });
+
+  it('returns an empty preference for non-object input', () => {
+    expect(normalizePreference('nope')).toEqual(EMPTY_PREFERENCE);
+    expect(normalizePreference(42)).toEqual(EMPTY_PREFERENCE);
+  });
+
+  it('passes through a well-formed preference', () => {
+    const raw = {
+      escalationChain: [{ name: 'Jane', phone: '216-555-0100' }],
+      notifyMethods: ['SMS', 'EMAIL'],
+      careInstructions: 'Call the cardiologist first.',
+    };
+    expect(normalizePreference(raw)).toEqual(raw);
+  });
+
+  it('coerces a null/garbage escalationChain to an empty array', () => {
+    expect(normalizePreference({ escalationChain: null }).escalationChain).toEqual([]);
+    expect(normalizePreference({ escalationChain: 'x' }).escalationChain).toEqual([]);
+  });
+
+  it('fills missing contact fields and drops non-string notify methods', () => {
+    const out = normalizePreference({
+      escalationChain: [{ name: 'Bob' }, null, { phone: '5551234' }],
+      notifyMethods: ['SMS', 42, null, 'CALL'],
+      careInstructions: 7,
+    });
+    expect(out.escalationChain).toEqual([
+      { name: 'Bob', phone: '' },
+      { name: '', phone: '' },
+      { name: '', phone: '5551234' },
+    ]);
+    expect(out.notifyMethods).toEqual(['SMS', 'CALL']);
+    expect(out.careInstructions).toBe('');
+  });
+
+  it('the result never has fields the UI would crash on', () => {
+    for (const input of [null, {}, { escalationChain: undefined }, { notifyMethods: undefined }]) {
+      const p = normalizePreference(input);
+      expect(Array.isArray(p.escalationChain)).toBe(true);
+      expect(Array.isArray(p.notifyMethods)).toBe(true);
+      expect(typeof p.careInstructions).toBe('string');
+    }
+  });
+});

--- a/src/app/family/emergency/page.tsx
+++ b/src/app/family/emergency/page.tsx
@@ -5,18 +5,12 @@ import { useRouter } from 'next/navigation';
 import DashboardLayout from '@/components/layout/DashboardLayout';
 import Link from 'next/link';
 import { FiArrowLeft, FiPlus, FiTrash2, FiSave } from 'react-icons/fi';
-
-// Define types for our form
-interface EscalationContact {
-  name: string;
-  phone: string;
-}
-
-interface EmergencyPreference {
-  escalationChain: EscalationContact[];
-  notifyMethods: string[];
-  careInstructions: string;
-}
+import {
+  type EscalationContact,
+  type EmergencyPreference,
+  EMPTY_PREFERENCE,
+  normalizePreference,
+} from '@/lib/family/emergency';
 
 export default function EmergencyPreferencesPage() {
   const router = useRouter();
@@ -30,11 +24,7 @@ export default function EmergencyPreferencesPage() {
   const isGuest = role === 'GUEST';
   
   // Form state
-  const [preferences, setPreferences] = useState<EmergencyPreference>({
-    escalationChain: [],
-    notifyMethods: [],
-    careInstructions: '',
-  });
+  const [preferences, setPreferences] = useState<EmergencyPreference>({ ...EMPTY_PREFERENCE });
 
   // Load existing preferences
   useEffect(() => {
@@ -44,13 +34,16 @@ export default function EmergencyPreferencesPage() {
         setError(null);
         if (!familyId) return;
         const response = await fetch(`/api/family/emergency?familyId=${familyId}`);
-        
+
         if (!response.ok) {
           throw new Error('Failed to load emergency preferences');
         }
-        
+
         const data = await response.json();
-        setPreferences(data.preference);
+        // The API returns { preferences } (null when none exist yet). Normalize
+        // to the safe shape so render never dereferences null/undefined — this
+        // was the cause of the "Something went wrong" error boundary.
+        setPreferences(normalizePreference(data?.preferences));
       } catch (err: any) {
         setError(err.message || 'An error occurred while loading preferences');
         console.error('Error loading emergency preferences:', err);
@@ -58,7 +51,7 @@ export default function EmergencyPreferencesPage() {
         setLoading(false);
       }
     };
-    
+
     loadPreferences();
   }, [familyId]);
 

--- a/src/lib/family/emergency.ts
+++ b/src/lib/family/emergency.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared types + normalizer for the family emergency-preferences page.
+ *
+ * Extracted so the data-contract logic is unit-testable without React. The
+ * /api/family/emergency GET returns `{ preferences }` which is `null` when a
+ * family has none yet, and whose `escalationChain` is free-form JSON — passing
+ * that straight into React state crashed the page (the "Something went wrong"
+ * error boundary). normalizePreference() coerces any input into the strict
+ * shape the UI renders.
+ */
+
+export interface EscalationContact {
+  name: string;
+  phone: string;
+}
+
+export interface EmergencyPreference {
+  escalationChain: EscalationContact[];
+  notifyMethods: string[];
+  careInstructions: string;
+}
+
+export const EMPTY_PREFERENCE: EmergencyPreference = {
+  escalationChain: [],
+  notifyMethods: [],
+  careInstructions: '',
+};
+
+export function normalizePreference(raw: any): EmergencyPreference {
+  if (!raw || typeof raw !== 'object') return { ...EMPTY_PREFERENCE };
+  const chain = Array.isArray(raw.escalationChain) ? raw.escalationChain : [];
+  return {
+    escalationChain: chain.map((c: any) => ({
+      name: typeof c?.name === 'string' ? c.name : '',
+      phone: typeof c?.phone === 'string' ? c.phone : '',
+    })),
+    notifyMethods: Array.isArray(raw.notifyMethods)
+      ? raw.notifyMethods.filter((m: any): m is string => typeof m === 'string')
+      : [],
+    careInstructions: typeof raw.careInstructions === 'string' ? raw.careInstructions : '',
+  };
+}


### PR DESCRIPTION
## Summary
Fixes `/family/emergency` throwing the global **"Something went wrong" error boundary** on load for FAMILY users (confirmed in prod as Jennifer Martinez).

## Root cause
A client/API contract mismatch:
- `GET /api/family/emergency` returns `{ preferences }` (plural), and it's **`null`** when a family has no preferences yet.
- The page read **`data.preference`** (singular) → always `undefined` → `setPreferences(undefined)`. The next render evaluated `preferences.notifyMethods.includes(...)` → `TypeError: Cannot read properties of undefined` → error boundary. (Even the correct key would crash on the common `null` "no prefs yet" case.)

## Fix
- Read `data.preferences` and **normalize** any input — `null`, partial, or a free-form JSON `escalationChain` — into the strict shape the UI renders, so render can never dereference null/undefined.
- Extracted the types + `normalizePreference()` into `src/lib/family/emergency.ts` (testable without React) and initialized state from `EMPTY_PREFERENCE`.

## Tests / verification
- `__tests__/family.emergency.normalize.unit.test.ts` — **6 cases** (null/garbage → empty, well-formed pass-through, partial-field coercion, "result never crashes the UI").
- ✅ `tsc` clean · `npm run build` passes (`/family/emergency` compiles).

The `/help` "Set up emergency contacts" link can stay enabled — the fix ships with it, so no interim-disable is needed.

> Backlog notes captured separately (in the companion Education-Hub PR's docs): `/family/residents` rendering without app chrome, and `/marketplace` Providers showing SF demo data.

https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_