### PR TITLE
docs: session wrap 2026-06-21 — batch-2 cleanup + address backfill

### DIFF
--- a/context/CARELINKAI_TECHNICAL_STATE.md
+++ b/context/CARELINKAI_TECHNICAL_STATE.md
@@ -1,8 +1,8 @@
 # CareLinkAI — Technical State
-_Last updated: 2026-06-16_
+_Last updated: 2026-06-21_
 
 ## Active Branch
-`main` — PRs #564–#568 merged (discharge-planner fix, inquiry 400, How-To hub + full 29-guide content, /help links). Pending PRs (2026-06-16): #569 `fix/family-emergency-page` (OL-072) and `feat/education-hub-tabs` (OL-073). Also pending: `chore/remove-non-cleveland-demo-data` (not yet a PR).
+`main` — latest merges: #578 (OL-079 instant claim email), #579 (batch-2 Cleveland supply seed + enrich runbook), **#580 (batch-2 cleanup script, `b19b9c2`)**. Batch-2 cleanup + address backfill executed on the Render production DB 2026-06-21 (see Recent Decisions). Session-wrap committed on `docs/session-wrap-2026-06-21` (fresh off main). ⚠️ `claude/inspiring-mayer-rvgyys` is a stale graveyard branch — do not push onto it (7 conflicts vs main, incl. code already merged via PRs). Earlier (2026-06-16) PRs #564–#568 merged (discharge-planner fix, inquiry 400, How-To hub, /help links).
 
 ## How-To Guides (Education Hub) — content pipeline
 The `/learn` How-To section renders from `src/app/learn/howto/content.ts` (`HOWTO_GUIDES`), role-gated by `src/lib/howto/access.ts` (audience→role; getting-started + family visible to all). That file is **auto-generated** — do not hand-edit. Source content is authored in the ChrisOS vault (`04_CareLinkAI/howto/`), cleaned into an app bundle (`manifest.json` + `content/<role>/*.md`), and transformed by `scripts/generate-howto-content.ts` (`npx tsx scripts/generate-howto-content.ts`). Guide screenshots live under `public/howto/`; the renderer shows only files that exist (build-time `AVAILABLE_HOWTO_IMAGES`), so missing captures are text-first with no 404s. The 71 expected screenshot filenames are checklisted in `public/howto/README.md` (OL-071). **IA (2026-06-16):** `/learn` is split into two tabs via the `?tab=` query param — **How-To & Tutorials** (default) and **Senior Care Guides** (the `GUIDES` articles in `src/app/learn/guides/content.ts`) — so How-To stays one click from the top as the article library grows.
@@ -221,6 +221,12 @@ See `REVENUE_MODEL.md` for the full breakdown. 12 streams finalized:
 - **Provider onboarding welcome email:** Fires after PROVIDER registration (fire-and-forget). 3 steps: complete profile → upload credentials → activate listing. Links corrected to `/settings/provider`, `/settings/provider/credentials`, `/settings/provider/billing`.
 - **Provider profile completeness checklist:** 8-step progress widget on provider dashboard. Shows % complete + progress bar + per-item checklist with direct CTAs. Disappears when all 8 steps done. Credentials quick-action tile added (shows X/3 verified).
 
