### PR TITLE
feat(claim-engine): inquiry → claim "pull" notification engine (OL-083)

### DIFF
--- a/__tests__/inquiry-claim-notification.unit.test.ts
+++ b/__tests__/inquiry-claim-notification.unit.test.ts
@@ -1,0 +1,29 @@
+import {
+  isUnclaimedHome,
+  DIRECTORY_UNCLAIMED_EMAIL,
+  NUDGE_THROTTLE_HOURS,
+} from '@/lib/claim-engine/inquiry-claim-notification';
+
+describe('inquiry→claim engine — unclaimed gate (OL-083)', () => {
+  it('treats the directory sentinel operator as unclaimed', () => {
+    expect(isUnclaimedHome(DIRECTORY_UNCLAIMED_EMAIL)).toBe(true);
+  });
+
+  it('is case-insensitive on the sentinel email', () => {
+    expect(isUnclaimedHome('Directory-Unclaimed@CareLinkAI.System')).toBe(true);
+  });
+
+  it('treats a real operator email as claimed (no nudge)', () => {
+    expect(isUnclaimedHome('owner@somefacility.com')).toBe(false);
+  });
+
+  it('treats null/undefined/empty as not unclaimed (safe default — no nudge)', () => {
+    expect(isUnclaimedHome(null)).toBe(false);
+    expect(isUnclaimedHome(undefined)).toBe(false);
+    expect(isUnclaimedHome('')).toBe(false);
+  });
+
+  it('exposes a sane throttle window', () => {
+    expect(NUDGE_THROTTLE_HOURS).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -190,6 +190,22 @@ Each loop: what it is, why it matters, what done looks like.
   3. **Beachwood Commons email unverified** — `asarota@npseniorliving.com` flagged LOW (bounce risk). Verify or replace before relying on the send; it's loaded into "Batch 2" but may bounce.
 - **Done when:** the broadcast is sent from Resend, the HOLD trio is emailed (or explicitly dropped), and the Beachwood Commons email is verified/replaced.
 
+### OL-083: Inquiry → Claim "pull" engine (2026-06-22)
+- **Status:** 🟢 BUILT (PR `feat/inquiry-claim-notification`, pending merge) — turns real demand on an unclaimed listing into a claim trigger. Sibling of OL-079. *(Note: the founder's ticket called this "OL-082", but that number was already taken by the batch-2 outreach loop above, so it's filed as OL-083.)*
+- **What it does:** when a family inquires on an **unclaimed/directory-owned** home, the inquiry is **always captured** (existing `Inquiry` row; `/api/inquiries` has no status guard) and surfaces on the operator dashboard the moment they claim (inquiries key off `homeId`, which reassigns on claim — no extra wiring). On top of that capture: a **best-effort notify** nudges the operator to claim.
+- **Build:**
+  - **Schema (migration `20260622000001_inquiry_claim_outreach_fields`, additive):** `AssistedLivingHome.outreachEmail`, `outreachPhone`, `claimNudgeLastSentAt`.
+  - **`src/lib/claim-engine/inquiry-claim-notification.ts`** — `notifyUnclaimedHomeInquiry({homeId, inquiryId})`: self-filters to unclaimed homes (directory sentinel operator `directory-unclaimed@carelinkai.system`); if `outreachEmail` known + not nudged in last 24h, mints a 45-day founder claim link (`signClaimToken`, `clevelandFounder:true`) and sends a **Resend email + Twilio SMS** (reusing existing infra), then stamps `claimNudgeLastSentAt`. Non-blocking, Sentry-tagged `feature: 'inquiry-claim-notification'`, idempotent (24h throttle).
+  - **`src/lib/email.ts` `sendInquiryClaimNudgeEmail` + `sms-service.ts` `sendInquiryClaimNudge`** — generic copy ("a family is trying to reach <Facility>… claim to respond securely"); the link IS the CTA.
+  - **Public counter:** `/api/homes/[id]` returns `unclaimed` + `pendingInquiryCount` (count of NEW inquiries); `src/app/homes/[id]/page.tsx` shows "N families have inquired — claim to view & respond securely" (or a soft "claim this listing" when 0).
+  - **Wire:** one non-blocking call in `/api/inquiries` POST. Unit test for the unclaimed gate.
+- **HIPAA:** inquiries may carry PHI (care needs). The email/SMS body and the public counter are **generic only** — facility name + a generic "a family is trying to reach you" / a bare count. Actual inquiry content stays behind auth, revealed only after claim.
+- **Residual / dependencies (OPEN):**
+  1. **Populate `outreachEmail`/`outreachPhone`** — the email/SMS branch is dormant until these are filled (from Cowork's batch research / the "Batch 2" contacts). A small backfill script can map the batch-2 outreach emails onto the home rows. Until then, only the **public counter** path is active.
+  2. **Anonymous capture** — `/api/inquiries` still requires a `familyId`; a family with no account inquiring on a public listing currently 400s. Owned by the **publish-wide rollout ticket** (listings must be PUBLIC + anonymous inquiry capture) — not built here. Within current auth, capture is intact.
+  3. **AI triage auto-ack** (optional in the ticket) — deferred to a phase 2; would auto-acknowledge the family to hold them while the operator claims.
+- **Done when:** outreach contacts are populated so the notify fires in production, the publish-wide ticket lands (public listings + anonymous capture), and (optionally) the AI auto-ack ships.
+
 ### OL-027: Provider listing fee ($99/mo)
 - **Status:** ✅ CLOSED (2026-05-02)
 - Schema fields + migration, Stripe Checkout + Customer Portal APIs, webhook handler, visibility gate in marketplace API, billing UI at `/settings/provider/billing`. Requires `STRIPE_PRICE_PROVIDER_LISTING` env var in Render.

--- a/prisma/migrations/20260622000001_inquiry_claim_outreach_fields/migration.sql
+++ b/prisma/migrations/20260622000001_inquiry_claim_outreach_fields/migration.sql
@@ -1,0 +1,5 @@
+-- OL-083 inquiry→claim "pull" engine: best-effort operator outreach contact on
+-- unclaimed/directory listings + a throttle stamp for claim nudges. Additive.
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "outreachEmail" TEXT;
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "outreachPhone" TEXT;
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "claimNudgeLastSentAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -530,6 +530,13 @@ model AssistedLivingHome {
   enrichmentStatus        EnrichmentStatus @default(NONE)
   enrichmentStartedAt     DateTime?
   enrichmentError         String?
+  // Best-effort operator contact for UNCLAIMED/directory listings (from outreach
+  // research) — used by the inquiry→claim "pull" engine (OL-083) to nudge the
+  // operator to claim. Null on most listings; the public waiting-leads counter is
+  // the fallback when no contact is known.
+  outreachEmail           String?
+  outreachPhone           String?
+  claimNudgeLastSentAt    DateTime?
   address                Address?
   operator               Operator         @relation(fields: [operatorId], references: [id], onDelete: Cascade)
   bookings               Booking[]

--- a/src/app/api/homes/[id]/route.ts
+++ b/src/app/api/homes/[id]/route.ts
@@ -7,6 +7,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { formatCurrency } from '@/lib/utils';
 import { createAuditLogFromRequest } from '@/lib/audit';
+import { isUnclaimedHome } from '@/lib/claim-engine/inquiry-claim-notification';
 
 /**
  * City coordinates lookup for homes without geo data
@@ -186,6 +187,14 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
       ? ratings.reduce((sum, r) => sum + r, 0) / ratings.length
       : null;
 
+    // Inquiry→claim "pull" engine (OL-083): on UNCLAIMED listings, surface a
+    // waiting-leads counter as the organic claim driver. HIPAA: count ONLY — no
+    // inquiry/health details are exposed publicly.
+    const unclaimed = isUnclaimedHome(home.operator?.user?.email);
+    const pendingInquiryCount = unclaimed
+      ? await prisma.inquiry.count({ where: { homeId: home.id, status: 'NEW' } })
+      : 0;
+
     // Choose primary image with fallback
     const primary = sanitizeImageUrl(home.photos?.find((p) => p.isPrimary)?.url ?? null);
     const fallback = HOME_IMAGES[home.id.length % HOME_IMAGES.length];
@@ -238,6 +247,8 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
       rating: averageRating,
       reviewCount: ratings.length,
       isFavorited,
+      unclaimed,
+      pendingInquiryCount,
     };
 
     // Best-effort audit log (non-blocking)

--- a/src/app/api/inquiries/route.ts
+++ b/src/app/api/inquiries/route.ts
@@ -9,6 +9,7 @@ import { authOptions } from '@/lib/auth';
 import { afterInquiryCreated } from '@/lib/hooks/inquiry-hooks';
 import { smsService } from '@/lib/sms/sms-service';
 import { createInquirySchema } from '@/lib/inquiries/schema';
+import { notifyUnclaimedHomeInquiry } from '@/lib/claim-engine/inquiry-claim-notification';
 
 /**
  * POST /api/inquiries - Create a new inquiry
@@ -107,7 +108,8 @@ export async function POST(request: NextRequest) {
       console.error('Failed to schedule follow-ups:', err);
     });
 
-    // SMS alert to operator (non-blocking)
+    // SMS alert to operator (non-blocking) — claimed homes only (the directory
+    // sentinel operator on unclaimed homes has no phone, so this no-ops there).
     const operatorPhone = inquiry.home?.operator?.user?.phone;
     if (operatorPhone) {
       smsService.sendNewInquiryAlert(
@@ -118,6 +120,11 @@ export async function POST(request: NextRequest) {
         inquiry.home.name
       ).catch(() => {});
     }
+
+    // Inquiry→claim "pull" engine (OL-083): if the home is UNCLAIMED, best-effort
+    // nudge the operator to claim (generic copy only — no PHI). Self-filters to
+    // unclaimed homes with a known outreach email; non-blocking.
+    notifyUnclaimedHomeInquiry({ homeId: inquiry.homeId, inquiryId: inquiry.id }).catch(() => {});
     
     return NextResponse.json(
       { success: true, inquiry },

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -772,6 +772,36 @@ export default function HomeDetailPage() {
             <div className="flex flex-col lg:flex-row lg:space-x-8">
               {/* Left column */}
               <div className="flex-1">
+                {/* Unclaimed listing → claim driver (OL-083). HIPAA: count only,
+                    no inquiry/health details surfaced publicly. */}
+                {realHome.unclaimed && (
+                  realHome.pendingInquiryCount > 0 ? (
+                    <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-primary-200 bg-primary-50 p-4">
+                      <p className="text-sm font-medium text-primary-900">
+                        📩 {realHome.pendingInquiryCount} {realHome.pendingInquiryCount === 1 ? 'family has' : 'families have'} inquired about this community — claim the listing to view &amp; respond securely.
+                      </p>
+                      <a
+                        href="/auth/register?role=OPERATOR"
+                        className="shrink-0 rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+                      >
+                        Claim this listing
+                      </a>
+                    </div>
+                  ) : (
+                    <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+                      <p className="text-sm text-neutral-700">
+                        Are you the operator of this community? Claim your free listing to manage it and respond to families.
+                      </p>
+                      <a
+                        href="/auth/register?role=OPERATOR"
+                        className="shrink-0 rounded-lg border border-primary-600 px-4 py-2 text-sm font-semibold text-primary-700 hover:bg-primary-50"
+                      >
+                        Claim this listing
+                      </a>
+                    </div>
+                  )
+                )}
+
                 {/* Header */}
                 <div className="mb-6">
                   <div className="flex flex-wrap items-start justify-between gap-3">

--- a/src/lib/claim-engine/inquiry-claim-notification.ts
+++ b/src/lib/claim-engine/inquiry-claim-notification.ts
@@ -1,0 +1,133 @@
+/**
+ * Inquiry → Claim "pull" engine (OL-083) — sibling of the OL-079 claim email.
+ *
+ * When a family/caregiver inquires on an UNCLAIMED (directory-owned) listing, the
+ * inquiry is ALWAYS captured (the `Inquiry` row) regardless of this function —
+ * leads are never lost and surface on the operator dashboard the moment the home
+ * is claimed (inquiries are keyed by `homeId`, which reassigns on claim).
+ *
+ * This function is the BEST-EFFORT notify layer on top of that capture: if we
+ * know the operator's outreach email, mint a 45-day founder claim link and send
+ * a Resend email (+ Twilio SMS when a phone is known). The notification IS the
+ * claim CTA. When no contact is known, this no-ops and the public waiting-leads
+ * counter on the listing is the organic claim driver instead.
+ *
+ * HIPAA: an inquiry may contain PHI (care needs). This path sends GENERIC copy
+ * only — facility name + "a family is trying to reach you" — never inquiry/health
+ * details. Actual content stays behind auth and is revealed only after claim.
+ *
+ * Idempotent (24h throttle via `claimNudgeLastSentAt`), non-blocking (callers
+ * fire-and-forget), and Sentry-logged on failure — never throws.
+ */
+
+import { prisma } from '@/lib/prisma';
+import { signClaimToken, DEFAULT_CLAIM_TOKEN_TTL_HOURS } from '@/lib/claim-token';
+import { sendInquiryClaimNudgeEmail } from '@/lib/email';
+import { smsService } from '@/lib/sms/sms-service';
+import { captureError } from '@/lib/sentry';
+
+/** Sentinel operator that owns unclaimed/directory listings (see seed scripts). */
+export const DIRECTORY_UNCLAIMED_EMAIL = 'directory-unclaimed@carelinkai.system';
+
+/** Don't nudge the same listing more than once per this window. */
+export const NUDGE_THROTTLE_HOURS = 24;
+
+/**
+ * A listing is "unclaimed" when it is still owned by the directory sentinel
+ * operator. (A DRAFT home owned by a real operator is NOT unclaimed.)
+ */
+export function isUnclaimedHome(operatorUserEmail: string | null | undefined): boolean {
+  return (operatorUserEmail ?? '').toLowerCase() === DIRECTORY_UNCLAIMED_EMAIL;
+}
+
+function buildClaimUrl(homeId: string, operatorEmail: string, secret: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const token = signClaimToken(
+    {
+      operatorEmail: operatorEmail.toLowerCase(),
+      homeId,
+      clevelandFounder: true,
+      iat: now,
+      exp: now + DEFAULT_CLAIM_TOKEN_TTL_HOURS * 3600,
+    },
+    secret,
+  );
+  const appUrl =
+    process.env['NEXT_PUBLIC_APP_URL'] || process.env['NEXTAUTH_URL'] || 'https://getcarelinkai.com';
+  return `${appUrl.replace(/\/$/, '')}/auth/register?role=OPERATOR&claimToken=${encodeURIComponent(token)}`;
+}
+
+/**
+ * Best-effort: nudge the operator of an unclaimed listing to claim, off the back
+ * of a real inquiry. Safe to call on ANY inquiry — it self-filters to unclaimed
+ * homes with a known outreach email.
+ */
+export async function notifyUnclaimedHomeInquiry(params: {
+  homeId: string;
+  inquiryId: string;
+}): Promise<void> {
+  const { homeId, inquiryId } = params;
+  try {
+    const home = await prisma.assistedLivingHome.findUnique({
+      where: { id: homeId },
+      select: {
+        id: true,
+        name: true,
+        outreachEmail: true,
+        outreachPhone: true,
+        claimNudgeLastSentAt: true,
+        operator: { select: { user: { select: { email: true } } } },
+      },
+    });
+
+    if (!home) return;
+    // Claimed homes are handled by the existing operator-alert path — skip.
+    if (!isUnclaimedHome(home.operator?.user?.email)) return;
+
+    const outreachEmail = home.outreachEmail?.trim();
+    const outreachPhone = home.outreachPhone?.trim();
+    // No bound email → nothing to send; the public waiting-leads counter drives
+    // the claim instead. (A phone alone can't bind a claim token to an account.)
+    if (!outreachEmail) return;
+
+    // Idempotency: don't re-nudge within the throttle window.
+    if (
+      home.claimNudgeLastSentAt &&
+      Date.now() - home.claimNudgeLastSentAt.getTime() < NUDGE_THROTTLE_HOURS * 3600 * 1000
+    ) {
+      return;
+    }
+
+    const secret = process.env['NEXTAUTH_SECRET'] || '';
+    if (!secret) {
+      console.error('[claim-engine] NEXTAUTH_SECRET not set — cannot mint claim link for nudge');
+      return;
+    }
+
+    const waitingCount = await prisma.inquiry.count({ where: { homeId, status: 'NEW' } });
+    const claimUrl = buildClaimUrl(home.id, outreachEmail, secret);
+
+    await sendInquiryClaimNudgeEmail({
+      facilityName: home.name,
+      toEmail: outreachEmail,
+      claimUrl,
+      waitingCount,
+    });
+
+    if (outreachPhone) {
+      await smsService.sendInquiryClaimNudge(outreachPhone, home.name, claimUrl);
+    }
+
+    await prisma.assistedLivingHome.update({
+      where: { id: home.id },
+      data: { claimNudgeLastSentAt: new Date() },
+    });
+
+    console.log(`[claim-engine] Sent inquiry→claim nudge for "${home.name}" (${home.id})`);
+  } catch (error) {
+    captureError(error instanceof Error ? error : new Error(String(error)), {
+      tags: { feature: 'inquiry-claim-notification' },
+      extra: { homeId, inquiryId },
+    });
+  }
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -179,6 +179,74 @@ export async function sendOperatorClaimNotification(args: {
 }
 
 /**
+ * Inquiry→claim "pull" engine (OL-083): when a family inquires on an UNCLAIMED
+ * listing and we know the operator's outreach email, nudge them to claim their
+ * free listing so they can respond. The notification IS the claim CTA.
+ *
+ * HIPAA: the body is intentionally GENERIC — it names only the facility and says
+ * a family is trying to reach them. It MUST NOT contain any inquiry/health
+ * details; those stay behind auth and are revealed only after the operator
+ * claims. Fire-and-forget: failures are logged + sent to Sentry, never thrown.
+ */
+export async function sendInquiryClaimNudgeEmail(args: {
+  facilityName: string;
+  toEmail: string;
+  claimUrl: string;
+  waitingCount?: number;
+}): Promise<boolean> {
+  const facilityName = args.facilityName?.trim() || 'your community';
+  const count = args.waitingCount && args.waitingCount > 1 ? args.waitingCount : 1;
+  const leadPhrase =
+    count > 1 ? `${count} families are trying to reach` : `A family is trying to reach`;
+  try {
+    if (!process.env.RESEND_API_KEY) {
+      console.error('[Resend] RESEND_API_KEY not configured — skipping inquiry claim nudge');
+      return false;
+    }
+    const safeFacility = escapeHtml(facilityName);
+    const subject = `${leadPhrase} ${facilityName} on CareLinkAI`;
+    const text =
+      `${leadPhrase} ${facilityName} on CareLinkAI.\n\n` +
+      `Claim your free listing in about 2 minutes to view and respond securely:\n${args.claimUrl}\n\n` +
+      `Inquiry details are kept private until you claim. There is no cost to claim or respond.`;
+    const html = `
+<!DOCTYPE html>
+<html><body style="font-family:Arial,sans-serif;color:#1f2937;line-height:1.5">
+  <p>${escapeHtml(leadPhrase)} <strong>${safeFacility}</strong> on CareLinkAI.</p>
+  <p>Claim your free listing in about 2 minutes to view and respond securely:</p>
+  <p><a href="${escapeHtml(args.claimUrl)}" style="display:inline-block;background:#0d9488;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600">Claim ${safeFacility}</a></p>
+  <p style="color:#6b7280;font-size:13px">Inquiry details are kept private until you claim. There is no cost to claim or respond.</p>
+</body></html>`;
+
+    const { data, error } = await resend.emails.send({
+      from: `${APP_NAME} <${FROM_EMAIL}>`,
+      to: [args.toEmail],
+      subject,
+      text,
+      html,
+    });
+
+    if (error) {
+      console.error('[Resend] Error sending inquiry claim nudge:', error);
+      captureError(
+        error instanceof Error ? error : new Error(String((error as { message?: string })?.message ?? error)),
+        { tags: { feature: 'inquiry-claim-notification' }, extra: { facilityName } }
+      );
+      return false;
+    }
+    console.log('[Resend] ✅ Inquiry claim nudge sent. Email ID:', data?.id);
+    return true;
+  } catch (error) {
+    console.error('[Resend] Exception sending inquiry claim nudge:', error);
+    captureError(error instanceof Error ? error : new Error(String(error)), {
+      tags: { feature: 'inquiry-claim-notification' },
+      extra: { facilityName },
+    });
+    return false;
+  }
+}
+
+/**
  * Generate HTML content for verification email
  */
 function generateVerificationEmailHTML(

--- a/src/lib/sms/sms-service.ts
+++ b/src/lib/sms/sms-service.ts
@@ -110,6 +110,18 @@ export class SMSService {
     return this.sendSMS(to, msg);
   }
 
+  // ── Operator (UNCLAIMED listing): inquiry→claim nudge (OL-083) ─────────────
+  // HIPAA: generic only — names the facility + a generic "family is trying to
+  // reach you", never inquiry/health details. The claim link IS the CTA.
+  async sendInquiryClaimNudge(
+    to: string,
+    facilityName: string,
+    claimUrl: string
+  ): Promise<boolean> {
+    const msg = `A family is trying to reach ${facilityName} on CareLinkAI. Claim your free listing (~2 min) to respond securely: ${claimUrl}`;
+    return this.sendSMS(to, msg);
+  }
+
   // Legacy — kept for backward compatibility
   async sendFollowUpSMS(to: string, contactName: string, inquiryId: string): Promise<boolean> {
     const msg = `Hi ${contactName}, this is CareLinkAI following up on your senior care inquiry. We're here to help! Reply YES to speak with an advisor or visit carelinkai.com. Ref: ${inquiryId.slice(0, 8)}`;


### PR DESCRIPTION
## OL-083 — Inquiry → Claim "pull" engine

Turns real demand on an **unclaimed** listing into the strongest claim trigger we have. Sibling of OL-079.

> **OL number:** the ticket called this "OL-082", but that number was already taken by the batch-2 outreach loop (PR #585), so it's filed as **OL-083**.

### How it works
- **Capture is always-on.** `/api/inquiries` already has no home-status guard, so inquiries on DRAFT/directory homes persist as normal `Inquiry` rows. Because inquiries key off `homeId` (which reassigns to the new operator on claim), the operator dashboard **auto-delivers the waiting leads the moment they claim** — no extra wiring.
- **Best-effort notify** (`src/lib/claim-engine/inquiry-claim-notification.ts`): self-filters to unclaimed/directory homes (sentinel operator `directory-unclaimed@carelinkai.system`); if an `outreachEmail` is known and we haven't nudged in the last 24h, it **mints a 45-day founder claim link** (`signClaimToken`, `clevelandFounder:true`) and sends a **Resend email + Twilio SMS** (reusing existing infra), then stamps `claimNudgeLastSentAt`. The notification **is** the claim CTA.
- **Public counter:** `/api/homes/[id]` returns `unclaimed` + `pendingInquiryCount`; the public listing shows "**N families have inquired — claim to view & respond securely**" (or a soft "claim this listing" when 0) as the organic claim driver when no operator contact is known.

### HIPAA (critical)
Inquiries may carry PHI (care needs). The email/SMS body **and** the public counter are **generic only** — facility name + a generic "a family is trying to reach you" / a bare count. Actual inquiry content stays behind auth and is revealed only after the operator claims.

### Idempotent · non-blocking · Sentry
24h throttle via `claimNudgeLastSentAt`; callers fire-and-forget; failures `captureError` under `feature: 'inquiry-claim-notification'`. Mirrors OL-079. No pay-for-referral anywhere.

### Files
- **Schema** (additive migration `20260622000001_inquiry_claim_outreach_fields`): `AssistedLivingHome.outreachEmail`, `outreachPhone`, `claimNudgeLastSentAt`.
- `src/lib/claim-engine/inquiry-claim-notification.ts` (new), `src/lib/email.ts` (+`sendInquiryClaimNudgeEmail`), `src/lib/sms/sms-service.ts` (+`sendInquiryClaimNudge`).
- `src/app/api/inquiries/route.ts` (wire), `src/app/api/homes/[id]/route.ts` (counter), `src/app/homes/[id]/page.tsx` (public CTA).
- `__tests__/inquiry-claim-notification.unit.test.ts`. `tsc --noEmit`, `eslint`, and the new unit test all pass.

### Residuals / dependencies (tracked in OL-083, not in this PR)
1. **Populate `outreachEmail`/`outreachPhone`** — the email/SMS branch is dormant until these are filled (from Cowork's batch research / the "Batch 2" contacts). Until then only the public counter is active.
2. **Anonymous capture** — `/api/inquiries` still requires `familyId`; anonymous public inquiries currently 400. Owned by the **publish-wide rollout ticket** (public listings + anonymous capture).
3. **AI triage auto-ack** (optional) — deferred to phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_