### PR TITLE
fix(marketplace): gate mock data to prod admins only (no demo leak to families)

### DIFF
--- a/__tests__/mock-mode.viewer.unit.test.ts
+++ b/__tests__/mock-mode.viewer.unit.test.ts
@@ -1,0 +1,50 @@
+import { getServerSession } from 'next-auth';
+import { isMockViewerAllowed } from '@/lib/mockMode.server';
+
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/auth', () => ({ authOptions: {} }));
+
+const mockGetSession = getServerSession as jest.Mock;
+
+const origEnv = process.env.NODE_ENV;
+function setEnv(v: string) {
+  Object.defineProperty(process.env, 'NODE_ENV', { value: v, configurable: true });
+}
+afterEach(() => {
+  Object.defineProperty(process.env, 'NODE_ENV', { value: origEnv, configurable: true });
+  jest.clearAllMocks();
+});
+
+describe('isMockViewerAllowed', () => {
+  it('allows everyone outside production (dev/preview/staging)', async () => {
+    setEnv('development');
+    mockGetSession.mockResolvedValue(null);
+    await expect(isMockViewerAllowed()).resolves.toBe(true);
+    // session is never even consulted off-prod
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it('allows a prod ADMIN', async () => {
+    setEnv('production');
+    mockGetSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+    await expect(isMockViewerAllowed()).resolves.toBe(true);
+  });
+
+  it('blocks a prod non-admin (e.g. FAMILY) even with a mock cookie', async () => {
+    setEnv('production');
+    mockGetSession.mockResolvedValue({ user: { role: 'FAMILY' } });
+    await expect(isMockViewerAllowed()).resolves.toBe(false);
+  });
+
+  it('blocks an unauthenticated prod visitor', async () => {
+    setEnv('production');
+    mockGetSession.mockResolvedValue(null);
+    await expect(isMockViewerAllowed()).resolves.toBe(false);
+  });
+
+  it('fails closed if the session lookup throws in prod', async () => {
+    setEnv('production');
+    mockGetSession.mockRejectedValue(new Error('boom'));
+    await expect(isMockViewerAllowed()).resolves.toBe(false);
+  });
+});

--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -117,11 +117,16 @@ Each loop: what it is, why it matters, what done looks like.
 - **Status:** ✅ CLOSED (2026-06-16, PR feat/education-hub-tabs)
 - **What:** The How-To tutorials sat below the senior-care articles, so as articles grow How-To would get buried. Added two tabs at the top of `/learn` — **How-To & Tutorials** (default) and **Senior Care Guides** — driven by the `?tab=` query param (URL-stable, refresh-safe, server-rendered, no client JS). Role-gating from #566 preserved under the How-To tab. The `/help` "Education Hub" card still deep-links to `/learn` (defaults to How-To).
 
-### OL-074: Two minor FAMILY-UX observations (backlog, not yet fixed)
+### OL-074: `/family/residents` renders without app chrome (backlog)
 - **Status:** 🟡 OPEN — captured during 2026-06-16 live inspection
 - **(a)** `/family/residents` renders **without the app sidebar/chrome** — confirm whether intended (other `/family/*` pages use `DashboardLayout`). Low priority, cosmetic.
-- **(b)** `/marketplace` **Providers** tab shows demo data ("Golden Years Home Care, San Francisco"). Demo-data cleanup is tracked separately (non-Cleveland demo cleanup, see OL-057 family); spot-check + purge the SF provider demo rows before broader launch.
-- **Done when:** (a) decision recorded + layout aligned if needed; (b) SF/demo provider rows removed from prod.
+- **Done when:** decision recorded + layout aligned if needed.
+
+### OL-075: Marketplace mock data could leak to real users in prod
+- **Status:** ✅ CLOSED (2026-06-16, PR `fix/mock-mode-prod-admin-only`)
+- **What:** The `/marketplace` Providers (and Caregivers) surfaces showed sample data ("Golden Years Home Care, San Francisco") because admin **mock mode** was on (a `carelink_mock_mode` cookie or `SHOW_SITE_MOCKS=1` env). The `_marketplace_mock` default-on path in `providers/[id]` and the on-empty/on-error mock fallbacks in the caregivers route could also surface mocks to real visitors. Founder chose a code hardening over an ops toggle.
+- **Fix:** added `isMockViewerAllowed()` (`src/lib/mockMode.server.ts`) — non-prod: always; **production: ADMIN only** — and gated every mock-serving point in the providers/caregivers + `providers/[id]` routes on it. So a stray cookie/env can no longer leak demo data to families on prod; admins keep the preview in dev/staging. Test: `__tests__/mock-mode.viewer.unit.test.ts` (5 cases).
+- **Note:** This is the durable fix for the OL-074(b) observation. If `SHOW_SITE_MOCKS=1` is *also* set in Render, it's now harmless for end users but can be unset for tidiness.
 
 ### OL-027: Provider listing fee ($99/mo)
 - **Status:** ✅ CLOSED (2026-05-02)

--- a/context/DEV_SESSION_SUMMARIES.md
+++ b/context/DEV_SESSION_SUMMARIES.md
@@ -1521,4 +1521,15 @@
 - **PRs:** #569 (emergency fix) + `feat/education-hub-tabs` (this PR carries the docs).
 - **Recommended next step:** Merge both PRs; then OL-074 (demo-data purge + residents-layout decision) and OL-071 (screenshots) remain.
 
+### 2026-06-16 — Harden marketplace mock mode (prod = admins only)
+- **Objective:** Stop `/marketplace` showing sample providers/caregivers ("Golden Years Home Care, San Francisco") to real families. Founder chose a code hardening over an ops cookie/env toggle.
+- **Work completed:** Root-caused to admin **mock mode** (cookie `carelink_mock_mode` or env `SHOW_SITE_MOCKS`) — a deliberate feature, not seeded data. Added `isMockViewerAllowed()` (`src/lib/mockMode.server.ts`): non-prod always; **production ADMIN only**. Gated every mock-serving point: providers list (primary + error fallback), caregivers list (on-empty + on-error fallbacks), and `providers/[id]` (the default-on `_marketplace_mock` detail path). A stray cookie/env can no longer leak demo data to families on prod; admins keep the preview in dev/staging.
+- **Files changed:** `src/lib/mockMode.server.ts` (new), `src/app/api/marketplace/providers/route.ts`, `src/app/api/marketplace/caregivers/route.ts`, `src/app/api/marketplace/providers/[id]/route.ts`, `__tests__/mock-mode.viewer.unit.test.ts` (new), context files.
+- **Commands run:** `npx jest` (5 passing), `npx tsc --noEmit` (exit 0), `npm run build` (Compiled successfully), `npx next lint` (clean).
+- **Tests/build status:** ✅ all green.
+- **Deployment impact:** No schema/migration. Behavior change only for prod non-admins (they now see real data / true empty states instead of mocks). Safe on Render auto-deploy.
+- **Loops:** closed OL-075 (this fix; the durable resolution of OL-074(b)); OL-074 narrowed to just the `/family/residents` chrome question.
+- **PR:** `fix/mock-mode-prod-admin-only`.
+- **Recommended next step:** Optionally unset `SHOW_SITE_MOCKS` in Render for tidiness; address OL-074(a) (residents layout) if desired.
+
 <!-- Add new sessions above this line, newest first -->

--- a/src/app/api/marketplace/caregivers/route.ts
+++ b/src/app/api/marketplace/caregivers/route.ts
@@ -9,6 +9,7 @@ import { authOptions } from '@/lib/auth';
 import { Prisma } from '@prisma/client';
 import { rateLimitAsync, getClientIp, buildRateLimitHeaders } from '@/lib/rateLimit';
 import { isMockModeEnabled } from '@/lib/mockMode';
+import { isMockViewerAllowed } from '@/lib/mockMode.server';
 
 /**
  * GET /api/marketplace/caregivers
@@ -439,8 +440,11 @@ export async function GET(request: Request) {
       };
     });
     
-    // If mock mode is enabled OR in development, return mock data when no results found
-    const useMockData = isMockModeEnabled(request) || process.env.NODE_ENV === 'development';
+    // Return mock data when no results found — only when the requester may see
+    // mocks (non-prod, or a prod admin). Real families get a true empty result.
+    const useMockData =
+      (isMockModeEnabled(request) || process.env.NODE_ENV !== 'production') &&
+      (await isMockViewerAllowed());
     if (useMockData && formattedCaregivers.length === 0) {
       // Fetch specialties from DB for more realistic mock data
       let specialtyCategories: string[] = [];
@@ -493,8 +497,11 @@ export async function GET(request: Request) {
   } catch (error) {
     console.error('Error fetching caregivers:', error);
     
-    // If mock mode is enabled OR in development, return mock data on error
-    const useMockData = isMockModeEnabled(request) || process.env.NODE_ENV === 'development';
+    // Fall back to mock data on error only when the requester may see mocks
+    // (non-prod, or a prod admin) — never leak sample data to real users.
+    const useMockData =
+      (isMockModeEnabled(request) || process.env.NODE_ENV !== 'production') &&
+      (await isMockViewerAllowed());
     if (useMockData) {
       const mockCaregivers = generateMockCaregivers(12);
       

--- a/src/app/api/marketplace/providers/[id]/route.ts
+++ b/src/app/api/marketplace/providers/[id]/route.ts
@@ -5,6 +5,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { isMockModeEnabled } from '@/lib/mockMode';
+import { isMockViewerAllowed } from '@/lib/mockMode.server';
 import { getMockProviderDetail } from '@/lib/mock/providers';
 import { computeProviderRideStats } from '@/lib/rideStats';
 
@@ -48,7 +49,9 @@ export async function GET(
       showMarketplace = false;
     }
     
-    if ((mockMode || showMarketplace) && isMarketplaceMockId) {
+    // Only serve a mock provider when the requester may see mocks (prod: admins
+    // only) — so a real family clicking through never lands on demo detail.
+    if ((mockMode || showMarketplace) && isMarketplaceMockId && (await isMockViewerAllowed())) {
       const mockProvider = getMockProviderDetail(id);
       
       if (!mockProvider) {

--- a/src/app/api/marketplace/providers/route.ts
+++ b/src/app/api/marketplace/providers/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
 import { isMockModeEnabled } from '@/lib/mockMode';
+import { isMockViewerAllowed } from '@/lib/mockMode.server';
 import { generateMockProviders, filterMockProviders } from '@/lib/mock/providers';
 
 /**
@@ -23,9 +24,10 @@ export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     
-    // Check if mock mode is enabled via cookie or environment variable
-    const useMockData = isMockModeEnabled(request);
-    
+    // Check if mock mode is requested (cookie/env) AND the requester may see
+    // mocks (prod: admins only). Real families never get sample providers.
+    const useMockData = isMockModeEnabled(request) && (await isMockViewerAllowed());
+
     // If mock mode is enabled, return mock data
     if (useMockData) {
       // Extract filter parameters for mock data filtering
@@ -336,9 +338,12 @@ export async function GET(request: Request) {
   } catch (error) {
     console.error('Error fetching providers:', error);
     
-    // In development mode OR if mock mode is enabled, return mock data as fallback
-    const useMockData = isMockModeEnabled(request) || process.env.NODE_ENV === 'development';
-    
+    // Fall back to mock data only when the requester may see mocks (non-prod,
+    // or a prod admin) — never leak sample data to real users on an error.
+    const useMockData =
+      (isMockModeEnabled(request) || process.env.NODE_ENV !== 'production') &&
+      (await isMockViewerAllowed());
+
     if (useMockData) {
       const mockProviders = generateMockProviders(12);
       

--- a/src/lib/mockMode.server.ts
+++ b/src/lib/mockMode.server.ts
@@ -1,0 +1,26 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+/**
+ * Whether the current requester may be shown mock/demo data.
+ *
+ * - Non-production (dev / preview / staging): always allowed — mocks are a
+ *   development affordance.
+ * - Production: ADMINs only. This ensures a stray `carelink_mock_mode` cookie
+ *   or a `SHOW_SITE_MOCKS` env var can never leak sample providers/caregivers
+ *   (e.g. "Golden Years Home Care, San Francisco") to real families on prod.
+ *
+ * Pair this with `isMockModeEnabled()` (which decides whether mock data is
+ * *requested* via cookie/env): only serve mocks when both are true.
+ *
+ * Server-only — imports NextAuth/Prisma, so do not import from Edge/middleware.
+ */
+export async function isMockViewerAllowed(): Promise<boolean> {
+  if (process.env.NODE_ENV !== 'production') return true;
+  try {
+    const session = await getServerSession(authOptions);
+    return (session?.user as any)?.role === 'ADMIN';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
Stops `/marketplace` from showing **mock providers/caregivers** (e.g. "Golden Years Home Care, San Francisco") to real families. You chose the **code hardening** over an ops cookie/env toggle.

## Root cause
Not seeded data and not a bug — it's the deliberate admin **mock mode** (cookie `carelink_mock_mode` or env `SHOW_SITE_MOCKS=1`). Several paths could surface mocks to ordinary visitors:
- Providers list when mock mode is on.
- `providers/[id]` detail via a `_marketplace_mock` path that **defaults on**.
- Caregivers list **on-empty** and **on-error** fallbacks (`isMockModeEnabled || NODE_ENV==='development'`).

## Fix
- New `isMockViewerAllowed()` (`src/lib/mockMode.server.ts`): **non-prod → always; production → ADMIN only** (fails closed on any session error). Server-only (imports NextAuth), so it's safe from Edge/middleware.
- Gated **every** mock-serving point in the providers, caregivers, and `providers/[id]` routes on it. A stray cookie/env can no longer leak demo data to families in prod; admins keep the preview in dev/staging.

## Behavior change
Prod **non-admins** now get real data / true empty states instead of mocks. Dev/staging and prod **admins** are unchanged. No schema/migration.

## Tests / verification
- `__tests__/mock-mode.viewer.unit.test.ts` — 5 cases (off-prod allows all; prod admin allows; prod FAMILY/anon/error all blocked).
- ✅ `tsc` clean · `npm run build` passes · `npx next lint` clean.

## Docs
Closes **OL-075** (the durable fix for the OL-074(b) observation); **OL-074** narrowed to just the `/family/residents`-renders-without-chrome question. If `SHOW_SITE_MOCKS=1` is also set in Render, it's now harmless for end users but can be unset for tidiness.

https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_