### PR TITLE
feat(claim): email founder on each operator listing claim

### DIFF
--- a/src/app/api/admin/homes/[id]/claim/route.ts
+++ b/src/app/api/admin/homes/[id]/claim/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { createAuditLogFromRequest } from '@/lib/audit';
 import { AuditAction } from '@prisma/client';
+import { sendOperatorClaimNotification } from '@/lib/email';
 
 export const dynamic = 'force-dynamic';
 
@@ -115,6 +116,13 @@ export async function POST(
         newStatus: 'PENDING_REVIEW',
       }
     );
+
+    // Surface the claim to the founder/admin in real time (non-blocking).
+    void sendOperatorClaimNotification({
+      facilityName: home.name,
+      operatorEmail: operator.user?.email ?? 'unknown',
+      status: 'PENDING_REVIEW',
+    }).catch((e) => console.error('[admin claim] founder notification failed', e));
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/operator/homes/[id]/claim/route.ts
+++ b/src/app/api/operator/homes/[id]/claim/route.ts
@@ -5,6 +5,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { UserRole } from '@prisma/client';
+import { sendOperatorClaimNotification } from '@/lib/email';
 
 /**
  * POST /api/operator/homes/[id]/claim
@@ -94,6 +95,13 @@ export async function POST(
       data: { seededHomeId: null },
     }),
   ]);
+
+  // Surface the claim to the founder/admin in real time (non-blocking).
+  void sendOperatorClaimNotification({
+    facilityName: updatedHome.name,
+    operatorEmail: user.email!,
+    status: 'ACTIVE',
+  }).catch((e) => console.error('[claim] founder notification failed', e));
 
   return NextResponse.json({ home: updatedHome });
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -72,6 +72,71 @@ export async function sendVerificationEmail(
   }
 }
 
+/** Minimal HTML escape for interpolating user-supplied strings into email HTML. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Notify the founder/admin that an operator completed a listing claim, so
+ * claims surface in real time without checking the backend. Fire-and-forget
+ * from the claim routes (failures are logged, never block the claim).
+ *
+ * Recipient defaults to chris@getcarelinkai.com, overridable via
+ * CLAIM_NOTIFY_EMAIL.
+ */
+export async function sendOperatorClaimNotification(args: {
+  facilityName: string;
+  operatorEmail: string;
+  status?: string;
+}): Promise<boolean> {
+  const to = process.env.CLAIM_NOTIFY_EMAIL || 'chris@getcarelinkai.com';
+  try {
+    if (!process.env.RESEND_API_KEY) {
+      console.error('[Resend] RESEND_API_KEY not configured — skipping operator claim notification');
+      return false;
+    }
+    const facilityName = args.facilityName || '(unnamed facility)';
+    const operatorEmail = args.operatorEmail || '(unknown operator)';
+    const status = args.status;
+
+    const { data, error } = await resend.emails.send({
+      from: `${APP_NAME} <${FROM_EMAIL}>`,
+      to: [to],
+      subject: `New operator claim: ${facilityName}`,
+      text:
+        `An operator just claimed a listing on CareLinkAI.\n\n` +
+        `Facility: ${facilityName}\n` +
+        `Operator: ${operatorEmail}\n` +
+        (status ? `Status: ${status}\n` : '') +
+        `\nReview it in the admin panel.`,
+      html:
+        `<p>An operator just claimed a listing on CareLinkAI.</p>` +
+        `<ul>` +
+        `<li><strong>Facility:</strong> ${escapeHtml(facilityName)}</li>` +
+        `<li><strong>Operator:</strong> ${escapeHtml(operatorEmail)}</li>` +
+        (status ? `<li><strong>Status:</strong> ${escapeHtml(status)}</li>` : '') +
+        `</ul>` +
+        `<p>Review it in the admin panel.</p>`,
+    });
+
+    if (error) {
+      console.error('[Resend] Error sending operator claim notification:', error);
+      return false;
+    }
+    console.log('[Resend] ✅ Operator claim notification sent. Email ID:', data?.id);
+    return true;
+  } catch (error) {
+    console.error('[Resend] Exception sending operator claim notification:', error);
+    return false;
+  }
+}
+
 /**
  * Generate HTML content for verification email
  */


### PR DESCRIPTION
## Summary
Adds a real-time founder/admin email on each operator listing claim (item 2).

## Confirmation (the "does one already exist?" answer)
**No founder email existed on claim.**
- **Operator self-claim** — `POST /api/operator/homes/[id]/claim` (founder claims their seeded home → `ACTIVE`): **no notification at all**.
- **Admin claim** — `POST /api/admin/homes/[id]/claim` (→ `PENDING_REVIEW`): created an in-app `notification` **for the operator**, but **no email to chris@**.

So claims didn't surface in real time without checking the backend.

## Change
- `sendOperatorClaimNotification({ facilityName, operatorEmail, status })` in `src/lib/email.ts` (Resend) → **chris@getcarelinkai.com** (overridable via `CLAIM_NOTIFY_EMAIL`). HTML-escaped, with text + html bodies.
- Wired **fire-and-forget** (non-blocking; failures logged, never block the claim) into **both** completion points: operator self-claim (`ACTIVE`) and admin claim (`PENDING_REVIEW`), each passing facility name + operator email + status.

## Verification
`tsc` clean. Uses the existing Resend setup (`RESEND_API_KEY`, `EMAIL_FROM` — already in Render); guarded to no-op + log if the key is missing.

https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_