+## Recent Technical Decisions (2026-06-21 — batch-2 cleanup)
+- **Guarded data-ops via hardcoded-id script, not ad-hoc SQL** — `scripts/cleanup-batch2.ts` (PR #580) is dry-run by default; only deletes/retires a home when it is `status=DRAFT` AND zero-activity across all child relations (inquiries, residents, bookings, tours, placements, waitlist, shifts, reviews, favorites, matches), with a per-target name check so a wrong id can't hit the wrong listing. Anything else is skipped + flagged. Reusable pattern for future cohort cleanups.
+- **INACTIVE is the soft-delete** — no `deletedAt` column on `AssistedLivingHome`; Villa Serena was retired via `status=INACTIVE` (reversible) rather than a hard delete, since it's a real facility just out of AL outreach scope (HUD 202 independent-living).
+- **Address backfill is Places-only and write-additive** — `autopopulate-cohort.ts --addresses-only` uses Google Places (no scrape/AI/photos, $0 Anthropic) and only fills a missing street/zip from a HIGH-confidence match (OL-066 guard rejects wrong-location/low matches); it does not set `autoPopulatedAt`, so backfilled homes stay `enriched=no` until a full enrich.
+- **Stale graveyard branch confirmed** — `claude/inspiring-mayer-rvgyys` carries How-To/discharge-planner work that was independently merged to main via PRs; merging main into it throws 7 conflicts incl. code files. Session-wraps and new work go on fresh branches off main (CLAUDE.md branching discipline), not onto it.
+
 ## Recent Technical Decisions (2026-06-05)
 - **Claim token expiry raised to 7 days (168h)** — 48h was too short for founders to act on email; NEXTAUTH_SECRET rotation is now the only invalidation path
 - **Inline robots.txt parser** — no external dependency; avoids npm dep for a small parsing task
@@ -234,7 +240,7 @@ See `REVENUE_MODEL.md` for the full breakdown. 12 streams finalized:
 - **AGENCY tier added at $799/mo** — shown in wizard Step 4 alongside Starter/Professional/Growth; `STRIPE_PRICE_AGENCY` env var needed
 
 ## Immediate Next Priorities
-0. **Open PRs for branch `claude/inspiring-mayer-rvgyys` (2026-06-15)** — 3 commits: (a) discharge-planner search PrismaClientValidationError + raw-error leak fix (Sentry `2f642d88976448d394ec4d7d9fc10ca0`, OL-067); (b) inquiry-form 400 field-mapping fix (OL-068); (c) role-gated How-To Guides hub at `/learn/howto` (OL-069). All unit-tested (24 passing), full typecheck clean, build passes. When the vault is available, port the 25 source guides into `src/app/learn/howto/content.ts` (OL-069).
+0. **Batch-2 punch list (2026-06-21)** — (a) fix Windsor Heights `websiteUrl` (still points to the wrong Sunshine/Beachwood Retirement site), then full-enrich the 3 address-only homes (Windsor Heights, Bickford, Rocky River Village) once working non-SPA URLs exist; (b) reconcile rebrand names — Bickford of Rocky River → "Bloom of Rocky River" and Rocky River Village → "Meadow Falls of Rocky River" (addresses confirm same buildings; mirror the Anthology→Ashton rename); (c) optional `--addresses-only` pass on The Ashton (shows `city=(pending)` despite enriched=yes). See OL-081.
 1. **Merge non-Cleveland demo homes cleanup** — branch `chore/remove-non-cleveland-demo-data`: create PR, dry-run, then `--force` to delete Golden Years (Chicago), Lakeside Rehab (Seattle), Harbor View (Miami).
 2. **Set `STRIPE_PRICE_AGENCY` in Render (OL-055)** — create $799/mo Agency product in Stripe dashboard, set env var. Agency Stripe Checkout fails without it.
 3. **Cleveland founder end-to-end smoke test (OL-056)** — seed a home, generate claim link, register new operator with claimToken, complete wizard Steps 1-4, verify free access granted, no Stripe redirect.

--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -1,5 +1,5 @@
 # CareLinkAI — Tech Open Loops
-_Last updated: 2026-06-16_
+_Last updated: 2026-06-21_
 
 ## Format
 Each loop: what it is, why it matters, what done looks like.
@@ -43,7 +43,7 @@ Each loop: what it is, why it matters, what done looks like.
 - **Residual:** next time in the Render shell, re-confirm against the live DB that no non-OH DRAFT homes exist. No code work remains.
 
 ### OL-058: Second batch Cleveland facilities auto-population
-- **Status:** 🟡 OPEN — likely progressed by the 2026-06-10 Render auto-population session (photos + addresses backfilled, see OL-060/061); confirm the remaining-cohort count against the live DB to decide if any facilities still need a run.
+- **Status:** 🟡 OPEN — **batch-2 seeded + partially cleaned (2026-06-19/21).** Supply staged via #579; cleanup script #580 applied 2026-06-21 (rename Anthology→Ashton, retire Villa Serena, purge 2 test homes); 3 fixable homes got Places address backfill. Remaining: full text/photo enrich of the 3 address-only homes + the per-home punch list (see **OL-081**).
 - **What:** Identify next set of Cleveland-area AssistedLivingHome records with `websiteUrl` available, create CSV, run `autopopulate-cohort.ts --dry-run` then `--force`.
 - **Note:** The Elms (mapped to "Hudson Elms Skilled Nursing & Rehabilitation Center"), Concordia at Sumner (city/address unresolved), Ohman + O'Neill North Ridgeville (capacity discrepancies) should be manually reviewed before operator outreach.
 - **Done when:** All Cleveland directory homes have `autoPopulatedAt` set or are marked as JS_ONLY/BLOCKED with a note.
@@ -168,6 +168,15 @@ Each loop: what it is, why it matters, what done looks like.
 - **What:** `AssistedLivingHome` has **no `phone` column**, and the PR #545 auto-populator (`scripts/autopopulate-cohort.ts`) extracts a phone from the website (`extracted.phone`) but **never writes it** — it's only counted toward `fieldsExtracted`. Same for **capacity**: the pipeline never writes `capacity`, so freshly-seeded homes (e.g. batch-2, seeded `capacity: 0`) stay at their seed value until an operator claim or a manual update. Net effect: the outreach step-4 handoff (`{homeId, name, city, phone, status}`) can't be fully DB-backed — phone has to come from Cowork's manual contact-research pass.
 - **Fix (when prioritized):** add `phone String?` (and optionally a structured capacity refresh) to `AssistedLivingHome` + migration; persist `extracted.phone` in `autopopulate-cohort.ts` (with provenance, like the address fallback); optionally surface it on the admin/operator listing views. Small, self-contained — deferred out of the batch-2 scope on purpose.
 - **Done when:** the enrich pipeline stores a verified phone on the listing and `report-directory-homes.ts` can emit phone directly (no manual research column).
+
+### OL-081: Batch-2 cohort punch list (post-cleanup, 2026-06-21)
+- **Status:** 🟡 OPEN — cleanup + address backfill done; data-quality follow-ups remain before these homes are outreach-ready. The structural cleanup is **CLOSED**: PR #580 applied on Render (`--force`, Applied: 4) — Anthology→**The Ashton at Mayfield Heights**, Villa Serena→**INACTIVE**, "Test Senior Living Cleveland" + "Chris Senior Care Home" **purged**.
+- **What remains:**
+  1. **Windsor Heights `websiteUrl` is wrong** (`cmql0xbos…`) — stored URL points to the Sunshine/Beachwood Retirement site, not Windsor Heights. Address is correct (23311 Harvard Rd, Beachwood 44122, via Places); the website must be corrected (or cleared) before the listing goes public, and before any full enrich (a wrong URL would scrape the wrong facility).
+  2. **Rebrand name reconciliation** — Bickford of Rocky River (`cmql0xbp9…`) → Places matched **"Bloom of Rocky River"**; Rocky River Village (`cmql0xbpc…`) → matched **"Meadow Falls of Rocky River"**. Same buildings (addresses confirm). Decide canonical names + rename, mirroring Anthology→Ashton.
+  3. **3 homes are `enriched=no`** — Windsor Heights / Bickford / Rocky River Village have verified addresses (Places, `--addresses-only`) but no description/photos. `--addresses-only` does not set `autoPopulatedAt`. Full enrich needs working non-SPA URLs (blocked on #1/#2).
+  4. **The Ashton shows `city=(pending)`** despite `enriched=yes` — one `--addresses-only` pass would backfill its address.
+- **Done when:** Windsor Heights URL fixed, rebrand names reconciled, and the 3 address-only homes fully enriched (or marked JS_ONLY/BLOCKED with a note).
 
 ### OL-027: Provider listing fee ($99/mo)
 - **Status:** ✅ CLOSED (2026-05-02)

--- a/context/DEV_SESSION_SUMMARIES.md
+++ b/context/DEV_SESSION_SUMMARIES.md
@@ -2,6 +2,46 @@
 
 ---
 
+### 2026-06-21 — Batch-2 Cleveland cohort: cleanup + address backfill
+
+- **Objective:** Land the guarded batch-2 cleanup script (PR #580), execute it on the production DB, and backfill addresses for the 3 fixable batch-2 homes — leaving the Cleveland directory cohort clean and outreach-ready.
+
+- **Work completed:**
+  - **PR #580 merged** (squash `b19b9c2`) — `scripts/cleanup-batch2.ts`, a single hardcoded-id, dry-run-by-default data-ops script. CI green (build-and-test, quality, migrate-deploy, Set-Cookie, e2e shards all passed). Merged after a clean dry-run review.
+  - **Cleanup executed on Render (`--force`)** — 4 actions applied, 0 skipped:
+    1. RENAME `cmql0xbpm…` "Anthology of Mayfield Heights" → **"The Ashton at Mayfield Heights"** (Sonida rebrand).
+    2. SOFT-DELETE `cmql0xbpo…` "Villa Serena" → `status=INACTIVE` (HUD 202 independent-living — out of AL outreach scope).
+    3. PURGE (hard delete, cascade) two leftover test homes: "Test Senior Living Cleveland" (`cmptv5deb…`) and "Chris Senior Care Home" (`cmpv5rg35…`). Both verified DRAFT + zero-activity + system directory operator before deletion.
+  - **Address backfill (`autopopulate-cohort.ts --addresses-only --force`)** on the 3 fixable homes — 3/3 succeeded, $0 Anthropic spend (Places-only, no scrape/AI/photos):
+    - Windsor Heights → **23311 Harvard Rd, Beachwood OH 44122** (HIGH).
+    - Bickford of Rocky River → **21600 Detroit Rd, Rocky River OH 44116** (HIGH; Places matched "Bloom of Rocky River" — rebrand).
+    - Rocky River Village → **22900 Center Ridge Rd, Rocky River OH 44116** (HIGH; Places matched "Meadow Falls of Rocky River" — rebrand).
+  - **Step-4 confirmation** via `report-directory-homes.ts --tsv`: Ashton renamed (enriched=yes), Villa Serena INACTIVE, both test homes gone, 3 backfilled homes now carry their city. Two new rebrands surfaced for the rename punch list (Bickford→Bloom, Rocky River Village→Meadow Falls).
+
+- **Files changed:** `scripts/cleanup-batch2.ts` (NEW, via #580). This session-wrap: `context/DEV_SESSION_SUMMARIES.md`, `context/CARELINKAI_TECHNICAL_STATE.md`, `context/CARELINKAI_TECH_OPEN_LOOPS.md`.
+
+- **Commands run (Render shell):**
+  - `npx tsx scripts/cleanup-batch2.ts` (dry-run) → `--force` (Applied: 4, Skipped: 0).
+  - `npx tsx scripts/autopopulate-cohort.ts /tmp/batch2_addr.csv --addresses-only --dry-run` → `--force` (3/3 succeeded).
+  - `npx tsx scripts/report-directory-homes.ts --tsv > /tmp/dir_after.tsv` + grep confirmation.
+
+- **Tests/build status:** PR #580 CI fully green before merge. Cleanup script typechecks clean (strict, standalone; `scripts/` excluded from app tsconfig). No app code changed.
+
+- **Deployment impact:** One PR merged → one Render auto-deploy (script-only, no migration, no runtime path change). Production DB mutated by the Render `--force` runs (4 cleanup actions + 3 address rows). All affected homes stay DRAFT/INACTIVE — no emails, no public listings.
+
+- **New risks/blockers:**
+  - **Windsor Heights `websiteUrl` is wrong** — still points to the Sunshine/Beachwood Retirement URL, not Windsor Heights. Must be corrected before that listing goes public.
+  - **Rebrand name reconciliation** — Bickford→Bloom and Rocky River Village→Meadow Falls (addresses confirm same buildings); canonical-name decision pending (Ashton already renamed).
+  - The 3 address-only homes are still `enriched=no` (verified address, no description/photos) — full enrich needs working non-SPA URLs.
+  - The designated session branch `claude/inspiring-mayer-rvgyys` is a stale graveyard (7 conflicts vs main incl. code files); this wrap was committed on a fresh `docs/session-wrap-2026-06-21` branch off main per CLAUDE.md branching discipline.
+
+- **Recommended next step:**
+  1. Fix Windsor Heights `websiteUrl` (find the real site or clear it), then full-enrich the 3 address-only homes once working URLs exist.
+  2. Decide canonical names for Bloom of Rocky River / Meadow Falls of Rocky River and rename (mirror the Ashton change).
+  3. Optionally run `--addresses-only` once on The Ashton (shows `city=(pending)` despite enriched=yes).
+
+---
+
 ### 2026-06-05 — AI Auto-Population Pipeline: Production Batch Run
 
 - **Objective:** Ship the full AI auto-population pipeline and execute it against the first 15 Cleveland facilities in production.


### PR DESCRIPTION
## Session wrap — batch-2 Cleveland cohort cleanup + address backfill

Docs-only. Updates the three `./context/` state files for the 2026-06-21 session. No code, no migration, no runtime impact.

### What this records
- **PR #580 merged + applied on Render** (`--force`, Applied: 4): rename Anthology → **The Ashton at Mayfield Heights**, retire **Villa Serena** → INACTIVE, purge two leftover test homes ("Test Senior Living Cleveland", "Chris Senior Care Home").
- **Places address backfill** (`autopopulate-cohort.ts --addresses-only --force`) of the 3 fixable homes — 3/3 HIGH, $0 Anthropic. Surfaced two rebrands: Bickford → "Bloom of Rocky River", Rocky River Village → "Meadow Falls of Rocky River".

### Files
- `context/DEV_SESSION_SUMMARIES.md` — new 2026-06-21 entry.
- `context/CARELINKAI_TECHNICAL_STATE.md` — active branch, batch-2 decisions, next priorities, graveyard-branch warning.
- `context/CARELINKAI_TECH_OPEN_LOOPS.md` — progressed OL-058; added **OL-081** (batch-2 punch list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_