### PR TITLE
chore(outreach): stage batch-2 Cleveland supply (seed + enrich runbook)

### DIFF
--- a/context/BATCH2_ENRICH_RUNBOOK.md
+++ b/context/BATCH2_ENRICH_RUNBOOK.md
@@ -1,0 +1,154 @@
+# Batch 2 — Seed + Enrich Runbook (Cleveland founder cohort)
+
+Branch: `chore/batch2-enrich` · Created: 2026-06-19
+Pairs with vault doc: `ChrisOS/03_Execution/cleveland_outreach/batch2_supply_prep.md`
+
+This runbook stages **batch 2** of the Cleveland operator outreach: seed the
+15 web-researched candidate facilities as DRAFT, enrich them via the PR #545
+auto-populator, and hand Cowork the locked `{homeId, name, city, status}` set.
+
+> **Where this runs:** the seed + enrich steps write to the **production DB** and
+> call **Anthropic + Google Places + Cloudinary** — so they run in the **Render
+> shell**, not a code sandbox (which has none of those). The scripts below are on
+> this branch; deploy/checkout the branch on Render to run them. Keep everything
+> **DRAFT** — do **not** send email or publish listings until research + review.
+
+---
+
+## Cross-check result (steps 1–2)
+
+**Batch-2 candidate pool = 15 web-researched facilities** (from `batch2_supply_prep.md`).
+Cross-checked by name + city against the canonical `TIER_A[]` (50 OH-DOH homes in
+`scripts/seed-cleveland-directory.ts`):
+
+**All 15 are NEW** — none are in the Tier-A seed list, and none overlap batch 1
+(which covered Twinsburg, Euclid, Newbury, Parma, Richfield, Chardon, Hudson,
+Olmsted Falls, Willoughby, Lakewood, N. Ridgeville, Copley, Cuyahoga Falls, Bath).
+So **step 2 = seed all 15** (done by `scripts/seed-cleveland-batch2.ts`).
+
+| # | Facility | City | County | In Tier-A seed? |
+|---|---|---|---|---|
+| 1 | Rose Senior Living Beachwood | Beachwood | Cuyahoga | new |
+| 2 | Windsor Heights | Beachwood | Cuyahoga | new |
+| 3 | Beachwood Commons | Beachwood | Cuyahoga | new |
+| 4 | Solon Pointe | Solon | Cuyahoga | new |
+| 5 | Vitalia Active Adult - Solon | Solon | Cuyahoga | new (verify AL vs IL-only) |
+| 6 | Fairmont of Westlake | Westlake | Cuyahoga | new |
+| 7 | Bickford of Rocky River | Rocky River | Cuyahoga | new |
+| 8 | Rocky River Village | Rocky River | Cuyahoga | new |
+| 9 | Embassy of Rockport | Rocky River | Cuyahoga | new |
+| 10 | Vitalia Strongsville | Strongsville | Cuyahoga | new |
+| 11 | Anthology of Mayfield Heights | Mayfield Heights | Cuyahoga | new |
+| 12 | Villa Serena | Mayfield Heights | Cuyahoga | new |
+| 13 | Symphony at Mentor | Mentor | Lake | new |
+| 14 | Vista Springs Ravinia Estate | Independence | Cuyahoga | new |
+| 15 | Jennings at Brecksville | Brecksville | Cuyahoga | new |
+
+### Step 1 — "seeded Tier-A DRAFT homes NOT in batch 1"
+
+The batch-2 SEND set is the 15 above. Separately, the ~35 already-seeded Tier-A
+homes that batch 1 didn't use are still DRAFT in the DB. The authoritative,
+DB-backed list of everything not-yet-sent (enriched=no) is:
+
+```bash
+npx tsx scripts/report-directory-homes.ts --unenriched
+```
+
+(`enriched=no` ⇒ `autoPopulatedAt IS NULL` ⇒ never run through the pipeline ⇒
+not part of an already-sent batch. The exact batch-1 15 can't be derived from
+the seed list alone because several batch-1 cities — Parma, Chardon, Copley —
+map to multiple Tier-A homes; the enrich flag is the reliable signal.)
+
+---
+
+## Render command sequence
+
+All commands assume the `chore/batch2-enrich` branch is checked out on Render
+and env vars are set: `DATABASE_URL`, `ANTHROPIC_API_KEY`, `GOOGLE_PLACES_API_KEY`,
+`CLOUDINARY_CLOUD_NAME/API_KEY/API_SECRET`.
+
+### 1. Seed the 15 batch-2 homes (DRAFT) + discover websites
+
+```bash
+# Preview first (no writes):
+npx tsx scripts/seed-cleveland-batch2.ts --dry-run
+
+# Live seed:
+npx tsx scripts/seed-cleveland-batch2.ts
+
+# Backfill website URLs via Google Places (idempotent; safe to re-run):
+npx tsx scripts/seed-cleveland-batch2.ts --with-websites
+```
+
+Idempotent: re-running skips homes already seeded (deduped by name under the
+"CareLinkAI Directory - Unclaimed Listings" operator).
+
+### 2. Build the enrich CSV from the seeded rows
+
+`autopopulate-cohort.ts --from-db` only targets homes that are **already**
+auto-populated, so the **first** enrich pass on fresh batch-2 homes needs a CSV.
+Generate it from the reporter:
+
+```bash
+# Dump the directory homes as TSV, keep the 15 batch-2 rows (enriched=no, has a website):
+npx tsx scripts/report-directory-homes.ts --tsv > /tmp/dir_homes.tsv
+
+# Reshape to the cohort CSV format: homeName,homeId,websiteUrl
+#   (columns from report: homeId<TAB>name<TAB>city<TAB>status<TAB>enriched<TAB>website)
+echo "homeName,homeId,websiteUrl" > /tmp/batch2_websites.csv
+awk -F'\t' 'NR>1 && $5=="no" && $6!="" {print "\""$2"\","$1","$6}' /tmp/dir_homes.tsv >> /tmp/batch2_websites.csv
+cat /tmp/batch2_websites.csv   # eyeball: should be the 15 batch-2 homes
+```
+
+> If a batch-2 home has no website after step 1 (Places miss), add its URL to the
+> CSV by hand before enriching, or it will be skipped.
+
+### 3. Enrich (AI profile + photos→Cloudinary + Places address)
+
+```bash
+# Dry run — shows extracted fields + cost, writes nothing:
+npx tsx scripts/autopopulate-cohort.ts /tmp/batch2_websites.csv --dry-run --with-photos
+
+# Live run — writes profile, addresses, and re-hosted photos:
+npx tsx scripts/autopopulate-cohort.ts /tmp/batch2_websites.csv --force --with-photos
+```
+
+Expected cost ≈ batch 1 (~$0.10/facility text; image classify adds a little).
+Subsequent re-runs can use `--from-db --photos-only` / `--addresses-only` once
+`autoPopulatedAt` is set.
+
+### 4. Spot-check (before handoff)
+
+- **Capacity is NOT auto-filled.** Batch-2 homes are seeded `capacity: 0`
+  ("unknown") and the enrich pipeline does not write capacity — set real bed
+  counts from the Cowork research pass or operator claim. Don't trust `0`.
+- **Name / city mismatches:** confirm the Places-matched address city equals the
+  expected city (table above). Reject wrong-location matches (the pipeline's
+  OL-066 guard helps, but eyeball Vitalia ×2 and the chain communities).
+- **LOW-confidence extractions:** the cohort run prints a "sparse" list — review
+  those listings' descriptions before relying on them.
+- Confirm all 15 are still `status=DRAFT` (not accidentally published).
+
+### 5. Step-4 handoff to Cowork
+
+```bash
+npx tsx scripts/report-directory-homes.ts --tsv
+```
+
+Take the 15 batch-2 rows → `{homeId, name, city, status}` for `batch2_email_research.md`.
+
+> **Phone:** there is no phone column on `AssistedLivingHome` and the enrich
+> pipeline does not persist one, so the `{…, phone, …}` field in the handoff is
+> supplied by Cowork's contact-research pass (it's already part of step 3 in the
+> supply-prep doc). If we want phone stored on the listing, that's a small
+> schema + pipeline change — flagged as a follow-up, out of scope for batch 2.
+
+---
+
+## Guardrails
+
+- Everything stays **DRAFT** until research + review. No emails, no public listings.
+- Claim links (45-day) + Resend "Batch 2" audience are generated **after** the set
+  is locked and reviewed — not in this runbook.
+- Scripts under `scripts/` are excluded from the app build/tsconfig; they were
+  typechecked standalone (strict, clean) on this branch.

