### PR TITLE
feat(privacy): gate third-party trackers behind cookie consent (OL-078)

### DIFF
--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -141,6 +141,17 @@ Each loop: what it is, why it matters, what done looks like.
 - **Resolution:** Kept the page's principled buckets (Completed=`CURRENT/COMPLIANT`; Open=`EXPIRING_SOON/EXPIRED/PENDING/MISSING`; Due Soon=expiry within 14d; Overdue=expiry past) and made `api/dev/seed-family-resident` produce a deterministic scenario that exercises all four: Flu Shot=`CURRENT` (completed), TB Test=`EXPIRING_SOON` expiry +10d (open + due-soon), Care Plan Review=`EXPIRED` expiry −5d (open + overdue) → Open=2 / Completed=1 / Due Soon=1 / Overdue=1, matching the spec. `family-resident-readonly` **un-quarantined**; `family-notifications` only asserts the cards render, so it's unaffected.
 - **Note:** the separate operator-facing `/api/.../compliance/summary` route uses a different (looser) bucketing and is out of scope here; revisit if that surface needs exact parity.
 
+### OL-078: Third-party trackers loaded with no cookie-consent gate (privacy/HIPAA exposure)
+- **Status:** ✅ CLOSED (2026-06-16, PR `feat/cookie-consent-tracker-gating`).
+- **What it was:** `layout.tsx` injected Meta Pixel, Microsoft Clarity, GA4, and GTM unconditionally (gated only by env-var presence, fired `afterInteractive`). The existing `CookieConsent` banner was cosmetic — it only flipped `ga-disable`/`fbq consent` *after* the scripts had already loaded and sent the initial PageView/session. On a HIPAA-positioned site, behavioral trackers fired before consent.
+- **Fix:**
+  - `src/lib/consent.ts` — shared consent state + `CONSENT_EVENT`. `AnalyticsScripts` (`src/components/analytics/AnalyticsScripts.tsx`, client) injects trackers **only after explicit consent** and reacts to the event (loads on opt-in, no reload). **Nothing fires pre-consent.** Removed the unconditional `<Script>` blocks from `layout.tsx`.
+  - **GA4 + GTM:** gated behind `analytics` consent (all pages). Dropped the GTM `<noscript>` (would bypass the JS consent gate).
+  - **Microsoft Clarity:** `analytics` consent only; site-wide masking via `data-clarity-mask="true"` on `<body>` (masks all text/inputs); not initially loaded on sensitive routes (auth + resident/care + logged-in app areas). **Founder action:** also set the Clarity dashboard masking to Strict for belt-and-suspenders.
+  - **Meta Pixel:** `marketing` consent only; **PageView only** (no custom events in the loader); excluded from logged-in operator/family + health/care routes via `SENSITIVE_PREFIXES`.
+  - `CookieConsent` refactored to use the shared helper (Accept All / Necessary Only / Customize) and dispatch the consent event.
+- **Verify:** with no stored consent, the network tab shows no requests to googletagmanager.com / connect.facebook.net / clarity.ms until the user opts in. `tsc` clean, build passes, lint clean.
+
 ### OL-027: Provider listing fee ($99/mo)
 - **Status:** ✅ CLOSED (2026-05-02)
 - Schema fields + migration, Stripe Checkout + Customer Portal APIs, webhook handler, visibility gate in marketplace API, billing UI at `/settings/provider/billing`. Requires `STRIPE_PRICE_PROVIDER_LISTING` env var in Render.

--- a/context/DEV_SESSION_SUMMARIES.md
+++ b/context/DEV_SESSION_SUMMARIES.md
@@ -1555,4 +1555,13 @@
 - **Tests/build:** `tsc` clean; e2e verified via the PR's CI (sandbox blocks local Playwright browser).
 - **Recommended next step:** if any of the 3 Sentry issues still report events *after* today's Render deploy, re-open with fresh stack traces — but they should be resolved. OL-076 (operator/residents Next-15 migration) remains the main open e2e item.
 
