### PR TITLE
feat(claims): instant founder email on operator/admin claim (OL-079)

### DIFF
--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -152,6 +152,17 @@ Each loop: what it is, why it matters, what done looks like.
   - `CookieConsent` refactored to use the shared helper (Accept All / Necessary Only / Customize) and dispatch the consent event.
 - **Verify:** with no stored consent, the network tab shows no requests to googletagmanager.com / connect.facebook.net / clarity.ms until the user opts in. `tsc` clean, build passes, lint clean.
 
+### OL-079: Operator-claim → instant email notification
+- **Status:** ✅ CLOSED (2026-06-18, PR `feat/claim-notification`).
+- **What it was:** When a home was claimed (operator self-claim onboarding → `ACTIVE`, or admin claim → `PENDING_REVIEW`), the founder had no real-time signal — claims had to be discovered by checking the backend. #576 had added a basic `sendOperatorClaimNotification`, but it sent to `chris@getcarelinkai.com` only, used a plain subject, omitted operator name / timestamp / deep link, had no idempotency on the admin path, and failures were only `console.error`'d (no Sentry).
+- **Fix:**
+  - `src/lib/email.ts` — `sendOperatorClaimNotification` now: **To** `profyt7@gmail.com` (override `CLAIM_NOTIFY_EMAIL`), **cc** `chris@getcarelinkai.com` (override/disable via `CLAIM_NOTIFY_CC=''`); subject `🎉 New CareLinkAI claim — <facility>`; body includes facility, operator name + email, **America/New_York** timestamp (`Intl.DateTimeFormat` ET), and a deep link to the admin home view (`${NEXT_PUBLIC_APP_URL||NEXTAUTH_URL}/admin/homes/<id>`). Non-blocking + `RESEND_API_KEY` guard preserved; failures now also `captureError` to **Sentry** (`feature: claim-notification`).
+  - `src/app/api/operator/homes/[id]/claim/route.ts` — passes `operatorName` + `homeId`. Idempotent by construction (the `seededHomeId` guard means a seeded home can only be claimed once; it's nulled in the same transaction).
+  - `src/app/api/admin/homes/[id]/claim/route.ts` — captures `wasAlreadyPendingReview = home.status === 'PENDING_REVIEW'` before the update and only fires the notification on a real transition INTO `PENDING_REVIEW`, so re-claiming/reassigning an already-pending home never double-sends. Passes `operatorName` + `homeId`.
+- **No schema migration** (idempotency via state-transition guards, not a dedicated sent-flag column).
+- **Residual edge:** two truly-concurrent admin claims on the same home could both observe the pre-update status and double-send; acceptable for a low-volume founder alert (no DB-level dedupe added).
+- **Verify:** `tsc --noEmit` clean, `npm run build` passes.
+
 ### OL-027: Provider listing fee ($99/mo)
 - **Status:** ✅ CLOSED (2026-05-02)
 - Schema fields + migration, Stripe Checkout + Customer Portal APIs, webhook handler, visibility gate in marketplace API, billing UI at `/settings/provider/billing`. Requires `STRIPE_PRICE_PROVIDER_LISTING` env var in Render.

--- a/context/DEV_SESSION_SUMMARIES.md
+++ b/context/DEV_SESSION_SUMMARIES.md
@@ -1564,4 +1564,17 @@
 - **Loops:** OL-078 closed (added + closed). 
 - **Recommended next step:** verify in prod/preview network tab that no tracker requests fire pre-consent; set Clarity dashboard masking to Strict.
 
+### 2026-06-18 — OL-079: operator-claim → instant founder email (Resend + Sentry)
+- **Objective:** Fire a real-time email the moment a home is claimed (operator self-claim → ACTIVE, and admin claim → PENDING_REVIEW), idempotent and non-blocking.
+- **Work completed:**
+  - `src/lib/email.ts` — upgraded `sendOperatorClaimNotification`: To `profyt7@gmail.com` (`CLAIM_NOTIFY_EMAIL`), cc `chris@getcarelinkai.com` (`CLAIM_NOTIFY_CC`, `''` disables); subject `🎉 New CareLinkAI claim — <facility>`; body now carries facility, operator name + email, America/New_York timestamp, and an admin deep link (`/admin/homes/<id>`). Failures `captureError` → Sentry (`feature: claim-notification`); still `RESEND_API_KEY`-guarded and fire-and-forget.
+  - `src/app/api/operator/homes/[id]/claim/route.ts` — passes `operatorName` + `homeId`; idempotent via the existing `seededHomeId` one-shot guard.
+  - `src/app/api/admin/homes/[id]/claim/route.ts` — added `wasAlreadyPendingReview` transition-guard so notification only fires on a real claim into PENDING_REVIEW (no double-send on reassignment); passes `operatorName` + `homeId`.
+- **Files changed:** `src/lib/email.ts`, `src/app/api/operator/homes/[id]/claim/route.ts`, `src/app/api/admin/homes/[id]/claim/route.ts`, `context/CARELINKAI_TECH_OPEN_LOOPS.md`, `context/DEV_SESSION_SUMMARIES.md`.
+- **Commands run:** `npx tsc --noEmit` (clean), `npm run build` (passes).
+- **Tests/build:** `tsc` clean; `npm run build` passes.
+- **Deployment impact:** No schema migration. Optional new env vars `CLAIM_NOTIFY_EMAIL` / `CLAIM_NOTIFY_CC` (both have sensible defaults). Relies on existing `RESEND_API_KEY` / `EMAIL_FROM` and `NEXT_PUBLIC_APP_URL`/`NEXTAUTH_URL` for the deep link.
+- **New risks/blockers:** Residual: two truly-concurrent admin claims on the same home could both pre-read the old status and double-send — acceptable for a low-volume founder alert.
+- **Recommended next step:** after deploy, do a live claim (or admin claim) and confirm the 🎉 email lands at profyt7@gmail.com with a working admin deep link.
+
 <!-- Add new sessions above this line, newest first -->

--- a/src/app/api/admin/homes/[id]/claim/route.ts
+++ b/src/app/api/admin/homes/[id]/claim/route.ts
@@ -66,6 +66,11 @@ export async function POST(
     }
 
     const previousOperatorId = home.operatorId;
+    // Idempotency guard for the claim notification: only notify when the home is
+    // actually transitioning INTO PENDING_REVIEW. Re-running an admin claim on a
+    // home that's already PENDING_REVIEW (e.g. reassigning operators) is a no-op
+    // for the founder alert and must not double-send (OL-079).
+    const wasAlreadyPendingReview = home.status === 'PENDING_REVIEW';
 
     // Reassign the listing to the operator and queue it for review
     const updatedHome = await prisma.assistedLivingHome.update({
@@ -117,12 +122,18 @@ export async function POST(
       }
     );
 
-    // Surface the claim to the founder/admin in real time (non-blocking).
-    void sendOperatorClaimNotification({
-      facilityName: home.name,
-      operatorEmail: operator.user?.email ?? 'unknown',
-      status: 'PENDING_REVIEW',
-    }).catch((e) => console.error('[admin claim] founder notification failed', e));
+    // Surface the claim to the founder/admin in real time (non-blocking, OL-079).
+    // Skip if the home was already PENDING_REVIEW — no real claim transition.
+    if (!wasAlreadyPendingReview) {
+      void sendOperatorClaimNotification({
+        facilityName: home.name,
+        operatorEmail: operator.user?.email ?? 'unknown',
+        operatorName:
+          [operator.user?.firstName, operator.user?.lastName].filter(Boolean).join(' ') || undefined,
+        homeId: home.id,
+        status: 'PENDING_REVIEW',
+      }).catch((e) => console.error('[admin claim] founder notification failed', e));
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/operator/homes/[id]/claim/route.ts
+++ b/src/app/api/operator/homes/[id]/claim/route.ts
@@ -96,10 +96,15 @@ export async function POST(
     }),
   ]);
 
