### PR TITLE
feat(homes): branded photo placeholder + add-photos claim nudge

### DIFF
--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -778,7 +778,7 @@ export default function HomeDetailPage() {
                   realHome.pendingInquiryCount > 0 ? (
                     <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-primary-200 bg-primary-50 p-4">
                       <p className="text-sm font-medium text-primary-900">
-                        📩 {realHome.pendingInquiryCount} {realHome.pendingInquiryCount === 1 ? 'family has' : 'families have'} inquired about this community — claim the listing to view &amp; respond securely.
+                        📩 {realHome.pendingInquiryCount} {realHome.pendingInquiryCount === 1 ? 'family has' : 'families have'} inquired about this community — claim the listing to view &amp; respond securely{photos.length === 0 ? ', and add your photos' : ''}.
                       </p>
                       <a
                         href="/auth/register?role=OPERATOR"
@@ -790,13 +790,15 @@ export default function HomeDetailPage() {
                   ) : (
                     <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
                       <p className="text-sm text-neutral-700">
-                        Are you the operator of this community? Claim your free listing to manage it and respond to families.
+                        {photos.length === 0
+                          ? 'Are you the operator of this community? Claim your free listing to add your photos, manage it, and respond to families.'
+                          : 'Are you the operator of this community? Claim your free listing to manage it and respond to families.'}
                       </p>
                       <a
                         href="/auth/register?role=OPERATOR"
                         className="shrink-0 rounded-lg border border-primary-600 px-4 py-2 text-sm font-semibold text-primary-700 hover:bg-primary-50"
                       >
-                        Claim this listing
+                        {photos.length === 0 ? 'Claim & add photos' : 'Claim this listing'}
                       </a>
                     </div>
                   )

--- a/src/components/homes/HomeImagePlaceholder.tsx
+++ b/src/components/homes/HomeImagePlaceholder.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Building2, Camera } from 'lucide-react';
+
+interface HomeImagePlaceholderProps {
+  /** Optional className to control sizing/rounding from the parent. */
+  className?: string;
+  /** Primary line, e.g. "Photos coming soon". */
+  label?: string;
+  /** Optional secondary line, e.g. an "add your photos" nudge. */
+  subtitle?: string;
+}
+
+/**
+ * Clean, branded stand-in for a senior-care listing that has no photos yet.
+ * Intentionally NOT a stock photo of a different building and NOT a broken
+ * image — an honest placeholder. Photos are operator-added on claim
+ * (OL-083), so this doubles as a gentle "add your photos" surface.
+ */
+export default function HomeImagePlaceholder({
+  className = 'h-64 w-full rounded-lg md:h-96',
+  label = 'Photos coming soon',
+  subtitle,
+}: HomeImagePlaceholderProps) {
+  return (
+    <div
+      className={`relative flex flex-col items-center justify-center overflow-hidden bg-gradient-to-br from-primary-50 via-white to-secondary-50 ${className}`}
+      role="img"
+      aria-label={label}
+    >
+      {/* Soft branded badge */}
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/70 shadow-sm ring-1 ring-primary-100">
+        <Building2 className="h-8 w-8 text-primary-300" />
+      </div>
+      <p className="mt-3 flex items-center gap-1.5 text-sm font-medium text-primary-700">
+        <Camera className="h-4 w-4 text-primary-400" />
+        {label}
+      </p>
+      {subtitle && <p className="mt-1 px-6 text-center text-xs text-neutral-500">{subtitle}</p>}
+    </div>
+  );
+}

--- a/src/components/homes/PhotoGallery.tsx
+++ b/src/components/homes/PhotoGallery.tsx
@@ -10,7 +10,7 @@ import {
   FiMinimize,
   FiGrid
 } from 'react-icons/fi';
-import { Camera } from 'lucide-react';
+import HomeImagePlaceholder from './HomeImagePlaceholder';
 
 export interface Photo {
   id: string;
@@ -147,16 +147,9 @@ const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     setIsLoading(false);
   };
 
-  // If no photos, show placeholder
+  // If no photos, show a clean branded placeholder (not a broken image).
   if (!photos.length) {
-    return (
-      <div className="relative h-64 w-full rounded-lg bg-neutral-200 md:h-96">
-        <div className="flex h-full w-full flex-col items-center justify-center">
-          <Camera className="mb-2 h-10 w-10 text-neutral-400" />
-          <p className="text-sm text-neutral-500">No photos available</p>
-        </div>
-      </div>
-    );
+    return <HomeImagePlaceholder className="h-64 w-full rounded-lg md:h-96" />;
   }
 
   return (


### PR DESCRIPTION
## Publish-wide PART C follow-up — branded photo placeholder + add-photos nudge (OL-083)

Per the publish decision, photos are **not** required to go ACTIVE (operators add them on claim), so photo-less directory listings need to render cleanly rather than look broken or borrow a misleading stock photo.

### Changes
- **New `HomeImagePlaceholder`** — a branded stand-in (brand gradient + building/camera icon + copy). Honest: not a stock photo of a different building, not a broken image.
- **`PhotoGallery`** now renders it for the empty state (replacing the plain grey "No photos available" box).
- **Unclaimed listing detail page** — the existing claim CTA is now **photo-aware**: when the home has no photos it nudges *"add your photos"* and the button reads **"Claim & add photos."**

### Scope note (flagged decision)
Search result cards still use the existing deterministic **stock-photo fallback** (`HOME_IMAGES`). That's not a broken image, but it isn't the real home either. Switching search to the branded placeholder for directory-wide consistency is a separate, more visible change (affects the whole directory's look) — happy to do it as a fast follow if you want that consistency; left out here to keep this PR low-risk.

`tsc` clean; `eslint` clean (pre-existing `<img>` warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_