### PR TITLE
feat(inquiries): capture anonymous leads with no linked family account

### DIFF
--- a/prisma/migrations/20260623000001_inquiry_nullable_family/migration.sql
+++ b/prisma/migrations/20260623000001_inquiry_nullable_family/migration.sql
@@ -1,0 +1,6 @@
+-- OL-083 anonymous inquiry capture: allow Inquiry rows with no linked family
+-- account. Public/anonymous leads are captured via on-row contact fields
+-- (contactName/contactEmail/contactPhone); an operator can link a real family
+-- later. The existing familyId FK (ON DELETE CASCADE) is preserved and remains
+-- valid for a nullable column. Additive / non-destructive.
+ALTER TABLE "Inquiry" ALTER COLUMN "familyId" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -834,7 +834,10 @@ model ResidentNote {
 
 model Inquiry {
   id                     String             @id @default(cuid())
-  familyId               String
+  /// Nullable: anonymous public inquiries are captured with no linked family
+  /// account. On-row contact fields (contactName/contactEmail/contactPhone)
+  /// carry the lead's details; an operator can link to a real family later.
+  familyId               String?
   homeId                 String
   status                 InquiryStatus      @default(NEW)
   message                String?
@@ -866,7 +869,7 @@ model Inquiry {
   assignedTo             User?              @relation("AssignedInquiries", fields: [assignedToId], references: [id])
   convertedBy            User?              @relation("InquiryConverter", fields: [convertedByUserId], references: [id])
   convertedResident      Resident?          @relation("ConvertedFromInquiry", fields: [convertedToResidentId], references: [id])
-  family                 Family             @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  family                 Family?            @relation(fields: [familyId], references: [id], onDelete: Cascade)
   home                   AssistedLivingHome @relation(fields: [homeId], references: [id], onDelete: Cascade)
   documents              InquiryDocument[]
   responses              InquiryResponse[]

--- a/src/app/admin/inquiries/[id]/page.tsx
+++ b/src/app/admin/inquiries/[id]/page.tsx
@@ -42,10 +42,11 @@ interface InquiryDetail {
       user: { firstName: string; lastName: string; email: string };
     };
   };
+  // Nullable: anonymous inquiries have no linked family account.
   family: {
     id: string;
     user: { firstName: string; lastName: string; email: string; phone: string | null };
-  };
+  } | null;
   assignedTo: { id: string; firstName: string; lastName: string; email: string } | null;
   convertedBy: { id: string; firstName: string; lastName: string } | null;
   convertedResident: { id: string; firstName: string; lastName: string } | null;

--- a/src/app/admin/inquiries/page.tsx
+++ b/src/app/admin/inquiries/page.tsx
@@ -38,10 +38,11 @@ interface Inquiry {
       user: { firstName: string; lastName: string; email: string };
     };
   };
+  // Nullable: anonymous inquiries have no linked family account.
   family: {
     id: string;
     user: { firstName: string; lastName: string; email: string; phone: string | null };
-  };
+  } | null;
   assignedTo: { id: string; firstName: string; lastName: string; email: string } | null;
   convertedResident: { id: string; firstName: string; lastName: string } | null;
   followUps: { id: string; scheduledFor: string; type: string }[];

