### PR TITLE
feat(search): badge unclaimed directory listings in search results

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -31,6 +31,7 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth';
 import { formatCurrency } from '@/lib/utils';
 import { calculateAIMatchScore, calculateAIMatchBreakdown } from '@/lib/ai-matching';
+import { isUnclaimedHome } from '@/lib/claim-engine/inquiry-claim-notification';
 import { prisma } from '@/lib/prisma';
 
 // Constants
@@ -491,6 +492,7 @@ export function generateMockHomes(count: number = 12) {
       aiMatchFactors: undefined,
       aiMatchWeights: undefined,
       isFavorited: false,
+      isUnclaimed: false,
     };
   });
 }
@@ -781,6 +783,10 @@ export async function GET(request: NextRequest) {
           name: `${home.operator.user.firstName} ${home.operator.user.lastName}`,
           email: home.operator.user.email
         } : null,
+        // A listing still owned by the directory sentinel operator is "unclaimed"
+        // — surfaced in results so the seeded directory shows, badged so families
+        // know no operator manages it yet.
+        isUnclaimed: isUnclaimedHome(home.operator?.user?.email),
         aiMatchScore,
         aiMatchFactors,
         aiMatchWeights,

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1013,6 +1013,13 @@ export default function SearchPage() {
                               Waitlist
                             </div>
                           )}
+
+                          {/* Unclaimed (directory) badge */}
+                          {home.isUnclaimed && (
+                            <div className="absolute left-2 top-2 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 shadow-md border border-amber-200">
+                              Unclaimed
+                            </div>
+                          )}
                         </div>
                         
                         <div className="flex flex-col p-4">
@@ -1154,6 +1161,13 @@ export default function SearchPage() {
                           ) : (
                             <div className="absolute right-2 top-2 rounded-full bg-neutral-500 px-2 py-1 text-xs font-medium text-white shadow-md">
                               Waitlist
+                            </div>
+                          )}
+
+                          {/* Unclaimed (directory) badge */}
+                          {home.isUnclaimed && (
+                            <div className="absolute left-2 top-2 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 shadow-md border border-amber-200">
+                              Unclaimed
                             </div>
                           )}
                         </div>

--- a/src/lib/searchService.ts
+++ b/src/lib/searchService.ts
@@ -103,6 +103,8 @@ export interface SearchResultItem {
   };
   /** Indicates whether the currently-logged-in family has favorited this home */
   isFavorited?: boolean;
+  /** True when the listing is still directory-owned (no operator has claimed it) */
+  isUnclaimed?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Publish-wide PART A step 1 — badge unclaimed listings in search (OL-083)

Search already returns all `ACTIVE` homes (no claimed/unclaimed filter), so the seeded directory listings surface. But families couldn't tell a **directory listing** (still owned by the sentinel operator `directory-unclaimed@carelinkai.system`) from an operator-managed one.

### Changes
- **`/api/search`** derives `isUnclaimed` per result via the existing `isUnclaimedHome()` helper on the operator user email that's **already included** in the query — no extra DB cost.
- **`SearchResultItem`** gains `isUnclaimed?: boolean`; dev mock-fallback homes set `false`.
- **Search result cards** (both grid and list layouts) render an amber **"Unclaimed"** badge in the top-left when the listing is directory-owned.

### Notes
- Zero new query cost (reuses the operator email already selected).
- `tsc --noEmit` clean; `eslint` clean (only pre-existing `<img>` LCP warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_