+### 2026-06-16 — Tracking consent gate (OL-078) + operator-claim founder email
+- **Objective:** (1) Gate all third-party trackers behind cookie consent (OL-078); (2) email the founder on each operator claim.
+- **Item 1 — consent gating (PR `feat/cookie-consent-tracker-gating`):** `layout.tsx` was loading Meta Pixel / Microsoft Clarity / GA4 / GTM unconditionally `afterInteractive`; the existing banner was cosmetic (flipped flags after scripts already fired). Added `src/lib/consent.ts` + `src/components/analytics/AnalyticsScripts.tsx` (client, consent-gated, reacts to `CONSENT_EVENT`) and removed the unconditional `<Script>` blocks. **Nothing fires pre-consent.** GA4/GTM gated on analytics consent; Clarity on analytics consent + site-wide `data-clarity-mask` on `<body>` + sensitive-route exclusion; Pixel on marketing consent + PageView-only + excluded from logged-in/health routes. Refactored `CookieConsent` to the shared helper. Founder follow-up: set Clarity dashboard masking to Strict.
+- **Item 2 — operator-claim founder email (PR `feat/operator-claim-founder-notification`, #576):** Confirmed no founder email existed on claim (operator self-claim → ACTIVE had none; admin claim → PENDING_REVIEW only made an in-app notification for the operator). Added `sendOperatorClaimNotification()` (Resend) → chris@getcarelinkai.com (env `CLAIM_NOTIFY_EMAIL` override), wired fire-and-forget into both claim routes.
+- **Files:** item 1 — `src/lib/consent.ts` (new), `src/components/analytics/AnalyticsScripts.tsx` (new), `src/app/layout.tsx`, `src/components/analytics/CookieConsent.tsx`, context docs; item 2 — `src/lib/email.ts`, `src/app/api/operator/homes/[id]/claim/route.ts`, `src/app/api/admin/homes/[id]/claim/route.ts`.
+- **Tests/build:** `tsc` clean (both); `npm run build` passes; `next lint` clean. Network-tab verification of "nothing before consent" to be confirmed on the deploy preview.
+- **Loops:** OL-078 closed (added + closed). 
+- **Recommended next step:** verify in prod/preview network tab that no tracker requests fire pre-consent; set Clarity dashboard masking to Strict.
+
 <!-- Add new sessions above this line, newest first -->

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, Viewport } from "next";
 import { Inter, DM_Serif_Display } from "next/font/google";
-import Script from "next/script";
 import "./globals.css";
 import { Providers } from "./providers";
 // WebSocket provider for real-time messaging
@@ -22,6 +21,8 @@ import CareConcierge from "../components/CareConcierge";
 import { BugReportButton } from "../components/bug-report/BugReportButton";
 // Cookie consent banner
 import CookieConsent from "../components/analytics/CookieConsent";
+// Consent-gated analytics loader (GA4/GTM, Meta Pixel, Microsoft Clarity)
+import AnalyticsScripts from "../components/analytics/AnalyticsScripts";
 // Error boundary
 import ErrorBoundary from "../components/ErrorBoundary";
 // Onboarding modal