-  // Surface the claim to the founder/admin in real time (non-blocking).
+  // Surface the claim to the founder/admin in real time (non-blocking, OL-079).
+  // Idempotent by construction: the seededHomeId guard above means a given
+  // seeded home can only be successfully claimed once (it's nulled in the same
+  // transaction), so this path never double-sends.
   void sendOperatorClaimNotification({
     facilityName: updatedHome.name,
     operatorEmail: user.email!,
+    operatorName: [user.firstName, user.lastName].filter(Boolean).join(' ') || undefined,
+    homeId: updatedHome.id,
     status: 'ACTIVE',
   }).catch((e) => console.error('[claim] founder notification failed', e));
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -12,6 +12,7 @@
  */
 
 import { Resend } from 'resend';
+import { captureError } from '@/lib/sentry';
 
 // Initialize Resend with API key from environment
 const resend = new Resend(process.env.RESEND_API_KEY);
@@ -83,19 +84,31 @@ function escapeHtml(s: string): string {
 }
 
 /**
- * Notify the founder/admin that an operator completed a listing claim, so
- * claims surface in real time without checking the backend. Fire-and-forget
- * from the claim routes (failures are logged, never block the claim).
+ * Notify the founder/admin the instant an operator claims a listing (either via
+ * the operator self-claim onboarding flow or an admin claim), so claims surface
+ * in real time without polling the backend (OL-079).
  *
- * Recipient defaults to chris@getcarelinkai.com, overridable via
- * CLAIM_NOTIFY_EMAIL.
+ * Fire-and-forget from the claim routes: failures are logged AND reported to
+ * Sentry, but never block the claim itself (the caller never awaits the result
+ * in a way that affects the response).
+ *
+ * Recipient defaults to profyt7@gmail.com (overridable via CLAIM_NOTIFY_EMAIL),
+ * cc'd to chris@getcarelinkai.com (overridable / disableable via
+ * CLAIM_NOTIFY_CC — set to empty string to drop the cc).
  */
 export async function sendOperatorClaimNotification(args: {
   facilityName: string;
   operatorEmail: string;
+  /** Display name of the claiming operator, if known. */
+  operatorName?: string;
+  /** Home id used to build the admin deep link (/admin/homes/<id>). */
+  homeId?: string;
   status?: string;
 }): Promise<boolean> {
-  const to = process.env.CLAIM_NOTIFY_EMAIL || 'chris@getcarelinkai.com';
+  const to = process.env.CLAIM_NOTIFY_EMAIL || 'profyt7@gmail.com';
+  // cc defaults to chris@; CLAIM_NOTIFY_CC='' explicitly drops it.
+  const ccRaw = process.env.CLAIM_NOTIFY_CC ?? 'chris@getcarelinkai.com';
+  const cc = ccRaw.trim() ? [ccRaw.trim()] : undefined;
   try {
     if (!process.env.RESEND_API_KEY) {
       console.error('[Resend] RESEND_API_KEY not configured — skipping operator claim notification');
@@ -103,36 +116,64 @@ export async function sendOperatorClaimNotification(args: {
     }
     const facilityName = args.facilityName || '(unnamed facility)';
     const operatorEmail = args.operatorEmail || '(unknown operator)';
+    const operatorName = args.operatorName?.trim();
     const status = args.status;
+
+    // Timestamp rendered in America/New_York (founder's timezone).
+    const claimedAt = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/New_York',
+      dateStyle: 'full',
+      timeStyle: 'short',
+    }).format(new Date()) + ' ET';
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com';
+    const adminLink = args.homeId ? `${appUrl.replace(/\/$/, '')}/admin/homes/${args.homeId}` : null;
+
+    const operatorLine = operatorName
+      ? `${operatorName} <${operatorEmail}>`
+      : operatorEmail;
 
     const { data, error } = await resend.emails.send({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [to],
-      subject: `New operator claim: ${facilityName}`,
+      ...(cc ? { cc } : {}),
+      subject: `🎉 New CareLinkAI claim — ${facilityName}`,
       text:
         `An operator just claimed a listing on CareLinkAI.\n\n` +
         `Facility: ${facilityName}\n` +
-        `Operator: ${operatorEmail}\n` +
+        `Operator: ${operatorLine}\n` +
         (status ? `Status: ${status}\n` : '') +
-        `\nReview it in the admin panel.`,
+        `Claimed: ${claimedAt}\n` +
+        (adminLink ? `\nReview it: ${adminLink}\n` : `\nReview it in the admin panel.\n`),
       html:
-        `<p>An operator just claimed a listing on CareLinkAI.</p>` +
+        `<p>An operator just claimed a listing on CareLinkAI. 🎉</p>` +
         `<ul>` +
         `<li><strong>Facility:</strong> ${escapeHtml(facilityName)}</li>` +
-        `<li><strong>Operator:</strong> ${escapeHtml(operatorEmail)}</li>` +
+        `<li><strong>Operator:</strong> ${escapeHtml(operatorLine)}</li>` +
         (status ? `<li><strong>Status:</strong> ${escapeHtml(status)}</li>` : '') +
+        `<li><strong>Claimed:</strong> ${escapeHtml(claimedAt)}</li>` +
         `</ul>` +
-        `<p>Review it in the admin panel.</p>`,
+        (adminLink
+          ? `<p><a href="${escapeHtml(adminLink)}">Review it in the admin panel →</a></p>`
+          : `<p>Review it in the admin panel.</p>`),
     });
 
     if (error) {
       console.error('[Resend] Error sending operator claim notification:', error);
+      captureError(
+        error instanceof Error ? error : new Error(String((error as { message?: string })?.message ?? error)),
+        { tags: { feature: 'claim-notification' }, extra: { facilityName, homeId: args.homeId, status } }
+      );
       return false;
     }
     console.log('[Resend] ✅ Operator claim notification sent. Email ID:', data?.id);
     return true;
   } catch (error) {
     console.error('[Resend] Exception sending operator claim notification:', error);
+    captureError(error instanceof Error ? error : new Error(String(error)), {
+      tags: { feature: 'claim-notification' },
+      extra: { facilityName: args.facilityName, homeId: args.homeId, status: args.status },
+    });
     return false;
   }
 }


