### PR TITLE
chore(marketing): soften unsubstantiated compliance claims before metro publish

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -147,7 +147,7 @@ export default function LoginPage() {
             <ul className="mt-10 space-y-3">
               {[
                 "Personalized AI-powered care matching",
-                "HIPAA-compliant secure platform",
+                "HIPAA-aligned secure platform",
                 "Streamlined placement process",
                 "Comprehensive care management tools",
               ].map((item) => (

--- a/src/app/discharge-planner/billing/page.tsx
+++ b/src/app/discharge-planner/billing/page.tsx
@@ -19,7 +19,7 @@ const INDIVIDUAL_FEATURES = [
   'Placement request management and history',
   'Analytics dashboard — placements, response times, outcomes',
   'Priority support from our care coordination team',
-  'HIPAA-compliant data handling',
+  'HIPAA-aligned data handling',
 ];
 
 const DEPT_FEATURES = [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,7 @@ export const metadata: Metadata = {
     "elderly care",
     "family portal",
     "care matching",
-    "HIPAA compliant",
+    "HIPAA-aligned safeguards",
   ],
   authors: [{ name: "CareLinkAI Team" }],
   creator: "CareLinkAI",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -210,7 +210,7 @@ export default function HomePage() {
               </h1>
               
               <p className="mt-6 text-xl text-neutral-700 max-w-xl leading-relaxed">
-                The all-in-one AI platform for senior care — intelligent matching for families, smart shift coverage for operators, and instant placements for discharge planners. HIPAA-compliant and live today.
+                The all-in-one AI platform for senior care — intelligent matching for families, smart shift coverage for operators, and instant placements for discharge planners. Built with HIPAA-aligned safeguards and live today.
               </p>
               
               {/* CTAs */}
@@ -254,7 +254,7 @@ export default function HomePage() {
                 </div>
                 <div className="flex items-center">
                   <FiShield className="text-secondary-500 mr-2 flex-shrink-0" />
-                  <span>HIPAA compliant</span>
+                  <span>HIPAA-aligned safeguards</span>
                 </div>
                 <div className="flex items-center">
                   <FiZap className="text-secondary-500 mr-2 flex-shrink-0" />
@@ -903,8 +903,8 @@ export default function HomePage() {
                     <FiShield className="text-white text-xl" />
                   </div>
                   <div>
-                    <h4 className="text-lg font-bold text-neutral-900 mb-2">HIPAA Secure</h4>
-                    <p className="text-neutral-500">Your health information is protected with bank-level security and full HIPAA compliance.</p>
+                    <h4 className="text-lg font-bold text-neutral-900 mb-2">HIPAA-Aligned Security</h4>
+                    <p className="text-neutral-500">Your health information is protected with encryption in transit and at rest, access controls, and audit logging.</p>
                   </div>
                 </div>
                 <div className="flex items-start space-x-4">
@@ -1109,8 +1109,8 @@ export default function HomePage() {
                     <FiShield className="text-white text-xl" />
                   </div>
                   <div>
-                    <h4 className="text-lg font-bold text-neutral-900 mb-2">HIPAA Compliant</h4>
-                    <p className="text-neutral-500">All patient information is securely handled with full HIPAA compliance.</p>
+                    <h4 className="text-lg font-bold text-neutral-900 mb-2">HIPAA-Aligned</h4>
+                    <p className="text-neutral-500">Patient information is handled with HIPAA-aligned safeguards — encryption, access controls, and audit logging.</p>
                   </div>
                 </div>
                 <div className="flex items-start space-x-4">
@@ -1440,7 +1440,7 @@ export default function HomePage() {
                   <div className="text-sm text-neutral-500 mt-1">1 planner · 14-day free trial</div>
                 </div>
                 <ul className="space-y-3 mb-8 flex-1">
-                  {['AI placement search', 'Multi-facility requests', 'Real-time bed availability', 'Placement history & analytics', 'HIPAA-compliant'].map((f) => (
+                  {['AI placement search', 'Multi-facility requests', 'Real-time bed availability', 'Placement history & analytics', 'HIPAA-aligned safeguards'].map((f) => (
                     <li key={f} className="flex items-center gap-2 text-sm text-neutral-500">
                       <FiCheck className="text-success-500 flex-shrink-0" /> {f}
                     </li>
@@ -1592,8 +1592,8 @@ export default function HomePage() {
             <div className="inline-flex items-center bg-white border-2 border-primary-500 rounded-full px-6 py-3 shadow-lg">
               <FiShield className="text-primary-500 text-2xl mr-3" />
               <div className="text-left">
-                <p className="font-bold text-neutral-900">HIPAA Compliant</p>
-                <p className="text-xs text-neutral-500">Your data is secure and protected</p>
+                <p className="font-bold text-neutral-900">HIPAA-Aligned</p>
+                <p className="text-xs text-neutral-500">Your data is secured with encryption and audit logging</p>
               </div>
             </div>
           </div>
@@ -1662,7 +1662,7 @@ export default function HomePage() {
                 {openFaqIndex === 1 && (
                   <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} transition={{ duration: 0.25 }} className="overflow-hidden">
                     <div className="px-6 pb-5 text-neutral-500">
-                      <p>Absolutely. We are fully HIPAA compliant with bank-level encryption, secure data storage, comprehensive audit logging, and regular security audits. Your health information is protected at every level of our platform.</p>
+                      <p>We follow HIPAA-aligned safeguards: encryption in transit and at rest, role-based access controls, and audit logging. Your health information is protected across the platform.</p>
                     </div>
                   </motion.div>
                 )}
@@ -1999,7 +1999,7 @@ export default function HomePage() {
             <p>© {new Date().getFullYear()} CareLinkAI. All rights reserved.</p>
             <div className="flex items-center mt-4 md:mt-0">
               <FiShield className="text-primary-500 mr-2" />
-              <span>HIPAA Compliant</span>
+              <span>HIPAA-Aligned</span>
             </div>
           </div>
         </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -47,7 +47,7 @@ export default function PrivacyPolicyPage() {
           <div className="bg-success-50 border border-success-200 rounded-lg p-4 mb-10 flex items-center justify-center">
             <FiShield className="text-success-600 mr-3 w-6 h-6" />
             <span className="text-success-800 font-medium">
-              HIPAA Compliant • GDPR & CCPA Aware
+              HIPAA-Aligned Safeguards • GDPR & CCPA Aware
             </span>
           </div>
 
@@ -159,7 +159,7 @@ export default function PrivacyPolicyPage() {
                 <li><strong>Monitoring:</strong> Continuous security monitoring and intrusion detection</li>
                 <li><strong>Audits:</strong> Regular security assessments and penetration testing</li>
                 <li><strong>Training:</strong> Employee security awareness training</li>
-                <li><strong>Compliance:</strong> HIPAA compliant infrastructure</li>
+                <li><strong>Compliance:</strong> HIPAA-aligned infrastructure</li>
               </ul>
             </section>
 


### PR DESCRIPTION
## Publish-wide PART C step 9 — soften unsubstantiated compliance claims

Prerequisite before metro-scale publishing. With the BAA/DPA still in **draft** (OL-052) and no formal audit/certification, absolute compliance claims aren't defensible. Reworded to accurate, provable language.

### Changes
- **"fully HIPAA compliant" / "full HIPAA compliance" → "HIPAA-aligned safeguards"**
- **Dropped "bank-level security" / "bank-level encryption"** and **"regular security audits"** → replaced with what we actually do: *encryption in transit and at rest, role-based access controls, audit logging*.
- Flat **"HIPAA Compliant"** badges/labels → **"HIPAA-Aligned"**.

### Files
`src/app/page.tsx` (hero subhead, trust badges ×3, two trust cards, discharge feature list, security FAQ answer), `auth/login`, `privacy` (badge + infra bullet), `layout.tsx` (SEO keyword), `discharge-planner/billing`.

### Scope notes
- Internal **code comments** that mention HIPAA intent (audit-log/security comments) are left as-is — not public claims.
- The cited "SOC2 / trusted by thousands / 98%" claims weren't present (already removed in #548).
- Content-only; no functional change. `eslint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_