@@ -221,97 +222,15 @@ export default function RootLayout({
         />
         */}
       </head>
-      <body className="min-h-screen bg-neutral-50 antialiased font-sans">
-        {/* Google Tag Manager */}
-        {process.env.NEXT_PUBLIC_GTM_ID && (
-          <>
-            <Script
-              id="gtm-script"
-              strategy="afterInteractive"
-              dangerouslySetInnerHTML={{
-                __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-                })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_ID}');`,
-              }}
-            />
-            <noscript>
-              <iframe
-                src={`https://www.googletagmanager.com/ns.html?id=${process.env.NEXT_PUBLIC_GTM_ID}`}
-                height="0"
-                width="0"
-                style={{ display: 'none', visibility: 'hidden' }}
-              />
-            </noscript>
-          </>
-        )}
-        
-        {/* Google Analytics 4 */}
-        {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
-          <>
-            <Script
-              src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}`}
-              strategy="afterInteractive"
-            />
-            <Script
-              id="ga-script"
-              strategy="afterInteractive"
-              dangerouslySetInnerHTML={{
-                __html: `
-                  window.dataLayer = window.dataLayer || [];
-                  function gtag(){dataLayer.push(arguments);}
-                  gtag('js', new Date());
-                  gtag('config', '${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}', {
-                    page_path: window.location.pathname,
-                    send_page_view: true
-                  });
-                  console.log('[GA4] Google Analytics 4 initialized with ID: ${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}');
-                `,
-              }}
-            />
-          </>
-        )}
-        
-        {/* Facebook Pixel */}
-        {process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID && (
-          <Script
-            id="fb-pixel"
-            strategy="afterInteractive"
-            dangerouslySetInnerHTML={{
-              __html: `
-                !function(f,b,e,v,n,t,s)
-                {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-                n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-                if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-                n.queue=[];t=b.createElement(e);t.async=!0;
-                t.src=v;s=b.getElementsByTagName(e)[0];
-                s.parentNode.insertBefore(t,s)}(window, document,'script',
-                'https://connect.facebook.net/en_US/fbevents.js');
-                fbq('init', '${process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID}');
-                fbq('track', 'PageView');
-              `,
-            }}
-          />
-        )}
-        
-        {/* Microsoft Clarity */}
-        {process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID && (
-          <Script
-            id="clarity-script"
-            strategy="afterInteractive"
-            dangerouslySetInnerHTML={{
-              __html: `
-                (function(c,l,a,r,i,t,y){
-                  c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-                  t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-                  y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-                })(window, document, "clarity", "script", "${process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID}");
-              `,
-            }}
-          />
-        )}
-        
+      {/* data-clarity-mask masks ALL text/inputs site-wide if Microsoft Clarity
+          loads — defense-in-depth for the HIPAA posture (trackers are also
+          consent-gated via AnalyticsScripts). */}
+      <body className="min-h-screen bg-neutral-50 antialiased font-sans" data-clarity-mask="true">
+        {/* Third-party trackers (GA4/GTM, Meta Pixel, Microsoft Clarity) load
+            ONLY after explicit cookie consent — see AnalyticsScripts. Nothing
+            fires before the user opts in (OL-078). */}
+        <AnalyticsScripts />
+
         <WebSocketProvider>
           <Providers>
             <SentryProvider>

--- a/src/components/analytics/AnalyticsScripts.tsx
+++ b/src/components/analytics/AnalyticsScripts.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import Script from 'next/script';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { getConsent, CONSENT_EVENT, type ConsentPreferences } from '@/lib/consent';
+
+const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
+const GA_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+const PIXEL_ID = process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID;
+const CLARITY_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID;
+
+/**
+ * Logged-in app + health/care/auth areas. On a HIPAA-positioned site we keep
+ * behavioral trackers (Meta Pixel, Microsoft Clarity) OFF these routes — Pixel
+ * never loads here, and Clarity is not initially loaded here (site-wide it is
+ * also fully masked via data-clarity-mask on <body>). GA4/GTM still load with
+ * analytics consent (page-level analytics only).
+ */
+const SENSITIVE_PREFIXES = [
+  '/family', '/operator', '/caregiver', '/provider', '/discharge-planner',
+  '/admin', '/settings', '/messages', '/dashboard', '/auth', '/residents',
+  '/rides', '/background-checks', '/calendar', '/shifts', '/timesheets', '/reports',
+];
+
+function isSensitiveRoute(pathname: string | null): boolean {
+  if (!pathname) return true; // fail safe (treat unknown as sensitive)
+  return SENSITIVE_PREFIXES.some((p) => pathname === p || pathname.startsWith(p + '/'));
+}
+
+/**
+ * Consent-gated analytics loader. Renders nothing until the user has made an
+ * explicit cookie choice; then injects only the trackers they opted into.
+ * Reacts to CONSENT_EVENT so trackers load immediately on opt-in (no reload).
+ */
+export default function AnalyticsScripts() {
+  const pathname = usePathname();
+  const [consent, setConsent] = useState<ConsentPreferences | null>(null);
+
+  useEffect(() => {
+    setConsent(getConsent());
+    const onChange = () => setConsent(getConsent());
+    window.addEventListener(CONSENT_EVENT, onChange);
+    return () => window.removeEventListener(CONSENT_EVENT, onChange);
+  }, []);
+
+  // Pre-consent (or no choice yet): load nothing.
+  if (!consent) return null;
+
+  const analytics = consent.analytics;
+  const marketing = consent.marketing;
+  const sensitive = isSensitiveRoute(pathname);
+
+  return (
+    <>
+      {/* Google Tag Manager — analytics consent (all pages) */}
+      {analytics && GTM_ID && (
+        <Script
+          id="gtm-script"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+              })(window,document,'script','dataLayer','${GTM_ID}');`,
+          }}
+        />
+      )}
+
+      {/* Google Analytics 4 — analytics consent (all pages) */}
+      {analytics && GA_ID && (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+            strategy="afterInteractive"
+          />
+          <Script
+            id="ga-script"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${GA_ID}', { page_path: window.location.pathname, send_page_view: true });
+              `,
+            }}
+          />
+        </>
+      )}
+
+      {/* Microsoft Clarity — analytics consent; skip initial load on sensitive
+          routes. Site-wide masking is enforced via data-clarity-mask on <body>. */}
+      {analytics && CLARITY_ID && !sensitive && (
+        <Script
+          id="clarity-script"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+              })(window, document, "clarity", "script", "${CLARITY_ID}");
+            `,
+          }}
+        />
+      )}
+
+      {/* Meta/Facebook Pixel — marketing consent; PageView ONLY (no custom
+          events here), and never on logged-in/health routes. */}
+      {marketing && PIXEL_ID && !sensitive && (
+        <Script
+          id="fb-pixel"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              !function(f,b,e,v,n,t,s)
+              {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+              if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+              n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];
+              s.parentNode.insertBefore(t,s)}(window, document,'script',
+              'https://connect.facebook.net/en_US/fbevents.js');
+              fbq('init', '${PIXEL_ID}');
+              fbq('track', 'PageView');
+            `,
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/analytics/CookieConsent.tsx
+++ b/src/components/analytics/CookieConsent.tsx
@@ -2,14 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { FiX, FiShield } from 'react-icons/fi';
-
-const COOKIE_CONSENT_KEY = 'carelinkai_cookie_consent';
-
-type ConsentPreferences = {
-  necessary: boolean;
-  analytics: boolean;
-  marketing: boolean;
-};
+import { getConsent, setConsent, type ConsentPreferences } from '@/lib/consent';
 
 export default function CookieConsent() {
   const [showBanner, setShowBanner] = useState(false);
@@ -21,43 +14,22 @@ export default function CookieConsent() {
   });
 
   useEffect(() => {
-    // Check if user has already consented
-    const consent = localStorage.getItem(COOKIE_CONSENT_KEY);
-    if (!consent) {
-      // Show banner after a short delay for better UX
+    // Show the banner only until the user makes an explicit choice. No tracker
+    // fires before that — AnalyticsScripts loads nothing until consent is set.
+    const existing = getConsent();
+    if (!existing) {
       const timer = setTimeout(() => setShowBanner(true), 1000);
       return () => clearTimeout(timer);
-    } else {
-      // Load existing preferences
-      try {
-        const saved = JSON.parse(consent);
-        setPreferences(saved);
-        // Apply saved preferences
-        applyConsent(saved);
-      } catch (e) {
-        console.error('Failed to parse cookie consent:', e);
-      }
-      return undefined;
     }
+    setPreferences(existing);
+    return undefined;
   }, []);
 
-  const applyConsent = (prefs: ConsentPreferences) => {
-    // Enable/disable analytics based on consent
-    if (typeof window !== 'undefined') {
-      (window as any)['ga-disable-' + process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID] = !prefs.analytics;
-      
-      // Facebook Pixel consent
-      if (prefs.marketing && (window as any).fbq) {
-        (window as any).fbq('consent', 'grant');
-      } else if ((window as any).fbq) {
-        (window as any).fbq('consent', 'revoke');
-      }
-    }
-  };
-
   const savePreferences = (prefs: ConsentPreferences) => {
-    localStorage.setItem(COOKIE_CONSENT_KEY, JSON.stringify(prefs));
-    applyConsent(prefs);
+    // Persist + dispatch the consent-changed event so AnalyticsScripts loads
+    // the opted-in trackers immediately (no reload needed).
+    setConsent(prefs);
+    setPreferences(prefs);
     setShowBanner(false);
   };
 

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,53 @@
+/**
+ * Cookie-consent state shared between the banner and the analytics loader.
+ *
+ * No third-party tracker (GA4/GTM, Meta Pixel, Microsoft Clarity) may load
+ * until the user opts in. `AnalyticsScripts` reads this and only injects the
+ * relevant <Script> tags once consent is granted; the banner writes it and
+ * dispatches `CONSENT_EVENT` so loading happens immediately (no reload).
+ *
+ * Client-only (uses localStorage / window). Guards for SSR.
+ */
+
+export const CONSENT_KEY = 'carelinkai_cookie_consent';
+export const CONSENT_EVENT = 'carelinkai-consent-changed';
+
+export type ConsentPreferences = {
+  necessary: boolean; // always true; not gated
+  analytics: boolean; // GA4 + GTM + Microsoft Clarity
+  marketing: boolean; // Meta/Facebook Pixel
+};
+
+export const DENY_ALL: ConsentPreferences = {
+  necessary: true,
+  analytics: false,
+  marketing: false,
+};
+
+/** Read stored consent, or null if the user hasn't chosen yet. */
+export function getConsent(): ConsentPreferences | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(CONSENT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return {
+      necessary: true,
+      analytics: parsed?.analytics === true,
+      marketing: parsed?.marketing === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Persist consent and notify listeners (so trackers load without a reload). */
+export function setConsent(prefs: ConsentPreferences): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(CONSENT_KEY, JSON.stringify(prefs));
+    window.dispatchEvent(new CustomEvent(CONSENT_EVENT, { detail: prefs }));
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Summary
Gates **all third-party trackers behind cookie consent** (OL-078). On a HIPAA-positioned site, Meta Pixel / Microsoft Clarity / GA4 / GTM were loading **unconditionally** in `layout.tsx` (`afterInteractive`, gated only by env-var presence); the existing `CookieConsent` banner was cosmetic — it flipped `ga-disable`/`fbq consent` only *after* the scripts had already loaded and fired the initial PageView/session.

## Changes
- **`src/lib/consent.ts`** — shared consent state + `CONSENT_EVENT`.
- **`src/components/analytics/AnalyticsScripts.tsx`** (client) — injects trackers **only after explicit consent**, reacts to `CONSENT_EVENT` (loads on opt-in, no reload). **Nothing fires pre-consent.** Removed the unconditional `<Script>` blocks from `layout.tsx` (and the GTM `<noscript>`, which would bypass the JS gate).
- **(a) Consent gate:** GA4 + GTM behind **analytics** consent; Pixel behind **marketing** consent; Clarity behind **analytics** consent. Default = nothing.
- **(b) Clarity masking + sensitive-page exclusion:** site-wide `data-clarity-mask="true"` on `<body>` (masks all text/inputs); Clarity not initially loaded on sensitive routes (auth + resident/care + logged-in app areas). *(Founder action: also set Clarity dashboard masking to Strict.)*
- **(c) Pixel restriction:** **PageView only** (no custom events in the loader); excluded from logged-in operator/family + health/care routes via `SENSITIVE_PREFIXES`.
- `CookieConsent` refactored to the shared helper (Accept All / Necessary Only / Customize), dispatching the consent event.

## Verification
`tsc` clean · `npm run build` passes · `next lint` clean. **To confirm on the preview:** with no stored consent, the network tab shows **no** requests to `googletagmanager.com` / `connect.facebook.net` / `clarity.ms` until you opt in; after "Accept All" they load without a reload.

Closes **OL-078**. (Companion: #576 — operator-claim founder email.)

https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_