--- a/src/app/api/inquiries/[id]/follow-ups/route.ts
+++ b/src/app/api/inquiries/[id]/follow-ups/route.ts
@@ -49,7 +49,7 @@ async function hasInquiryAccess(userId: string, userRole: string, inquiryId: str
   }
   
   if (userRole === 'FAMILY') {
-    return inquiry.family.userId === userId;
+    return inquiry.family?.userId === userId;
   }
   
   if (userRole === 'OPERATOR') {

--- a/src/app/api/inquiries/[id]/responses/route.ts
+++ b/src/app/api/inquiries/[id]/responses/route.ts
@@ -40,7 +40,7 @@ async function hasInquiryAccess(userId: string, userRole: string, inquiryId: str
   }
   
   if (userRole === 'FAMILY') {
-    return inquiry.family.userId === userId;
+    return inquiry.family?.userId === userId;
   }
   
   if (userRole === 'OPERATOR') {
@@ -135,9 +135,9 @@ export async function POST(
     let toAddress = data.toAddress;
     if (!toAddress) {
       if (data.channel === 'EMAIL' || data.channel === 'IN_APP') {
-        toAddress = inquiry.contactEmail || inquiry.family.user.email;
+        toAddress = inquiry.contactEmail || inquiry.family?.user?.email;
       } else if (data.channel === 'SMS' || data.channel === 'PHONE') {
-        toAddress = inquiry.contactPhone || inquiry.family.user.phone || undefined;
+        toAddress = inquiry.contactPhone || inquiry.family?.user?.phone || undefined;
       }
     }
     

--- a/src/app/api/inquiries/[id]/route.ts
+++ b/src/app/api/inquiries/[id]/route.ts
@@ -58,7 +58,8 @@ async function hasInquiryAccess(userId: string, userRole: string, inquiryId: str
   }
   
   if (userRole === 'FAMILY') {
-    return inquiry.family.userId === userId;
+    // Anonymous (no-family) inquiries are never owned by a family user.
+    return inquiry.family?.userId === userId;
   }
   
   if (userRole === 'OPERATOR') {

--- a/src/app/api/inquiries/responses/[responseId]/route.ts
+++ b/src/app/api/inquiries/responses/[responseId]/route.ts
@@ -40,7 +40,7 @@ async function hasResponseAccess(userId: string, userRole: string, responseId: s
   }
   
   if (userRole === 'FAMILY') {
-    return response.inquiry.family.userId === userId;
+    return response.inquiry.family?.userId === userId;
   }
   
   if (userRole === 'OPERATOR') {

--- a/src/app/api/inquiries/responses/[responseId]/send/route.ts
+++ b/src/app/api/inquiries/responses/[responseId]/send/route.ts
@@ -33,7 +33,7 @@ async function hasResponseAccess(userId: string, userRole: string, responseId: s
   }
   
   if (userRole === 'FAMILY') {
-    return response.inquiry.family.userId === userId;
+    return response.inquiry.family?.userId === userId;
   }
   
   if (userRole === 'OPERATOR') {
@@ -153,7 +153,7 @@ export async function POST(
     if (familyPhone) {
       smsService.sendInquiryResponseReceived(
         familyPhone,
-        response.inquiry.family.user!.firstName,
+        response.inquiry.family?.user?.firstName ?? '',
         response.inquiry.home?.name ?? 'an assisted living home'
       ).catch(() => {});
     }

--- a/src/app/api/inquiries/route.ts
+++ b/src/app/api/inquiries/route.ts
@@ -42,19 +42,16 @@ export async function POST(request: NextRequest) {
           select: { id: true, referredByCode: true },
         })
       : null;
-    const familyId = familyRecord?.id ?? data.familyId;
+    // Anonymous public submissions are allowed: when no family is resolved the
+    // inquiry is captured against its on-row contact fields (contactName/
+    // contactEmail are required by the schema) with familyId = null. An operator
+    // can link it to a real family later.
+    const familyId = familyRecord?.id ?? data.familyId ?? null;
 
     // Fall back to the family's stored referral code if none passed explicitly
     const resolvedAffiliateCode =
       data.affiliateCode || familyRecord?.referredByCode || null;
-    
-    if (!familyId) {
-      return NextResponse.json(
-        { success: false, error: 'Family ID is required for inquiry creation' },
-        { status: 400 }
-      );
-    }
-    
+
     // Create the inquiry
     const inquiry = await prisma.inquiry.create({
       data: {

--- a/src/app/api/operator/inquiries/[id]/route.ts
+++ b/src/app/api/operator/inquiries/[id]/route.ts
@@ -51,12 +51,23 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
       message: inquiry.message || null,
       internalNotes: inquiry.internalNotes || '',
       home: { id: inquiry.home.id, name: inquiry.home.name },
-      family: {
-        id: inquiry.family.id,
-        name: [inquiry.family.user.firstName, inquiry.family.user.lastName].filter(Boolean).join(' '),
-        email: inquiry.family.user.email,
-        phone: inquiry.family.user.phone || null,
+      // On-row lead contact — source of truth for anonymous (unlinked) inquiries.
+      contact: {
+        name: inquiry.contactName || null,
+        email: inquiry.contactEmail || null,
+        phone: inquiry.contactPhone || null,
+        careRecipientName: inquiry.careRecipientName || null,
       },
+      // Null for anonymous inquiries that aren't linked to a family account yet.
+      family: inquiry.family
+        ? {
+            id: inquiry.family.id,
+            name: [inquiry.family.user?.firstName, inquiry.family.user?.lastName].filter(Boolean).join(' '),
+            email: inquiry.family.user?.email || null,
+            phone: inquiry.family.user?.phone || null,
+            user: inquiry.family.user || null,
+          }
+        : null,
     };
 
     return NextResponse.json({ inquiry: data });

--- a/src/app/api/operator/inquiries/route.ts
+++ b/src/app/api/operator/inquiries/route.ts
@@ -184,6 +184,24 @@ export async function GET(request: NextRequest) {
             },
           },
         },
+        // On-row contact fields — covers anonymous inquiries with no linked family
+        {
+          contactName: {
+            contains: search,
+            mode: 'insensitive',
+          },
+        },
+        {
+          contactEmail: {
+            contains: search,
+            mode: 'insensitive',
+          },
+        },
+        {
+          contactPhone: {
+            contains: search,
+          },
+        },
         {
           message: {
             contains: search,

--- a/src/app/operator/inquiries/[id]/page.tsx
+++ b/src/app/operator/inquiries/[id]/page.tsx
@@ -26,13 +26,21 @@ type InquiryDetail = {
     name: string; 
     address?: { street: string; city: string; state: string; }
   };
-  family: { 
-    id: string; 
-    name: string; 
-    email: string; 
-    phone: string | null; 
-    user: { firstName: string; lastName: string; email: string; phone?: string; }
+  // On-row lead contact — source of truth for anonymous (unlinked) inquiries.
+  contact?: {
+    name: string | null;
+    email: string | null;
+    phone: string | null;
+    careRecipientName: string | null;
   };
+  // Null for anonymous inquiries that aren't linked to a family account yet.
+  family: {
+    id: string;
+    name: string;
+    email: string | null;
+    phone: string | null;
+    user: { firstName: string; lastName: string; email: string; phone?: string; } | null;
+  } | null;
   convertedToResidentId?: string | null;
   conversionDate?: string | null;
   convertedResident?: {
@@ -218,7 +226,8 @@ export default function OperatorLeadDetailPage() {
         <div className="grid gap-6 lg:grid-cols-3">
           {/* Left column */}
           <div className="space-y-6 lg:col-span-2">
-            {/* Family contact */}
+            {/* Contact — linked family account, or anonymous on-row lead contact */}
+            {data.family ? (
             <div className="rounded-lg border border-neutral-200 bg-white p-4">
               <div className="mb-3 flex items-center justify-between">
                 <div className="text-sm font-medium text-neutral-800">Family Contact</div>
@@ -263,6 +272,40 @@ export default function OperatorLeadDetailPage() {
                 </div>
               </div>
             </div>
+            ) : (
+            <div className="rounded-lg border border-amber-200 bg-amber-50/50 p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <div className="text-sm font-medium text-neutral-800">Lead Contact</div>
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 border border-amber-200">
+                  Not linked to a family account
+                </span>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <div className="text-xs text-neutral-500">Name</div>
+                  <div className="font-medium text-neutral-900">{data.contact?.name || '—'}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-neutral-500">Email</div>
+                  {data.contact?.email ? (
+                    <a className="font-medium text-primary-600 hover:underline" href={`mailto:${data.contact.email}`}>{data.contact.email}</a>
+                  ) : (
+                    <div className="font-medium text-neutral-900">—</div>
+                  )}
+                </div>
+                <div>
+                  <div className="text-xs text-neutral-500">Phone</div>
+                  <div className="font-medium text-neutral-900">{data.contact?.phone || '—'}</div>
+                </div>
+                {data.contact?.careRecipientName && (
+                  <div>
+                    <div className="text-xs text-neutral-500">Care recipient</div>
+                    <div className="font-medium text-neutral-900">{data.contact.careRecipientName}</div>
+                  </div>
+                )}
+              </div>
+            </div>
+            )}
 
             {/* Inquiry details */}
             <div className="rounded-lg border border-neutral-200 bg-white p-4">
@@ -349,6 +392,7 @@ export default function OperatorLeadDetailPage() {
                 )}
               </div>
             ) : !isFamily && canConvert && ['QUALIFIED', 'CONVERTING', 'TOUR_COMPLETED', 'PLACEMENT_OFFERED'].includes(data.status) ? (
+              data.family ? (
               <div className="rounded-lg border border-neutral-200 bg-white p-4">
                 <button
                   onClick={() => setShowConvertModal(true)}
@@ -363,6 +407,14 @@ export default function OperatorLeadDetailPage() {
                   Create a resident profile from this inquiry
                 </p>
               </div>
+              ) : (
+              <div className="rounded-lg border border-amber-200 bg-amber-50/50 p-4">
+                <p className="text-sm font-medium text-amber-800">Link to a family first</p>
+                <p className="text-xs text-amber-700 mt-1">
+                  This lead isn't linked to a family account yet. Link it to a family before converting to a resident.
+                </p>
+              </div>
+              )
             ) : null}
           </div>
         </div>
@@ -373,7 +425,7 @@ export default function OperatorLeadDetailPage() {
             inquiry={{
               id: data.id,
               family: {
-                user: data.family.user,
+                user: data.family?.user,
               },
               home: {
                 name: data.home.name,

--- a/src/components/operator/InquiriesFilterPanel.tsx
+++ b/src/components/operator/InquiriesFilterPanel.tsx
@@ -17,7 +17,9 @@ type Inquiry = {
   createdAt: string;
   tourDate: string | null;
   home: { id: string; name: string };
-  family: { id: string; name: string };
+  // Nullable: anonymous inquiries have no linked family account.
+  family?: { id: string; name?: string | null } | null;
+  contactName?: string | null;
 };
 
 type PaginationData = {
@@ -331,7 +333,7 @@ export default function InquiriesFilterPanel({ homes, initialFilters = {} }: Inq
                         {inquiry.home.name}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-600">
-                        {inquiry.family.name}
+                        {inquiry.family?.name || inquiry.contactName || 'Unlinked lead'}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-600">
                         {new Date(inquiry.createdAt).toLocaleDateString()}
@@ -403,7 +405,7 @@ export default function InquiriesFilterPanel({ homes, initialFilters = {} }: Inq
                         {inquiry.status.replace(/_/g, ' ')}
                       </span>
                     </div>
-                    <div className="text-sm text-neutral-600">{inquiry.family.name}</div>
+                    <div className="text-sm text-neutral-600">{inquiry.family?.name || inquiry.contactName || 'Unlinked lead'}</div>
                     <div className="flex items-center justify-between text-xs text-neutral-500">
                       <span>Created: {new Date(inquiry.createdAt).toLocaleDateString()}</span>
                       {inquiry.tourDate && (

--- a/src/components/operator/inquiries/ConvertInquiryModal.tsx
+++ b/src/components/operator/inquiries/ConvertInquiryModal.tsx
@@ -7,14 +7,17 @@ import { FiX, FiUser, FiHome, FiCalendar, FiAlertCircle } from 'react-icons/fi';
 interface ConvertInquiryModalProps {
   inquiry: {
     id: string;
-    family: {
-      user: {
+    family?: {
+      user?: {
         firstName: string;
         lastName: string;
         email: string;
         phone?: string;
-      };
-    };
+      } | null;
+    } | null;
+    contactName?: string | null;
+    contactEmail?: string | null;
+    contactPhone?: string | null;
     home: {
       name: string;
       address?: {
@@ -40,9 +43,13 @@ export default function ConvertInquiryModal({
   const [validationErrors, setValidationErrors] = useState<Record<string, string[]>>({});
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  // Pre-fill from the linked family account when present, otherwise fall back to
+  // the on-row lead contact name (anonymous inquiries).
+  const [fallbackFirst = '', ...fallbackRest] = (inquiry.contactName || '').trim().split(/\s+/);
+  const fallbackLast = fallbackRest.join(' ');
   const [formData, setFormData] = useState({
-    firstName: inquiry.family.user.firstName || '',
-    lastName: inquiry.family.user.lastName || '',
+    firstName: inquiry.family?.user?.firstName || fallbackFirst || '',
+    lastName: inquiry.family?.user?.lastName || fallbackLast || '',
     dateOfBirth: '',
     gender: 'PREFER_NOT_TO_SAY' as 'MALE' | 'FEMALE' | 'OTHER' | 'PREFER_NOT_TO_SAY',
     moveInDate: '',
@@ -150,13 +157,15 @@ export default function ConvertInquiryModal({
               <div className="flex items-start gap-2">
                 <FiUser className="w-4 h-4 text-primary-600 mt-0.5" />
                 <div>
-                  <span className="font-medium">Family Contact:</span>
+                  <span className="font-medium">{inquiry.family ? 'Family Contact:' : 'Lead Contact:'}</span>
                   <p className="text-neutral-700">
-                    {inquiry.family.user.firstName} {inquiry.family.user.lastName}
+                    {inquiry.family?.user
+                      ? `${inquiry.family.user.firstName} ${inquiry.family.user.lastName}`
+                      : inquiry.contactName || '—'}
                   </p>
-                  <p className="text-neutral-600">{inquiry.family.user.email}</p>
-                  {inquiry.family.user.phone && (
-                    <p className="text-neutral-600">{inquiry.family.user.phone}</p>
+                  <p className="text-neutral-600">{inquiry.family?.user?.email || inquiry.contactEmail || ''}</p>
+                  {(inquiry.family?.user?.phone || inquiry.contactPhone) && (
+                    <p className="text-neutral-600">{inquiry.family?.user?.phone || inquiry.contactPhone}</p>
                   )}
                 </div>
               </div>

--- a/src/components/operator/inquiries/FollowUpRemindersWidget.tsx
+++ b/src/components/operator/inquiries/FollowUpRemindersWidget.tsx
@@ -13,12 +13,13 @@ interface Reminder {
   completed: boolean;
   inquiry: {
     id: string;
-    family: {
-      user: {
+    family?: {
+      user?: {
         firstName: string;
         lastName: string;
-      };
-    };
+      } | null;
+    } | null;
+    contactName?: string | null;
   };
 }
 
@@ -128,8 +129,9 @@ export function FollowUpRemindersWidget({ reminders, onUpdate }: FollowUpReminde
                     href={`/operator/inquiries/${reminder.inquiry.id}`}
                     className="text-primary-600 hover:text-primary-800 truncate"
                   >
-                    {reminder.inquiry.family.user.firstName}{' '}
-                    {reminder.inquiry.family.user.lastName}
+                    {reminder.inquiry.family?.user
+                      ? `${reminder.inquiry.family.user.firstName} ${reminder.inquiry.family.user.lastName}`
+                      : reminder.inquiry.contactName || 'Unlinked lead'}
                   </Link>
                 </div>
                 <div className="flex items-center gap-2 text-sm text-neutral-600">

--- a/src/components/operator/inquiries/InquiryCard.tsx
+++ b/src/components/operator/inquiries/InquiryCard.tsx
@@ -49,13 +49,18 @@ export interface InquiryCardData {
     id: string;
     name: string;
   };
-  family: {
+  // Nullable: anonymous public inquiries have no linked family account.
+  family?: {
     id: string;
-    name: string;
+    name?: string | null;
     primaryContactName?: string | null;
     phone?: string | null;
     emergencyPhone?: string | null;
-  };
+  } | null;
+  // On-row contact details — the source of truth for anonymous inquiries.
+  contactName?: string | null;
+  contactEmail?: string | null;
+  contactPhone?: string | null;
   aiMatchScore?: number | null;
   // Future fields
   source?: InquirySource;
@@ -82,9 +87,15 @@ export default function InquiryCard({ inquiry, onEdit, onContact, isFamily = fal
     tourDate: inquiry.tourDate,
   });
 
-  // Get contact info
-  const contactName = inquiry.family.primaryContactName || inquiry.family.name;
-  const phone = inquiry.family.phone || inquiry.family.emergencyPhone;
+  // Get contact info — fall back to on-row fields for anonymous (no-family) leads
+  const contactName =
+    inquiry.family?.primaryContactName ||
+    inquiry.family?.name ||
+    inquiry.contactName ||
+    'Unknown contact';
+  const phone =
+    inquiry.family?.phone || inquiry.family?.emergencyPhone || inquiry.contactPhone;
+  const isUnlinkedLead = !inquiry.family;
 
   return (
     <div
@@ -143,10 +154,21 @@ export default function InquiryCard({ inquiry, onEdit, onContact, isFamily = fal
               </a>
             </div>
           )}
-          <div className="flex items-center gap-2 text-sm text-neutral-700">
-            <FiUser className="w-4 h-4 text-neutral-400" />
-            <span>{inquiry.family.name}</span>
-          </div>
+          {(inquiry.family?.name || inquiry.contactEmail) && (
+            <div className="flex items-center gap-2 text-sm text-neutral-700">
+              {inquiry.contactEmail && !inquiry.family ? (
+                <FiMail className="w-4 h-4 text-neutral-400" />
+              ) : (
+                <FiUser className="w-4 h-4 text-neutral-400" />
+              )}
+              <span>{inquiry.family?.name || inquiry.contactEmail}</span>
+            </div>
+          )}
+          {isUnlinkedLead && (
+            <div className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 border border-amber-200">
+              New lead · not yet linked
+            </div>
+          )}
         </div>
 
         {/* Key Dates */}

--- a/src/lib/services/inquiry-conversion.ts
+++ b/src/lib/services/inquiry-conversion.ts
@@ -86,6 +86,18 @@ export async function convertInquiryToResident(
       };
     }
 
+    // Anonymous (no-family) inquiries cannot be converted until linked to a
+    // family account — a Resident requires a family. The operator links the
+    // lead to a family first, then converts.
+    if (!inquiry.familyId) {
+      return {
+        success: false,
+        inquiryId: validated.inquiryId,
+        error: 'This lead is not linked to a family account yet. Link it to a family before converting to a resident.',
+      };
+    }
+    const familyId = inquiry.familyId; // non-null past the guard
+
     // Check if already converted
     if (inquiry.convertedToResidentId) {
       return {
@@ -110,7 +122,7 @@ export async function convertInquiryToResident(
       // Create resident record
       const resident = await tx.resident.create({
         data: {
-          familyId: inquiry.familyId,
+          familyId,
           homeId: inquiry.homeId,
           firstName: validated.firstName,
           lastName: validated.lastName,
@@ -128,7 +140,7 @@ export async function convertInquiryToResident(
       });
 
       // Create primary family contact from inquiry family
-      if (inquiry.family.user) {
+      if (inquiry.family?.user) {
         await tx.familyContact.create({
           data: {
             residentId: resident.id,
@@ -175,7 +187,7 @@ export async function convertInquiryToResident(
         : 'OPERATOR';
       triggerAffiliateCommission(
         inquiry.affiliateCode,
-        inquiry.contactEmail || inquiry.family.user?.email || null,
+        inquiry.contactEmail || inquiry.family?.user?.email || null,
         validated.inquiryId,
         referralType as 'FAMILY' | 'OPERATOR'
       ).catch((err) => console.error('[AFFILIATE] Unexpected error:', err));
@@ -401,6 +413,13 @@ export async function canConvertInquiry(inquiryId: string): Promise<{
 
   if (inquiry.convertedToResidentId) {
     return { canConvert: false, reason: 'Already converted to resident' };
+  }
+
+  if (!inquiry.familyId) {
+    return {
+      canConvert: false,
+      reason: 'Lead is not linked to a family account yet. Link it to a family before converting.',
+    };
   }
 
   const allowedStatuses = ['QUALIFIED', 'CONVERTING', 'TOUR_COMPLETED', 'PLACEMENT_OFFERED'];

--- a/src/types/inquiry.ts
+++ b/src/types/inquiry.ts
@@ -78,7 +78,8 @@ export enum FollowUpStatus {
 // Main Inquiry interface
 export interface Inquiry {
   id: string;
-  familyId: string;
+  // Nullable: anonymous inquiries are not linked to a family account.
+  familyId?: string | null;
   homeId: string;
   status: InquiryStatus;
   message?: string | null;


### PR DESCRIPTION
## Publish-wide PART A step 2 — capture anonymous inquiries (OL-083)

### The bug this fixes
The public home-detail tour/inquiry form (`src/app/homes/[id]/page.tsx`) POSTs to `/api/inquiries` **without authentication**, but the route hard-required a `familyId` and returned **400** when none resolved. Every anonymous lead from the public site was silently failing. This wires the path end-to-end.

### Approach (per decision: nullable `familyId`, no guest accounts, link later)
- **`Inquiry.familyId` is now nullable** — migration does `ALTER COLUMN "familyId" DROP NOT NULL` (additive/non-destructive; FK + `ON DELETE CASCADE` preserved).
- Anonymous leads live on the row's own contact fields (`contactName`/`contactEmail` are required by the Zod schema; plus `contactPhone`, `careRecipientName`, …).

### What changed
**Capture** — `/api/inquiries` POST drops the `familyId` 400; resolves from session/payload, else `null`.

**Operator + admin rendering** (null-safe with on-row fallbacks):
- Operator list search now matches `contactName/email/phone` → anonymous leads are findable.
- `InquiryCard` falls back to on-row contact and shows a **"New lead · not yet linked"** badge.
- Operator lead-detail route returns a `contact` block + nullable `family`; the page renders a **"Lead Contact / Not linked to a family account"** card.
- `FollowUpRemindersWidget`, `ConvertInquiryModal`, `InquiriesFilterPanel`, admin list/detail, `types/inquiry.ts` — `family` optional with fallbacks.

**Conversion guard** — anonymous inquiries can't convert (a `Resident` requires a family). `convertInquiryToResident`/`canConvertInquiry` block with a clear *"link to a family first"* message; the detail page hides Convert and shows the same guidance.

**Authz** — FAMILY-role checks use `family?.userId` (anonymous inquiries are never family-owned; operator/admin unchanged).

### Audited surface
Every `inquiry.family` / `familyId` read across the inquiry routes, services, widgets, and admin/operator pages was checked and guarded (full fan-out audit). `prisma validate`, `tsc --noEmit`, and `eslint` all clean (only pre-existing `useEffect`-dep warnings).

### Follow-up (not in this PR)
Link an anonymous inquiry to a real family by **email match** when that family later registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_