--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -163,6 +163,12 @@ Each loop: what it is, why it matters, what done looks like.
 - **Residual edge:** two truly-concurrent admin claims on the same home could both observe the pre-update status and double-send; acceptable for a low-volume founder alert (no DB-level dedupe added).
 - **Verify:** `tsc --noEmit` clean, `npm run build` passes.
 
+### OL-080: Phone (and capacity) not persisted on AssistedLivingHome by the enrich pipeline
+- **Status:** 🔴 OPEN — surfaced 2026-06-19 during batch-2 supply prep (`chore/batch2-enrich`).
+- **What:** `AssistedLivingHome` has **no `phone` column**, and the PR #545 auto-populator (`scripts/autopopulate-cohort.ts`) extracts a phone from the website (`extracted.phone`) but **never writes it** — it's only counted toward `fieldsExtracted`. Same for **capacity**: the pipeline never writes `capacity`, so freshly-seeded homes (e.g. batch-2, seeded `capacity: 0`) stay at their seed value until an operator claim or a manual update. Net effect: the outreach step-4 handoff (`{homeId, name, city, phone, status}`) can't be fully DB-backed — phone has to come from Cowork's manual contact-research pass.
+- **Fix (when prioritized):** add `phone String?` (and optionally a structured capacity refresh) to `AssistedLivingHome` + migration; persist `extracted.phone` in `autopopulate-cohort.ts` (with provenance, like the address fallback); optionally surface it on the admin/operator listing views. Small, self-contained — deferred out of the batch-2 scope on purpose.
+- **Done when:** the enrich pipeline stores a verified phone on the listing and `report-directory-homes.ts` can emit phone directly (no manual research column).
+
 ### OL-027: Provider listing fee ($99/mo)
 - **Status:** ✅ CLOSED (2026-05-02)
 - Schema fields + migration, Stripe Checkout + Customer Portal APIs, webhook handler, visibility gate in marketplace API, billing UI at `/settings/provider/billing`. Requires `STRIPE_PRICE_PROVIDER_LISTING` env var in Render.