### PR DESCRIPTION
## OL-079: operator-claim → instant email notification

Fires a real-time email the moment a home is claimed, covering **both** claim paths:
- operator self-claim onboarding (`POST /api/operator/homes/[id]/claim` → `ACTIVE`)
- admin claim (`POST /api/admin/homes/[id]/claim` → `PENDING_REVIEW`)

### What changed
- **`src/lib/email.ts`** — `sendOperatorClaimNotification` upgraded:
  - **To** `profyt7@gmail.com` (override `CLAIM_NOTIFY_EMAIL`), **cc** `chris@getcarelinkai.com` (override/disable via `CLAIM_NOTIFY_CC=''`)
  - Subject: `🎉 New CareLinkAI claim — <facility>`
  - Body: facility, operator **name + email**, timestamp in **America/New_York** (ET), and a deep link to the **admin home view** (`${NEXT_PUBLIC_APP_URL||NEXTAUTH_URL}/admin/homes/<id>`)
  - Non-blocking + `RESEND_API_KEY` guard preserved; failures now also `captureError` → **Sentry** (`feature: claim-notification`)
- **`src/app/api/operator/homes/[id]/claim/route.ts`** — passes `operatorName` + `homeId`. Idempotent by construction (the `seededHomeId` guard means a seeded home is claimable once; it's nulled in the same transaction).
- **`src/app/api/admin/homes/[id]/claim/route.ts`** — captures `wasAlreadyPendingReview` before the update and only fires on a real transition **into** `PENDING_REVIEW`, so re-claiming/reassigning an already-pending home never double-sends. Passes `operatorName` + `homeId`.

### Idempotent + non-blocking
- No schema migration — idempotency via state-transition guards, not a sent-flag column.
- Claim always succeeds even if the email fails (fire-and-forget, caught, reported to Sentry).
- **Residual edge:** two truly-concurrent admin claims on the same home could both pre-read the old status and double-send — acceptable for a low-volume founder alert.

### Verification
- `npx tsc --noEmit` — clean
- `npm run build` — passes

Docs: closed OL-079 in `context/CARELINKAI_TECH_OPEN_LOOPS.md`; session entry appended to `context/DEV_SESSION_SUMMARIES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_