--- a/scripts/report-directory-homes.ts
+++ b/scripts/report-directory-homes.ts
@@ -1,0 +1,99 @@
+/**
+ * report-directory-homes.ts
+ *
+ * Read-only reporter for the "CareLinkAI Directory - Unclaimed Listings"
+ * operator. Prints every seeded DRAFT/unclaimed listing with the fields the
+ * outreach pipeline needs:
+ *
+ *   homeId, name, city, status, enriched(yes/no), website
+ *
+ * Use it to:
+ *   - Step 1: see which seeded Tier-A DRAFT homes are NOT yet enriched
+ *             (enriched=no) — i.e. not part of an already-sent batch.
+ *   - Step 4: export the batch-2 set ({homeId, name, city, status}) for the
+ *             Cowork ED/email contact-research pass once enrich has run.
+ *
+ * NOTE: there is no phone column on AssistedLivingHome, and the PR #545 enrich
+ * pipeline does not persist a phone, so "phone" for the step-4 handoff comes
+ * from the Cowork research pass — it is intentionally omitted here.
+ *
+ * City is read from the home's Address; freshly-seeded batch-2 homes show
+ * "(pending)" until the enrich/Places step creates the address row.
+ *
+ * Writes nothing. Safe to run anytime.
+ *
+ * Usage:
+ *   npx tsx scripts/report-directory-homes.ts                 # all directory homes
+ *   npx tsx scripts/report-directory-homes.ts --unenriched    # only enriched=no
+ *   npx tsx scripts/report-directory-homes.ts --tsv           # tab-separated (paste to a sheet)
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const SEED_USER_EMAIL = 'directory-unclaimed@carelinkai.system';
+
+async function main() {
+  const unenrichedOnly = process.argv.includes('--unenriched');
+  const tsv = process.argv.includes('--tsv');
+
+  const seedUser = await prisma.user.findUnique({ where: { email: SEED_USER_EMAIL } });
+  const seedOperator = seedUser
+    ? await prisma.operator.findUnique({ where: { userId: seedUser.id } })
+    : null;
+
+  if (!seedOperator) {
+    console.error('Directory operator not found — has the seed script been run?');
+    process.exit(1);
+  }
+
+  const homes = await prisma.assistedLivingHome.findMany({
+    where: {
+      operatorId: seedOperator.id,
+      ...(unenrichedOnly ? { autoPopulatedAt: null } : {}),
+    },
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      websiteUrl: true,
+      autoPopulatedAt: true,
+      address: { select: { city: true } },
+    },
+    orderBy: [{ autoPopulatedAt: { sort: 'asc', nulls: 'first' } }, { name: 'asc' }],
+  });
+
+  const rows = homes.map((h) => ({
+    homeId: h.id,
+    name: h.name,
+    city: h.address?.city ?? '(pending)',
+    status: h.status,
+    enriched: h.autoPopulatedAt ? 'yes' : 'no',
+    website: h.websiteUrl ?? '',
+  }));
+
+  if (tsv) {
+    console.log(['homeId', 'name', 'city', 'status', 'enriched', 'website'].join('\t'));
+    for (const r of rows) {
+      console.log([r.homeId, r.name, r.city, r.status, r.enriched, r.website].join('\t'));
+    }
+  } else {
+    console.table(rows);
+  }
+
+  const enrichedCount = homes.filter((h) => h.autoPopulatedAt).length;
+  console.log(
+    `\n${homes.length} directory home(s)${unenrichedOnly ? ' (unenriched only)' : ''}: ` +
+    `${enrichedCount} enriched, ${homes.length - enrichedCount} not enriched.`,
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error('ERROR:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/seed-cleveland-batch2.ts
+++ b/scripts/seed-cleveland-batch2.ts
@@ -1,0 +1,242 @@
+/**
+ * seed-cleveland-batch2.ts
+ *
+ * Seeds the Batch 2 Greater-Cleveland assisted-living candidate pool (15
+ * web-researched facilities) as DRAFT listings, attached to the same
+ * placeholder "CareLinkAI Directory - Unclaimed Listings" operator used by
+ * seed-cleveland-directory.ts.
+ *
+ * These 15 were curated by the outreach research pass (Cowork) to widen supply
+ * into Greater-Cleveland suburbs NOT covered by batch 1 (Beachwood, Solon,
+ * Westlake, Rocky River, Strongsville, Mayfield Heights, Mentor, Independence,
+ * Brecksville). None overlap batch 1, and none were in the original Tier-A DOH
+ * seed (scripts/seed-cleveland-directory.ts) — so all 15 are new rows.
+ *
+ * IMPORTANT — capacity:
+ *   Unlike the Tier-A DOH seed (which carries licensed bed counts from public
+ *   records), these chain/community candidates have NO authoritative public bed
+ *   count, so capacity is seeded as 0 ("unknown — verify"). The PR #545 enrich
+ *   pipeline (autopopulate-cohort.ts) does NOT write capacity, so it stays 0
+ *   until set from the Cowork research pass or an operator claim. Do not treat
+ *   capacity 0 as real.
+ *
+ * Listings are DRAFT (NOT publicly visible). careLevel here is a starting hint
+ * from the research notes; the enrich pipeline refines it from the website.
+ *
+ * Idempotent: re-running skips facilities already seeded under the directory
+ * operator (deduped by name).
+ *
+ * Usage:
+ *   npx tsx scripts/seed-cleveland-batch2.ts --dry-run        # preview only
+ *   npx tsx scripts/seed-cleveland-batch2.ts                  # write to DB
+ *   npx tsx scripts/seed-cleveland-batch2.ts --with-websites  # also auto-discover
+ *                                                             # website URLs via
+ *                                                             # Google Places
+ *   (--with-websites requires GOOGLE_PLACES_API_KEY)
+ *
+ * Source: ChrisOS vault 03_Execution/cleveland_outreach/batch2_supply_prep.md
+ * Risk register: Risk 2 (two-sided marketplace cold start).
+ */
+
+import { PrismaClient, CareLevel, HomeStatus, UserRole } from '@prisma/client';
+import { findWebsiteUrl, isAnyLookupConfigured } from '../src/lib/place-lookup';
+
+const prisma = new PrismaClient();
+
+// Be polite to the Places API between lookups.
+const PLACES_DELAY_MS = 250;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const SEED_USER_EMAIL = 'directory-unclaimed@carelinkai.system';
+const SEED_OPERATOR_NAME = 'CareLinkAI Directory - Unclaimed Listings';
+
+interface SeedFacility {
+  name: string;
+  city: string;
+  county: string;
+  /** Starting-hint care levels from the research notes; enrich refines from the website. */
+  careLevel: CareLevel[];
+  /** Optional public-record note (e.g. a known street) carried into the description. */
+  note?: string;
+}
+
+const IL_AL_MC: CareLevel[] = [CareLevel.INDEPENDENT, CareLevel.ASSISTED, CareLevel.MEMORY_CARE];
+const AL_MC: CareLevel[] = [CareLevel.ASSISTED, CareLevel.MEMORY_CARE];
+const IL_AL: CareLevel[] = [CareLevel.INDEPENDENT, CareLevel.ASSISTED];
+const AL: CareLevel[] = [CareLevel.ASSISTED];
+
+// 15 web-researched batch-2 candidates (counties are accurate Ohio geography;
+// all Cuyahoga except Symphony at Mentor, which is Lake).
+const BATCH_2: SeedFacility[] = [
+  { name: 'Rose Senior Living Beachwood', city: 'Beachwood', county: 'Cuyahoga', careLevel: IL_AL_MC, note: 'Atria/Rose' },
+  { name: 'Windsor Heights', city: 'Beachwood', county: 'Cuyahoga', careLevel: AL_MC },
+  { name: 'Beachwood Commons', city: 'Beachwood', county: 'Cuyahoga', careLevel: AL_MC, note: 'New Perspective' },
+  { name: 'Solon Pointe', city: 'Solon', county: 'Cuyahoga', careLevel: IL_AL_MC },
+  { name: 'Vitalia Active Adult - Solon', city: 'Solon', county: 'Cuyahoga', careLevel: IL_AL, note: 'Vitalia/Omni — Active Adult (verify AL vs IL-only)' },
+  { name: 'Fairmont of Westlake', city: 'Westlake', county: 'Cuyahoga', careLevel: AL_MC },
+  { name: 'Bickford of Rocky River', city: 'Rocky River', county: 'Cuyahoga', careLevel: AL_MC, note: '21600 Detroit Rd, 44116' },
+  { name: 'Rocky River Village', city: 'Rocky River', county: 'Cuyahoga', careLevel: AL_MC },
+  { name: 'Embassy of Rockport', city: 'Rocky River', county: 'Cuyahoga', careLevel: IL_AL_MC, note: '20375 Center Ridge Rd' },
+  { name: 'Vitalia Strongsville', city: 'Strongsville', county: 'Cuyahoga', careLevel: AL_MC, note: 'Vitalia/Omni' },
+  { name: 'Anthology of Mayfield Heights', city: 'Mayfield Heights', county: 'Cuyahoga', careLevel: IL_AL_MC, note: 'Anthology' },
+  { name: 'Villa Serena', city: 'Mayfield Heights', county: 'Cuyahoga', careLevel: AL, note: '6-acre campus' },
+  { name: 'Symphony at Mentor', city: 'Mentor', county: 'Lake', careLevel: AL, note: 'near Lake West/Hillcrest' },
+  { name: 'Vista Springs Ravinia Estate', city: 'Independence', county: 'Cuyahoga', careLevel: AL_MC, note: 'Vista Springs — AL/MC/respite' },
+  { name: 'Jennings at Brecksville', city: 'Brecksville', county: 'Cuyahoga', careLevel: IL_AL, note: 'Jennings (faith-based)' },
+];
+
+function descriptionFor(f: SeedFacility): string {
+  return (
+    'Assisted living community in ' + f.city + ', Ohio (' + f.county + ' County). ' +
+    'Unclaimed listing — staged for the CareLinkAI Cleveland operator outreach ' +
+    '(batch 2). Capacity, address, pricing, and amenities are pending the enrich ' +
+    'pass and operator claim. The operator can claim this listing to add photos, ' +
+    'current pricing, amenities, availability, and verified details.' +
+    (f.note ? ' (Research note: ' + f.note + ')' : '')
+  );
+}
+
+/**
+ * Look up and persist a home's website URL via Google Places. Stores only
+ * HIGH/MEDIUM-confidence matches so low-quality guesses don't pollute the data.
+ */
+async function discoverAndStoreWebsite(
+  homeId: string,
+  name: string,
+  city: string,
+): Promise<string> {
+  const result = await findWebsiteUrl({ name, city, state: 'OH' });
+  await sleep(PLACES_DELAY_MS);
+  if (!result) return 'no match';
+  const via = result.source === 'web_search' ? 'web' : 'places';
+  if (result.confidence === 'LOW') return `low-confidence (skipped, ${via}): ${result.url}`;
+  await prisma.assistedLivingHome.update({
+    where: { id: homeId },
+    data: { websiteUrl: result.url },
+  });
+  return `${result.confidence} via ${via}: ${result.url}`;
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const withWebsites = process.argv.includes('--with-websites');
+  console.log(dryRun ? '=== DRY RUN - no writes ===' : '=== LIVE RUN ===');
+  if (withWebsites) {
+    if (!isAnyLookupConfigured()) {
+      console.error(
+        'ERROR: --with-websites requires GOOGLE_PLACES_API_KEY (Places) and/or ' +
+        'GOOGLE_SEARCH_ENGINE_ID + an API key (web-search fallback).',
+      );
+      process.exit(1);
+    }
+    console.log('=== Website discovery ENABLED (Google Places + web-search fallback) ===');
+  }
+  console.log('Batch 2 facilities to seed: ' + BATCH_2.length + '\n');
+
+  // 1. Seed User (system placeholder; shared with seed-cleveland-directory.ts)
+  let seedUser;
+  if (dryRun) {
+    seedUser = await prisma.user.findUnique({ where: { email: SEED_USER_EMAIL } });
+    console.log('Seed user: ' + (seedUser ? 'exists (' + seedUser.id + ')' : 'WOULD CREATE'));
+  } else {
+    seedUser = await prisma.user.upsert({
+      where: { email: SEED_USER_EMAIL },
+      update: {},
+      create: {
+        email: SEED_USER_EMAIL,
+        firstName: 'CareLinkAI',
+        lastName: 'Directory (Unclaimed)',
+        role: UserRole.OPERATOR,
+      },
+    });
+    console.log('Seed user ready: ' + seedUser.id);
+  }
+
+  // 2. Seed Operator
+  let seedOperator;
+  if (dryRun) {
+    seedOperator = seedUser
+      ? await prisma.operator.findUnique({ where: { userId: seedUser.id } })
+      : null;
+    console.log('Seed operator: ' + (seedOperator ? 'exists (' + seedOperator.id + ')' : 'WOULD CREATE') + '\n');
+  } else {
+    if (!seedUser) throw new Error('Seed user was not initialized.');
+    seedOperator = await prisma.operator.upsert({
+      where: { userId: seedUser.id },
+      update: {},
+      create: { userId: seedUser.id, companyName: SEED_OPERATOR_NAME },
+    });
+    console.log('Seed operator ready: ' + seedOperator.id + '\n');
+  }
+
+  // 3. Seed the facilities as DRAFT listings
+  let created = 0;
+  let skipped = 0;
+  for (const f of BATCH_2) {
+    const existing = seedOperator
+      ? await prisma.assistedLivingHome.findFirst({
+          where: { name: f.name, operatorId: seedOperator.id },
+        })
+      : null;
+    if (existing) {
+      if (withWebsites && !dryRun && !existing.websiteUrl) {
+        const status = await discoverAndStoreWebsite(existing.id, f.name, f.city);
+        console.log('SKIP  (exists): ' + f.name + ' — website ' + status);
+      } else {
+        console.log('SKIP  (exists): ' + f.name);
+      }
+      skipped++;
+      continue;
+    }
+    if (dryRun) {
+      console.log(
+        'WOULD CREATE:   ' + f.name + ' (' + f.city + ')' +
+        (withWebsites ? ' [+website lookup]' : ''),
+      );
+      created++;
+      continue;
+    }
+    if (!seedOperator) throw new Error('Seed operator was not initialized.');
+    const home = await prisma.assistedLivingHome.create({
+      data: {
+        operatorId: seedOperator.id,
+        name: f.name,
+        description: descriptionFor(f),
+        capacity: 0, // unknown at seed time — verify in research/claim (see header note)
+        status: HomeStatus.DRAFT,
+        careLevel: f.careLevel,
+      },
+    });
+    let websiteNote = '';
+    if (withWebsites) {
+      const status = await discoverAndStoreWebsite(home.id, f.name, f.city);
+      websiteNote = ' — website ' + status;
+    }
+    console.log('CREATED:        ' + f.name + ' (' + f.city + ')' + websiteNote);
+    created++;
+  }
+
+  console.log('\n=== Summary ===');
+  console.log((dryRun ? 'Would create' : 'Created') + ': ' + created);
+  console.log('Skipped (already seeded): ' + skipped);
+
+  if (!dryRun && seedOperator) {
+    const total = await prisma.assistedLivingHome.count({
+      where: { operatorId: seedOperator.id },
+    });
+    const nonDraft = await prisma.assistedLivingHome.count({
+      where: { operatorId: seedOperator.id, status: { not: HomeStatus.DRAFT } },
+    });
+    console.log('Total listings under directory operator: ' + total);
+    console.log('Non-DRAFT (publicly visible) under directory operator: ' + nonDraft + ' (expected 0)');
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error('ERROR:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Batch 2 — Cleveland founder cohort supply prep

Stages the next wave of operator outreach: seed the 15 web-researched candidate facilities as DRAFT, enrich them via the PR #545 auto-populator, and hand Cowork a locked `{homeId, name, city, status}` set. Pairs with the vault doc `cleveland_outreach/batch2_supply_prep.md`.

### Cross-check result (steps 1–2)
Checked the 15 candidates by name + city against the canonical `TIER_A[]` (50 OH-DOH homes in `seed-cleveland-directory.ts`): **all 15 are new** — none in the Tier-A seed, none overlap batch 1's cities. So the batch-2 set = seed all 15.

### What's in this PR (no app code touched)
- **`scripts/seed-cleveland-batch2.ts`** — seeds the 15 candidates as DRAFT under the existing "Directory – Unclaimed Listings" operator. Idempotent; `--dry-run` / `--with-websites`. Accurate counties, care-level hints from the research notes, `capacity: 0` sentinel (unknown — pipeline doesn't write capacity).
- **`scripts/report-directory-homes.ts`** — read-only reporter for the directory operator's homes (`{homeId, name, city, status, enriched, website}`); `--unenriched` (step 1) and `--tsv` (step-4 handoff) modes.
- **`context/BATCH2_ENRICH_RUNBOOK.md`** — cross-check table, step-1 analysis, and the exact Render-shell seed→website→enrich→spot-check→handoff command sequence.
- **`context/CARELINKAI_TECH_OPEN_LOOPS.md`** — logs **OL-080** (phone/capacity not persisted by the enrich pipeline).

### Where it runs
Seed + enrich write to the **production DB** and call **Anthropic + Google Places + Cloudinary** — so they run on the **Render shell** (the code sandbox has none of those). This branch makes it a copy-paste run. Scripts are excluded from the app tsconfig; both were typechecked standalone (strict, clean).

### Guardrails
Everything stays **DRAFT** — no emails sent, no public listings generated. Claim links + Resend audience happen only after the set is locked and reviewed.

### Known follow-up (OL-080)
`AssistedLivingHome` has no `phone` column and the pipeline persists neither phone nor capacity, so the step-4 handoff's phone comes from Cowork's research pass. Deferred out of batch-2 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_