### PR TITLE
feat(directory): seed Greater-Cleveland 6-county metro RCF list (OL-083 Part B)

### DIFF
--- a/context/METRO_RCF_MASTER_LIST.md
+++ b/context/METRO_RCF_MASTER_LIST.md
@@ -1,0 +1,313 @@
+# Greater-Cleveland Metro — Assisted Living / Residential Care Facility (RCF) Master List
+
+**Purpose:** Supply-side directory seed list for CareLinkAI. This is the comprehensive
+list of licensed assisted-living / Residential Care Facilities (RCFs) across the 6
+greater-Cleveland counties, intended for a developer to dedupe and seed into the
+facilities database.
+
+**Counties covered:** Cuyahoga, Summit, Lake, Geauga, Medina, Lorain (Ohio).
+
+**Compiled:** 2026-06-22
+
+---
+
+## Method & Sources
+
+- **Primary backbone:** `continuingcarecommunities.org` county pages (an A-Place-for-Mom
+  partner directory). Critically, this source republishes **Ohio Department of Health (ODH)
+  license numbers** for most entries. License numbers ending in **`R`** (e.g. `2318R`) are
+  ODH **Residential Care Facility (RCF)** licenses — the canonical "this is a licensed
+  assisted-living facility" signal. License numbers in the **`365xxx`/`366xxx`** range are
+  **nursing-home (SNF)** licenses; facilities carrying only a 365/366 number are
+  nursing-primary and many also operate an attached AL/RCF wing.
+- **Cross-reference / coverage fill:** WebSearch + facility/operator sites for SeniorLiving.org,
+  Caring.com, A Place for Mom, Seniorly, AssistedLiving.org, and operator chains
+  (Vitalia, StoryPoint/Danbury, Brookdale, Sunrise, Arden Courts, Anthology, HarborChase,
+  Vista Springs, Ohio Living, Judson, Eliza Jennings, O'Neill Healthcare).
+
+### Care-type key
+- **AL** = Assisted Living / Residential Care Facility
+- **MC** = Memory Care (dementia/Alzheimer's) — noted where the facility advertises a dedicated unit
+- **IL** = Independent Living also on campus
+- **SNF** = Skilled Nursing also on campus (mixed-care campus)
+- *(SNF-primary)* = nursing-home-primary per ODH license; AL/RCF presence is secondary or
+  attached. Included because they were listed in the AL directory and most carry an
+  RCF-eligible AL wing, **but the developer should verify these before seeding** — a few may
+  be SNF-only and should be dropped.
+
+### Coverage caveats (READ BEFORE SEEDING)
+1. **This list is intentionally over-inclusive on the SNF-mixed edge.** The backbone
+   directory blends true RCF/AL communities with some nursing-home-primary campuses. Entries
+   I judged nursing-primary are tagged *(SNF-primary)*. The CareLinkAI exclusion rule
+   (skilled-nursing-ONLY) means a handful of these should be dropped on verification.
+2. **Pure independent-living / 55+ apartments (HUD 202 etc.) were excluded** — e.g. National
+   Church Residences IL-only properties are not listed unless they also carry AL/RCF.
+3. **License numbers shown are as published by the directory and may be stale.** Treat the
+   ODH Long-Term Care Consumer Guide (`ltcohio.org` / `ltc.ohio.gov`) as the authority for
+   current licensure before any outreach commitment.
+4. **Geauga and (to a lesser degree) Medina/Lake are genuinely smaller markets** — the lower
+   counts there reflect real supply, not thin research. I did not pad them.
+5. **Dedupe note:** This list has NOT been deduped against the ~65 already-seeded facilities
+   (Tier-A 50 + batch-2 15). The developer should dedupe against the existing seed before
+   inserting the gap. Watch for chain naming variants (e.g. "Arden Courts of X" vs "Arden
+   Courts A ProMedica Memory Care Community of X"; "Danbury X" vs "StoryPoint X").
+
+### Counts
+| County | Facilities listed (rows) |
+|--------|------------------:|
+| Cuyahoga | 60 |
+| Summit | 45 |
+| Lorain | 21 |
+| Lake | 18 |
+| Medina | 14 |
+| Geauga | 11 |
+| **TOTAL** | **169** |
+
+*(Row numbering runs 1–170 continuously because Summit's placeholder row was removed, leaving
+169 actual facility rows. A handful of rows are tagged *(SNF-primary)* or *(verify)* and may be
+dropped on verification, so the seed-eligible net will likely land ~140–155.)*
+
+---
+
+## CUYAHOGA COUNTY
+
+| # | Facility Name | City | County | Care types | Source |
+|---|---------------|------|--------|-----------|--------|
+| 1 | A.M. McGregor Home | East Cleveland | Cuyahoga | AL, MC (lic 0592R) | continuingcarecommunities.org |
+| 2 | Algart Health Care | Cleveland | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 3 | Altercare at Saint Joseph Center | Cleveland | Cuyahoga | AL, MC (lic 1303R) | continuingcarecommunities.org |
+| 4 | Anthology of Mayfield Heights | Mayfield Heights | Cuyahoga | AL, MC | seniorsbluebook.com / seniorcareauthority.com |
+| 5 | Arden Courts of Parma | Parma / North Royalton | Cuyahoga | MC (lic 2234R) | continuingcarecommunities.org / seniorly.com |
+| 6 | Arden Courts of Westlake | Westlake | Cuyahoga | MC (lic 2117R) | continuingcarecommunities.org |
+| 7 | Aristocrat Berea | Berea | Cuyahoga | AL, MC *(SNF-primary)* | continuingcarecommunities.org |
+| 8 | Ashton at Mayfield Heights | Mayfield Heights | Cuyahoga | AL, MC | seniorly.com |
+| 9 | Athenian Assisted Living | North Royalton | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 10 | Belvedere of Westlake | Westlake | Cuyahoga | AL (lic 2318R) | seniorlivingnearme.org |
+| 11 | Berea Lake Towers Retirement Community | Berea | Cuyahoga | AL, IL | continuingcarecommunities.org |
+| 12 | Broadway Care Center of Maple Heights | Maple Heights | Cuyahoga | AL, MC *(SNF-primary, lic 365701)* | continuingcarecommunities.org |
+| 13 | Brookdale Gardens at Westlake | Westlake | Cuyahoga | AL | seniorliving.org |
+| 14 | Brookdale Middleburg Heights | Middleburg Heights | Cuyahoga | AL, MC (lic 2220R) | continuingcarecommunities.org |
+| 15 | Brookdale Richmond Heights | Richmond Heights | Cuyahoga | AL, MC (lic 2274R) | continuingcarecommunities.org |
+| 16 | Brookdale Westlake Village | Westlake | Cuyahoga | AL, IL | aplaceformom.com |
+| 17 | Candlewood Park Healthcare Center | East Cleveland | Cuyahoga | AL, MC *(SNF-primary)* | continuingcarecommunities.org |
+| 18 | Cedarwood Plaza | Cleveland Heights | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 19 | Century Oak Care Center | Middleburg Heights | Cuyahoga | AL, MC *(SNF-primary, lic 365702)* | continuingcarecommunities.org |
+| 20 | Concord Reserve (Paragon Building) | Westlake | Cuyahoga | AL, MC, IL | continuingcarecommunities.org |
+| 21 | Danbury Senior Living Broadview Heights | Broadview Heights | Cuyahoga | AL, MC | continuingcarecommunities.org / storypoint.com |
+| 22 | Devon Oaks | Westlake | Cuyahoga | AL (lic 2315R) | continuingcarecommunities.org |
+| 23 | East Park Memory Care Facility | Brook Park | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 24 | East Park Retirement Community | Brook Park | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 25 | Eliza Jennings (Eliza Jennings Home / campus) | Cleveland (Lakewood area) | Cuyahoga | AL, MC, SNF | jenningsohio / seniorly.com |
+| 26 | Emerald Village Senior Living | North Olmsted | Cuyahoga | AL, MC (lic 2481R) | continuingcarecommunities.org |
+| 27 | Generations Senior Living of Strongsville | Strongsville | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 28 | Governor's Village | Mayfield Village | Cuyahoga | AL, MC | seniorly.com |
+| 29 | HarborChase of Shaker Heights | Shaker Heights | Cuyahoga | AL, MC | seniorly.com |
+| 30 | Harbor Court Retirement Community | Rocky River | Cuyahoga | AL, MC | caring.com |
+| 31 | Haven at Lakewood | Lakewood | Cuyahoga | AL | seniorliving.org |
+| 32 | Heights Care and Rehabilitation Center | Broadview Heights | Cuyahoga | AL, MC *(SNF-primary, lic 365661)* | continuingcarecommunities.org |
+| 33 | Judson Manor | Cleveland | Cuyahoga | AL, IL | caring.com / judsonseniorliving |
+| 34 | Judson Park | Cleveland Heights | Cuyahoga | AL, MC, IL | judsonseniorliving |
+| 35 | Kemper House Highland Heights | Highland Heights | Cuyahoga | AL, MC | seniorhomes.com |
+| 36 | Kemper House Strongsville | Strongsville | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 37 | Kindred Living at The Fountains | Lyndhurst | Cuyahoga | AL, MC (lic 2089R) | continuingcarecommunities.org |
+| 38 | Lakewood Health Care Center | Lakewood | Cuyahoga | AL, MC (lic 0506R) | continuingcarecommunities.org |
+| 39 | Landerbrook Transitional Care | Mayfield Heights | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 40 | Legacy Place - Parma | Parma | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 41 | Light of Hearts Villa | Bedford | Cuyahoga | AL, MC | assistedlivingmagazine.com / seniorhomes.com |
+| 42 | Marymount Place | Garfield Heights | Cuyahoga | AL, MC (lic 2207R) | continuingcarecommunities.org |
+| 43 | Menorah Park Center for Senior Living | Beachwood | Cuyahoga | AL, MC, SNF | continuingcarecommunities.org |
+| 44 | O'Neill Healthcare Bay Village | Bay Village | Cuyahoga | AL, MC (lic 0448R) | continuingcarecommunities.org |
+| 45 | O'Neill Healthcare Fairview Park | Fairview Park | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 46 | O'Neill Healthcare Lakewood | Lakewood | Cuyahoga | AL, MC, IL, SNF (lic 365267) | continuingcarecommunities.org |
+| 47 | O'Neill Healthcare North Olmsted | North Olmsted | Cuyahoga | AL (lic 2329R) | seniorlivingnearme.org |
+| 48 | Oaks of Brecksville | Brecksville | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 49 | Park Creek Center | Parma Heights | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 50 | Park East (Wiggins / Montefiore campus) | Beachwood | Cuyahoga | AL, MC (lic 365810) | continuingcarecommunities.org |
+| 51 | Parkside Villa | Middleburg Heights | Cuyahoga | AL, MC (lic 2347R) | continuingcarecommunities.org |
+| 52 | Pleasant Lake Villa | Parma | Cuyahoga | AL, MC (lic 1872R) | continuingcarecommunities.org |
+| 53 | Rose Senior Living Beachwood | Beachwood | Cuyahoga | AL, MC, IL | seniorly.com |
+| 54 | Singleton Health Care Center | Cleveland | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 55 | Solon Pointe at Emerald Ridge | Solon | Cuyahoga | AL, MC (lic 2219R) | continuingcarecommunities.org |
+| 56 | St. Augustine Towers | Cleveland | Cuyahoga | AL, MC | continuingcarecommunities.org |
+| 57 | Sunrise at Shaker Heights | Shaker Heights | Cuyahoga | AL, MC | seniorhomes.net |
+| 58 | Sunrise of Rocky River (Bickford of Rocky River) | Rocky River | Cuyahoga | AL, MC (lic 2190R) | continuingcarecommunities.org |
+| 59 | The Montefiore Home | Beachwood | Cuyahoga | AL, MC, SNF | continuingcarecommunities.org |
+| 60 | The Woodlands of Shaker Heights | Shaker Heights | Cuyahoga | AL, MC | seniorly.com |
+
+*Additional Cuyahoga SNF-primary campuses that appeared in the AL directory but should be
+verified/likely dropped (skilled-nursing-leaning): Manorcare Mayfield Heights, Southern Hills
+Health & Rehab (Middleburg Hts), Seven Hills Health & Rehab, Southwest Commons (Strongsville),
+The Pavilion Rehab & Nursing (North Royalton), Willows Health & Rehab (Euclid), Cedarwood,
+Vantage Place (Cleveland — AL/MC, keep). Listed here as a verification note, not seeded rows.*
+
+---
+
+## SUMMIT COUNTY
+
+| # | Facility Name | City | County | Care types | Source |
+|---|---------------|------|--------|-----------|--------|
+| 61 | Arden Courts of Bath | Akron (Bath) | Summit | AL, MC | continuingcarecommunities.org |
+| 62 | Avenue at Macedonia | Macedonia | Summit | AL, MC (lic 366454) | continuingcarecommunities.org |
+| 63 | Briarwood | Stow | Summit | AL, MC (lic 1963R) | continuingcarecommunities.org |
+| 64 | Brookdale Barberton | Barberton | Summit | AL, MC | continuingcarecommunities.org |
+| 65 | Brookdale Bath | Akron (Bath) | Summit | AL, MC | continuingcarecommunities.org |
+| 66 | Brookdale Montrose | Akron | Summit | AL | continuingcarecommunities.org |
+| 67 | Brookdale Stow | Stow | Summit | AL, MC (lic 2502R) | continuingcarecommunities.org |
+| 68 | Cardinal Retirement Village | Cuyahoga Falls | Summit | AL, MC | continuingcarecommunities.org |
+| 69 | Cherry Creek Acres | Stow | Summit | AL, MC (lic 2520R) | continuingcarecommunities.org |
+| 70 | Concordia at Sumner | Copley | Summit | AL, MC, IL (lic 2389R) | continuingcarecommunities.org |
+| 71 | Crown Center at Laurel Lake | Hudson | Summit | AL, MC, IL | continuingcarecommunities.org |
+| 72 | Danbury Woods | Cuyahoga Falls | Summit | AL, MC | continuingcarecommunities.org |
+| 73 | Elmcroft of Sagamore Hills | Sagamore Hills | Summit | AL, MC (lic 2271R) | continuingcarecommunities.org |
+| 74 | Elms Assisted Living | Hudson | Summit | AL, MC | continuingcarecommunities.org |
+| 75 | Essex Healthcare of Tallmadge | Tallmadge | Summit | AL, MC *(SNF-primary)* | continuingcarecommunities.org |
+| 76 | Gables of Hudson | Hudson | Summit | AL, MC | continuingcarecommunities.org |
+| 77 | Gardens of Western Reserve at Cuyahoga Falls | Cuyahoga Falls | Summit | AL, MC (lic 2429R) | continuingcarecommunities.org |
+| 78 | Grande Village Suites | Twinsburg | Summit | AL, MC (lic 2437R) | continuingcarecommunities.org |
+| 79 | Grande Village Villas | Twinsburg | Summit | AL, MC | continuingcarecommunities.org |
+| 80 | Greenfield Estate Alzheimer's Special Care Center | Akron | Summit | AL, MC | continuingcarecommunities.org |
+| 81 | Greenview Senior Assisted Living | Uniontown | Summit | AL, MC | continuingcarecommunities.org |
+| 82 | Heartland of Twinsburg | Twinsburg | Summit | AL, MC *(SNF-primary, lic 366419)* | continuingcarecommunities.org |
+| 83 | Heather Knoll Retirement Village | Tallmadge | Summit | AL, MC | continuingcarecommunities.org |
+| 84 | Heritage of Hudson | Hudson | Summit | AL, MC | continuingcarecommunities.org |
+| 85 | Legacy Place - Twinsburg | Twinsburg | Summit | AL, MC (lic 2240R) | continuingcarecommunities.org |
+| 86 | Maplewood at Cuyahoga Falls | Cuyahoga Falls | Summit | AL, MC | continuingcarecommunities.org |
+| 87 | Maplewood at Twinsburg | Twinsburg | Summit | AL, MC | continuingcarecommunities.org |
+| 88 | Merriman | Akron | Summit | AL, MC (lic 0523R) | continuingcarecommunities.org |
+| 89 | Mulberry Gardens | Munroe Falls | Summit | AL, MC (lic 2405R) | continuingcarecommunities.org |
+| 90 | National Church Residences Portage Trail Village | Cuyahoga Falls | Summit | AL (lic 2588R) | continuingcarecommunities.org |
+| 91 | Pleasant Pointe Assisted Living | Barberton | Summit | AL, MC (lic 2249R) | continuingcarecommunities.org |
+| 92 | Regina Health Center | Richfield | Summit | AL, MC, SNF (lic 2001R) | continuingcarecommunities.org |
+| 93 | Renaissance Assisted Living | Richfield | Summit | AL, MC | continuingcarecommunities.org |
+| 94 | Rockynol Retirement Community (Ohio Living) | Akron | Summit | AL, MC, IL | continuingcarecommunities.org |
+| 95 | St. Luke Lutheran Community - Portage Lakes | Akron | Summit | AL, MC (lic 0670R) | continuingcarecommunities.org |
+| 96 | Stow Glen Assisted Living | Stow | Summit | AL, MC (lic 1797R) | continuingcarecommunities.org |
+| 97 | Summit Point | Macedonia | Summit | AL, MC | continuingcarecommunities.org |
+| 98 | Sunrise Assisted Living of Cuyahoga Falls | Cuyahoga Falls | Summit | AL, MC (lic 2294R) | continuingcarecommunities.org |
+| 99 | Tallmadge Senior Living | Tallmadge | Summit | AL, MC | continuingcarecommunities.org |
+| 100 | The Pinnacle Rehabilitation and Nursing Center | Tallmadge | Summit | AL, MC *(SNF-primary, lic 366010)* | continuingcarecommunities.org |
+| 101 | Village at St. Edward | Fairlawn | Summit | AL, MC, IL | continuingcarecommunities.org |
+| 102 | Vista Springs Macedonia | Macedonia | Summit | AL, MC (lic 2707R) | continuingcarecommunities.org |
+| 103 | Vitalia Montrose (The V Living) | Akron (Montrose) | Summit | AL, MC, IL | vitaliaseniorliving.com |
+| 104 | Vitalia Stow | Stow | Summit | AL, MC, IL | vitaliaseniorliving.com |
+| 105 | Pleasant View Health Care Center | Barberton | Summit | AL, MC *(SNF-primary)* | continuingcarecommunities.org |
+
+*Summit note: rows 61–105 = 45 distinct facilities. The backbone directory reported "46" for
+Summit; the remainder are SNF-primary campuses I excluded (Manorcare Barberton, Saber Skilled
+Nursing Unit Barberton — both nursing-only per their 365xxx licenses). Verify the *(SNF-primary)*
+rows above (75, 82, 100, 105) before seeding.*
+
+---
+
+## LORAIN COUNTY
+
+| # | Facility Name | City | County | Care types | Source |
+|---|---------------|------|--------|-----------|--------|
+| 107 | Abbewood Assisted Living | Elyria | Lorain | AL, MC | continuingcarecommunities.org |
+| 108 | Amherst Manor Assisted Living | Amherst | Lorain | AL, MC (lic 0416R) | continuingcarecommunities.org |
+| 109 | Anchor Lodge Limited | Lorain | Lorain | AL, MC | continuingcarecommunities.org |
+| 110 | Avenue Assisted Living (Avon Lake) | Avon Lake | Lorain | AL, MC (lic 2462R) | continuingcarecommunities.org |
+| 111 | Avon Place | Avon | Lorain | AL, MC *(SNF-primary, lic 365155)* | continuingcarecommunities.org |
+| 112 | Danbury North Ridgeville | North Ridgeville | Lorain | AL, MC | storypoint.com |
+| 113 | Elmcroft of Lorain | Lorain | Lorain | AL, MC (lic 2301R) | continuingcarecommunities.org |
+| 114 | Elms Retirement Village | Wellington | Lorain | AL, MC (lic 1194R) | continuingcarecommunities.org |
+| 115 | Gardens of French Creek at Avon Oaks | Avon | Lorain | AL, MC | continuingcarecommunities.org |
+| 116 | Independence Village of Avon Lake | Avon Lake | Lorain | AL, MC | continuingcarecommunities.org |
+| 117 | Kendal at Oberlin | Oberlin | Lorain | AL, MC, IL, SNF | continuingcarecommunities.org |
+| 118 | Main Street Care Center | Avon Lake | Lorain | AL, MC *(SNF-primary, lic 365865)* | continuingcarecommunities.org |
+| 119 | O'Neill Healthcare North Ridgeville | North Ridgeville | Lorain | AL, MC | continuingcarecommunities.org |
+| 120 | O'Neill Healthcare Assisted Living (N. Ridgeville) | North Ridgeville | Lorain | AL, MC | continuingcarecommunities.org |
+| 121 | St. Mary of the Woods | Avon | Lorain | AL, MC (lic 2439R) | continuingcarecommunities.org |
+| 122 | Wesleyan Village (Ohio Living) | Elyria | Lorain | AL, MC, IL (lic 0477R) | continuingcarecommunities.org |
+| 123 | Lake Pointe Health Care | Lorain | Lorain | AL, MC *(SNF-primary)* | continuingcarecommunities.org |
+| 124 | Northridge Health Center | North Ridgeville | Lorain | AL, MC *(SNF-primary, lic 365645)* | continuingcarecommunities.org |
+| 125 | Oak Hills Nursing Center | Lorain | Lorain | AL, MC *(SNF-primary)* | continuingcarecommunities.org |
+| 126 | Autumn Aegis (Lorain) | Lorain | Lorain | AL, MC *(SNF-primary, lic 365940)* | continuingcarecommunities.org |
+| 127 | Wellington Place / Welcome Nursing Home (verify) | Oberlin | Lorain | AL, MC *(SNF-primary, verify)* | directory cross-ref |
+
+*Lorain note: Several rows (111, 118, 123–127) are nursing-primary campuses that the directory
+listed under AL. Verify against ODH before seeding; some may be SNF-only and should drop. Amherst
+Manor Nursing Home (SNF) was folded into Amherst Manor Assisted Living (#108) as one campus.*
+
+---
+
+## LAKE COUNTY
+
+| # | Facility Name | City | County | Care types | Source |
+|---|---------------|------|--------|-----------|--------|
+| 128 | Brookdale Mentor | Mentor | Lake | AL, MC | continuingcarecommunities.org |
+| 129 | Brookdale Newell Creek | Mentor | Lake | AL, MC (lic 2652R) | continuingcarecommunities.org |
+| 130 | Brookdale Wickliffe | Wickliffe | Lake | AL, MC | continuingcarecommunities.org |
+| 131 | Brookdale Willoughby | Willoughby | Lake | AL, MC | continuingcarecommunities.org |
+| 132 | Danbury Mentor | Mentor | Lake | AL, MC | storypoint.com / seniorly.com |
+| 133 | Governor's Pointe | Mentor | Lake | AL, MC | continuingcarecommunities.org |
+| 134 | Homestead I | Painesville | Lake | AL, MC (lic 365492) | continuingcarecommunities.org |
+| 135 | Homestead II | Painesville | Lake | AL, MC | continuingcarecommunities.org |
+| 136 | Ivy House Assisted Living | Painesville | Lake | AL, MC (lic 0080R) | continuingcarecommunities.org |
+| 137 | Lantern of Madison | Madison | Lake | AL, MC | continuingcarecommunities.org |
+| 138 | Nason Center of Breckenridge Village | Willoughby | Lake | AL, MC (lic 1760R) | continuingcarecommunities.org |
+| 139 | Ohio Living Breckenridge Village | Willoughby | Lake | AL, MC, IL (lic 365581) | continuingcarecommunities.org |
+| 140 | Salida Woods Assisted Living | Mentor | Lake | AL, MC | continuingcarecommunities.org |
+| 141 | Symphony at Mentor | Mentor | Lake | AL, MC | continuingcarecommunities.org |
+| 142 | Van Gorder Manor | Willoughby | Lake | AL, MC | continuingcarecommunities.org |
+| 143 | Wickliffe Country Place | Wickliffe | Lake | AL, MC *(SNF-primary)* | continuingcarecommunities.org |
+| 144 | Heartland of Willoughby | Willoughby | Lake | AL *(SNF-primary, lic 365305)* | continuingcarecommunities.org |
+| 145 | Kindred Transitional Care & Rehab - LakeMed | Painesville | Lake | AL, MC *(SNF-primary, lic 365713)* | continuingcarecommunities.org |
+
+---
+
+## MEDINA COUNTY
+
+| # | Facility Name | City | County | Care types | Source |
+|---|---------------|------|--------|-----------|--------|
+| 146 | Altercare of Wadsworth | Wadsworth | Medina | AL, MC *(SNF-primary)* | continuingcarecommunities.org |
+| 147 | Brookdale Medina North | Medina | Medina | AL, MC (lic 2357R) | continuingcarecommunities.org |
+| 148 | Brookdale Medina South | Medina | Medina | AL, MC (lic 2319R) | continuingcarecommunities.org |
+| 149 | Danbury Brunswick | Brunswick | Medina | AL, MC | storypoint.com |
+| 150 | Elmcroft of Medina | Medina | Medina | AL, MC (lic 2227R) | continuingcarecommunities.org |
+| 151 | Inn at Coal Ridge | Wadsworth | Medina | AL, MC | continuingcarecommunities.org |
+| 152 | Liberty Residence Holdings | Wadsworth | Medina | AL, MC | continuingcarecommunities.org |
+| 153 | Plum Creek Assisted Living | Brunswick | Medina | AL, MC | continuingcarecommunities.org |
+| 154 | Samaritan Villa | Medina | Medina | AL | continuingcarecommunities.org |
+| 155 | Sanctuary Wadsworth | Wadsworth | Medina | AL, MC | continuingcarecommunities.org |
+| 156 | StoryPoint Medina East | Medina | Medina | AL, IL | storypoint.com |
+| 157 | StoryPoint Medina West | Medina | Medina | AL, MC, IL | storypoint.com |
+| 158 | Wadsworth Pointe | Wadsworth | Medina | AL, MC (lic 2059R) | continuingcarecommunities.org |
+| 159 | Western Reserve Masonic Community | Medina | Medina | AL, MC, IL (lic 2188R) | continuingcarecommunities.org |
+
+*Medina note: Willowood Care Center of Brunswick (lic 365785) and Pearlview Rehab & Wellness
+(Brunswick) appeared in the AL directory but are SNF-primary — verify before seeding; likely drop.*
+
+---
+
+## GEAUGA COUNTY
+
+| # | Facility Name | City | County | Care types | Source |
+|---|---------------|------|--------|-----------|--------|
+| 160 | Arden Courts of Chagrin Falls | Bainbridge | Geauga | AL, MC (lic 2243R) | continuingcarecommunities.org |
+| 161 | Briar Hill Health Care Residence | Middlefield | Geauga | AL, MC (lic 0260R) | continuingcarecommunities.org |
+| 162 | Briarcliff Manor | Middlefield | Geauga | AL, MC | continuingcarecommunities.org |
+| 163 | Holly Hill | Newbury | Geauga | AL, MC | continuingcarecommunities.org |
+| 164 | Maplewood at Heather Hill | Chardon | Geauga | AL, MC (lic 2264R) | continuingcarecommunities.org |
+| 165 | Pines at Brooks House | Hiram | Geauga | AL, MC (lic 2500R) | continuingcarecommunities.org |
+| 166 | Princeton Place | Huntsburg | Geauga | AL, MC (lic 0666R) | continuingcarecommunities.org |
+| 167 | Residence of Chardon | Chardon | Geauga | AL, MC | continuingcarecommunities.org |
+| 168 | South Franklin Circle | Bainbridge | Geauga | AL, MC, IL | continuingcarecommunities.org |
+| 169 | Weils of Bainbridge (The Weils) | Bainbridge | Geauga | AL, MC, SNF | continuingcarecommunities.org |
+| 170 | Hamlet at Chagrin Falls (verify county — Chagrin Falls campus) | Chagrin Falls | Geauga/Cuyahoga border | AL, MC, IL *(verify)* | directory cross-ref |
+
+*Geauga note: This is a genuinely small market (~10–11 facilities). Count is not padded. Row 170
+(Hamlet at Chagrin Falls) straddles the Cuyahoga/Geauga line — verify county assignment.*
+
+---
+
+## End-of-list verification checklist for the developer
+1. **Dedupe** against the ~65 already-seeded Tier-A + batch-2 facilities (name + city + license).
+2. **Drop or confirm** every row tagged *(SNF-primary)* — verify it carries an AL/RCF wing in
+   the ODH Long-Term Care Consumer Guide; if SNF-only, exclude per CareLinkAI rules.
+3. **Verify license numbers** against `ltcohio.org` / `ltc.ohio.gov` (some published numbers
+   may be stale; some `365xxx` are SNF not RCF).
+4. **Resolve chain naming variants** before insert (Arden Courts / ProMedica; Danbury /
+   StoryPoint; Vitalia / Omni Lifestyle).
+5. **Confirm county** for border rows (Hamlet at Chagrin Falls; any Bath/Montrose Summit-Cuyahoga
+   edge cases).

--- a/scripts/seed-cleveland-metro.ts
+++ b/scripts/seed-cleveland-metro.ts
@@ -1,0 +1,455 @@
+/**
+ * seed-cleveland-metro.ts  (OL-083 PART B)
+ *
+ * Seeds the Greater-Cleveland 6-county RCF/AL master list (compiled by Cowork,
+ * 2026-06-22 — see context/METRO_RCF_MASTER_LIST.md) as DRAFT listings under the
+ * same placeholder "CareLinkAI Directory - Unclaimed Listings" operator used by
+ * seed-cleveland-directory.ts and seed-cleveland-batch2.ts.
+ *
+ * Counties: Cuyahoga, Summit, Lorain, Lake, Geauga, Medina. 169 source rows.
+ *
+ * DEDUPE: This list overlaps the ~65 already-seeded facilities (Tier-A + batch-2).
+ * The script dedupes against ALL existing homes (any operator) by a normalized
+ * facility name, plus a small curated alias set for known rebrands the normalizer
+ * can't catch (e.g. Anthology→Ashton, Bickford/Sunrise→Bloom). Anything matching is
+ * SKIPPED; only genuinely-new facilities are created. Re-running is idempotent.
+ *
+ * SNF-PRIMARY GATING: Rows the source flagged *(SNF-primary)* are nursing-home-
+ * primary per their ODH 365xxx/366xxx license; CareLinkAI excludes skilled-nursing-
+ * ONLY facilities. These are NOT seeded by default — they are reported as held and
+ * require ODH verification first. Pass --include-unverified to seed them anyway.
+ *
+ * Listings are DRAFT (NOT publicly visible). careLevel is a starting hint from the
+ * source; the enrich pipeline (autopopulate-cohort.ts) refines it and fills address.
+ * capacity is seeded 0 ("unknown — verify") — these have no authoritative public bed
+ * count. Do not treat capacity 0 as real.
+ *
+ * Flow: seed (this) → enrich (autopopulate-cohort.ts) → publish (publish-directory-homes.ts).
+ *
+ * Usage:
+ *   npx tsx scripts/seed-cleveland-metro.ts --dry-run                  # preview (recommended first)
+ *   npx tsx scripts/seed-cleveland-metro.ts                            # write new DRAFT rows
+ *   npx tsx scripts/seed-cleveland-metro.ts --include-unverified       # also seed SNF-primary rows
+ *   npx tsx scripts/seed-cleveland-metro.ts --with-websites            # also auto-discover website URLs
+ *   (--with-websites requires GOOGLE_PLACES_API_KEY)
+ *
+ * Risk register: Risk 2 (two-sided marketplace cold start — supply density).
+ */
+
+import { PrismaClient, CareLevel, HomeStatus, UserRole } from '@prisma/client';
+import { findWebsiteUrl, isAnyLookupConfigured } from '../src/lib/place-lookup';
+
+const prisma = new PrismaClient();
+
+const PLACES_DELAY_MS = 250;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const SEED_USER_EMAIL = 'directory-unclaimed@carelinkai.system';
+const SEED_OPERATOR_NAME = 'CareLinkAI Directory - Unclaimed Listings';
+
+interface MetroFacility {
+  name: string;
+  city: string;
+  county: string;
+  careLevel: CareLevel[];
+  /** ODH license number as published by the source directory (may be stale). */
+  lic?: string;
+  /** Source flagged this as nursing-home-primary — gated out unless --include-unverified. */
+  snfPrimary?: boolean;
+  /** Source flagged this row to verify (county border, SNF edge). Informational. */
+  verify?: boolean;
+  /** Terse provenance note (alternate name, sub-area). */
+  note?: string;
+}
+
+const METRO: MetroFacility[] = [
+  // --- CUYAHOGA COUNTY ---
+  { name: 'A.M. McGregor Home', city: 'East Cleveland', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '0592R' },
+  { name: 'Algart Health Care', city: 'Cleveland', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Altercare at Saint Joseph Center', city: 'Cleveland', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '1303R' },
+  { name: 'Anthology of Mayfield Heights', city: 'Mayfield Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Arden Courts of Parma', city: 'Parma', county: 'Cuyahoga', careLevel: [CareLevel.MEMORY_CARE], lic: '2234R', note: 'Parma / North Royalton' },
+  { name: 'Arden Courts of Westlake', city: 'Westlake', county: 'Cuyahoga', careLevel: [CareLevel.MEMORY_CARE], lic: '2117R' },
+  { name: 'Aristocrat Berea', city: 'Berea', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], snfPrimary: true, verify: true },
+  { name: 'Ashton at Mayfield Heights', city: 'Mayfield Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Athenian Assisted Living', city: 'North Royalton', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Belvedere of Westlake', city: 'Westlake', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED], lic: '2318R' },
+  { name: 'Berea Lake Towers Retirement Community', city: 'Berea', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.INDEPENDENT] },
+  { name: 'Broadway Care Center of Maple Heights', city: 'Maple Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '365701', snfPrimary: true, verify: true },
+  { name: 'Brookdale Gardens at Westlake', city: 'Westlake', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED] },
+  { name: 'Brookdale Middleburg Heights', city: 'Middleburg Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2220R' },
+  { name: 'Brookdale Richmond Heights', city: 'Richmond Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2274R' },
+  { name: 'Brookdale Westlake Village', city: 'Westlake', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.INDEPENDENT] },
+  { name: 'Candlewood Park Healthcare Center', city: 'East Cleveland', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], snfPrimary: true, verify: true },
+  { name: 'Cedarwood Plaza', city: 'Cleveland Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Century Oak Care Center', city: 'Middleburg Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '365702', snfPrimary: true, verify: true },
+  { name: 'Concord Reserve (Paragon Building)', city: 'Westlake', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT] },
+  { name: 'Danbury Senior Living Broadview Heights', city: 'Broadview Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Devon Oaks', city: 'Westlake', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED], lic: '2315R' },
+  { name: 'East Park Memory Care Facility', city: 'Brook Park', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'East Park Retirement Community', city: 'Brook Park', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Eliza Jennings', city: 'Cleveland', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.SKILLED_NURSING], note: 'aka Eliza Jennings Home / campus; Lakewood area' },
+  { name: 'Emerald Village Senior Living', city: 'North Olmsted', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2481R' },
+  { name: 'Generations Senior Living of Strongsville', city: 'Strongsville', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Governor\'s Village', city: 'Mayfield Village', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'HarborChase of Shaker Heights', city: 'Shaker Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Harbor Court Retirement Community', city: 'Rocky River', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Haven at Lakewood', city: 'Lakewood', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED] },
+  { name: 'Heights Care and Rehabilitation Center', city: 'Broadview Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '365661', snfPrimary: true, verify: true },
+  { name: 'Judson Manor', city: 'Cleveland', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.INDEPENDENT] },
+  { name: 'Judson Park', city: 'Cleveland Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT] },
+  { name: 'Kemper House Highland Heights', city: 'Highland Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Kemper House Strongsville', city: 'Strongsville', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Kindred Living at The Fountains', city: 'Lyndhurst', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2089R' },
+  { name: 'Lakewood Health Care Center', city: 'Lakewood', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '0506R' },
+  { name: 'Landerbrook Transitional Care', city: 'Mayfield Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Legacy Place - Parma', city: 'Parma', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Light of Hearts Villa', city: 'Bedford', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Marymount Place', city: 'Garfield Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2207R' },
+  { name: 'Menorah Park Center for Senior Living', city: 'Beachwood', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.SKILLED_NURSING] },
+  { name: 'O\'Neill Healthcare Bay Village', city: 'Bay Village', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '0448R' },
+  { name: 'O\'Neill Healthcare Fairview Park', city: 'Fairview Park', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'O\'Neill Healthcare Lakewood', city: 'Lakewood', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT, CareLevel.SKILLED_NURSING], lic: '365267' },
+  { name: 'O\'Neill Healthcare North Olmsted', city: 'North Olmsted', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED], lic: '2329R' },
+  { name: 'Oaks of Brecksville', city: 'Brecksville', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Park Creek Center', city: 'Parma Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Park East', city: 'Beachwood', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '365810', note: 'Wiggins / Montefiore campus' },
+  { name: 'Parkside Villa', city: 'Middleburg Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2347R' },
+  { name: 'Pleasant Lake Villa', city: 'Parma', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '1872R' },
+  { name: 'Rose Senior Living Beachwood', city: 'Beachwood', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT] },
+  { name: 'Singleton Health Care Center', city: 'Cleveland', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Solon Pointe at Emerald Ridge', city: 'Solon', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2219R' },
+  { name: 'St. Augustine Towers', city: 'Cleveland', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Sunrise at Shaker Heights', city: 'Shaker Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Sunrise of Rocky River', city: 'Rocky River', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2190R', note: 'aka Bickford of Rocky River' },
+  { name: 'The Montefiore Home', city: 'Beachwood', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.SKILLED_NURSING] },
+  { name: 'The Woodlands of Shaker Heights', city: 'Shaker Heights', county: 'Cuyahoga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+
+  // --- SUMMIT COUNTY ---
+  { name: 'Arden Courts of Bath', city: 'Akron', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], note: 'Bath area' },
+  { name: 'Avenue at Macedonia', city: 'Macedonia', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '366454' },
+  { name: 'Briarwood', city: 'Stow', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '1963R' },
+  { name: 'Brookdale Barberton', city: 'Barberton', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Brookdale Bath', city: 'Akron', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], note: 'Bath area' },
+  { name: 'Brookdale Montrose', city: 'Akron', county: 'Summit', careLevel: [CareLevel.ASSISTED], note: 'Montrose area' },
+  { name: 'Brookdale Stow', city: 'Stow', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2502R' },
+  { name: 'Cardinal Retirement Village', city: 'Cuyahoga Falls', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Cherry Creek Acres', city: 'Stow', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2520R' },
+  { name: 'Concordia at Sumner', city: 'Copley', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT], lic: '2389R' },
+  { name: 'Crown Center at Laurel Lake', city: 'Hudson', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT] },
+  { name: 'Danbury Woods', city: 'Cuyahoga Falls', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Elmcroft of Sagamore Hills', city: 'Sagamore Hills', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2271R' },
+  { name: 'Elms Assisted Living', city: 'Hudson', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Essex Healthcare of Tallmadge', city: 'Tallmadge', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], snfPrimary: true, verify: true },
+  { name: 'Gables of Hudson', city: 'Hudson', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Gardens of Western Reserve at Cuyahoga Falls', city: 'Cuyahoga Falls', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2429R' },
+  { name: 'Grande Village Suites', city: 'Twinsburg', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2437R' },
+  { name: 'Grande Village Villas', city: 'Twinsburg', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Greenfield Estate Alzheimer\'s Special Care Center', city: 'Akron', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Greenview Senior Assisted Living', city: 'Uniontown', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Heartland of Twinsburg', city: 'Twinsburg', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '366419', snfPrimary: true, verify: true },
+  { name: 'Heather Knoll Retirement Village', city: 'Tallmadge', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Heritage of Hudson', city: 'Hudson', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Legacy Place - Twinsburg', city: 'Twinsburg', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2240R' },
+  { name: 'Maplewood at Cuyahoga Falls', city: 'Cuyahoga Falls', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Maplewood at Twinsburg', city: 'Twinsburg', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Merriman', city: 'Akron', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '0523R' },
+  { name: 'Mulberry Gardens', city: 'Munroe Falls', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2405R' },
+  { name: 'National Church Residences Portage Trail Village', city: 'Cuyahoga Falls', county: 'Summit', careLevel: [CareLevel.ASSISTED], lic: '2588R' },
+  { name: 'Pleasant Pointe Assisted Living', city: 'Barberton', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2249R' },
+  { name: 'Regina Health Center', city: 'Richfield', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.SKILLED_NURSING], lic: '2001R' },
+  { name: 'Renaissance Assisted Living', city: 'Richfield', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Rockynol Retirement Community', city: 'Akron', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT], note: 'Ohio Living' },
+  { name: 'St. Luke Lutheran Community - Portage Lakes', city: 'Akron', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '0670R' },
+  { name: 'Stow Glen Assisted Living', city: 'Stow', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '1797R' },
+  { name: 'Summit Point', city: 'Macedonia', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Sunrise Assisted Living of Cuyahoga Falls', city: 'Cuyahoga Falls', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2294R' },
+  { name: 'Tallmadge Senior Living', city: 'Tallmadge', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'The Pinnacle Rehabilitation and Nursing Center', city: 'Tallmadge', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '366010', snfPrimary: true, verify: true },
+  { name: 'Village at St. Edward', city: 'Fairlawn', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT] },
+  { name: 'Vista Springs Macedonia', city: 'Macedonia', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2707R' },
+  { name: 'Vitalia Montrose', city: 'Akron', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT], note: 'aka The V Living; Montrose area' },
+  { name: 'Vitalia Stow', city: 'Stow', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT] },
+  { name: 'Pleasant View Health Care Center', city: 'Barberton', county: 'Summit', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], snfPrimary: true, verify: true },
+
+  // --- LORAIN COUNTY ---
+  { name: 'Abbewood Assisted Living', city: 'Elyria', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Amherst Manor Assisted Living', city: 'Amherst', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '0416R' },
+  { name: 'Anchor Lodge Limited', city: 'Lorain', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Avenue Assisted Living', city: 'Avon Lake', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2462R', note: 'Avon Lake' },
+  { name: 'Avon Place', city: 'Avon', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '365155', snfPrimary: true, verify: true },
+  { name: 'Danbury North Ridgeville', city: 'North Ridgeville', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Elmcroft of Lorain', city: 'Lorain', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2301R' },
+  { name: 'Elms Retirement Village', city: 'Wellington', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '1194R' },
+  { name: 'Gardens of French Creek at Avon Oaks', city: 'Avon', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Independence Village of Avon Lake', city: 'Avon Lake', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Kendal at Oberlin', city: 'Oberlin', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT, CareLevel.SKILLED_NURSING] },
+  { name: 'Main Street Care Center', city: 'Avon Lake', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '365865', snfPrimary: true, verify: true },
+  { name: 'O\'Neill Healthcare North Ridgeville', city: 'North Ridgeville', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  // NOTE: source row #120 "O'Neill Healthcare Assisted Living (N. Ridgeville)" is the
+  // same physical campus as the row above and is intentionally collapsed into it
+  // (the name-normalizer can't equate them). This is why this list has 168 rows, not 169.
+  { name: 'St. Mary of the Woods', city: 'Avon', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2439R' },
+  { name: 'Wesleyan Village', city: 'Elyria', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT], lic: '0477R', note: 'Ohio Living' },
+  { name: 'Lake Pointe Health Care', city: 'Lorain', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], snfPrimary: true, verify: true },
+  { name: 'Northridge Health Center', city: 'North Ridgeville', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '365645', snfPrimary: true, verify: true },
+  { name: 'Oak Hills Nursing Center', city: 'Lorain', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], snfPrimary: true, verify: true },
+  { name: 'Autumn Aegis', city: 'Lorain', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '365940', snfPrimary: true, verify: true },
+  { name: 'Wellington Place / Welcome Nursing Home', city: 'Oberlin', county: 'Lorain', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], snfPrimary: true, verify: true },
+
+  // --- LAKE COUNTY ---
+  { name: 'Brookdale Mentor', city: 'Mentor', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Brookdale Newell Creek', city: 'Mentor', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2652R' },
+  { name: 'Brookdale Wickliffe', city: 'Wickliffe', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Brookdale Willoughby', city: 'Willoughby', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Danbury Mentor', city: 'Mentor', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Governor\'s Pointe', city: 'Mentor', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Homestead I', city: 'Painesville', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '365492' },
+  { name: 'Homestead II', city: 'Painesville', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Ivy House Assisted Living', city: 'Painesville', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '0080R' },
+  { name: 'Lantern of Madison', city: 'Madison', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Nason Center of Breckenridge Village', city: 'Willoughby', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '1760R' },
+  { name: 'Ohio Living Breckenridge Village', city: 'Willoughby', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT], lic: '365581' },
+  { name: 'Salida Woods Assisted Living', city: 'Mentor', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Symphony at Mentor', city: 'Mentor', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Van Gorder Manor', city: 'Willoughby', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Wickliffe Country Place', city: 'Wickliffe', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], snfPrimary: true, verify: true },
+  { name: 'Heartland of Willoughby', city: 'Willoughby', county: 'Lake', careLevel: [CareLevel.ASSISTED], lic: '365305', snfPrimary: true, verify: true },
+  { name: 'Kindred Transitional Care & Rehab - LakeMed', city: 'Painesville', county: 'Lake', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '365713', snfPrimary: true, verify: true },
+
+  // --- MEDINA COUNTY ---
+  { name: 'Altercare of Wadsworth', city: 'Wadsworth', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], snfPrimary: true, verify: true },
+  { name: 'Brookdale Medina North', city: 'Medina', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2357R' },
+  { name: 'Brookdale Medina South', city: 'Medina', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2319R' },
+  { name: 'Danbury Brunswick', city: 'Brunswick', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Elmcroft of Medina', city: 'Medina', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2227R' },
+  { name: 'Inn at Coal Ridge', city: 'Wadsworth', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Liberty Residence Holdings', city: 'Wadsworth', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Plum Creek Assisted Living', city: 'Brunswick', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Samaritan Villa', city: 'Medina', county: 'Medina', careLevel: [CareLevel.ASSISTED] },
+  { name: 'Sanctuary Wadsworth', city: 'Wadsworth', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'StoryPoint Medina East', city: 'Medina', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.INDEPENDENT] },
+  { name: 'StoryPoint Medina West', city: 'Medina', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT] },
+  { name: 'Wadsworth Pointe', city: 'Wadsworth', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2059R' },
+  { name: 'Western Reserve Masonic Community', city: 'Medina', county: 'Medina', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT], lic: '2188R' },
+
+  // --- GEAUGA COUNTY ---
+  { name: 'Arden Courts of Chagrin Falls', city: 'Bainbridge', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2243R' },
+  { name: 'Briar Hill Health Care Residence', city: 'Middlefield', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '0260R' },
+  { name: 'Briarcliff Manor', city: 'Middlefield', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Holly Hill', city: 'Newbury', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'Maplewood at Heather Hill', city: 'Chardon', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2264R' },
+  { name: 'Pines at Brooks House', city: 'Hiram', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '2500R' },
+  { name: 'Princeton Place', city: 'Huntsburg', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE], lic: '0666R' },
+  { name: 'Residence of Chardon', city: 'Chardon', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE] },
+  { name: 'South Franklin Circle', city: 'Bainbridge', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT] },
+  { name: 'Weils of Bainbridge', city: 'Bainbridge', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.SKILLED_NURSING], note: 'aka The Weils' },
+  { name: 'Hamlet at Chagrin Falls', city: 'Chagrin Falls', county: 'Geauga', careLevel: [CareLevel.ASSISTED, CareLevel.MEMORY_CARE, CareLevel.INDEPENDENT], verify: true, note: 'Geauga/Cuyahoga border — verify county' },
+];
+
+/**
+ * Known rebrands / aliases whose normalized name will NOT match the already-seeded
+ * home (because the seed was renamed). Force-skip these so we don't create a
+ * duplicate of the same physical building. Keys are normalized facility names.
+ *   - Anthology of Mayfield Heights → seeded as "The Ashton at Mayfield Heights"
+ *     (the metro list also has "Ashton at Mayfield Heights", which dedupes normally).
+ *   - Sunrise / Bickford of Rocky River → seeded as "Bloom at Rocky River".
+ */
+const ALIAS_SKIP = new Set<string>([
+  'anthology mayfield heights',
+  'sunrise rocky river',
+  'bickford rocky river',
+]);
+
+const STOPWORDS = new Set(['of', 'at', 'the', 'and', 'a']);
+
+/** Normalize a facility name for dedupe: lowercase, saint→st, drop punctuation and stopwords. */
+function normName(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\bsaint\b/g, 'st')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((w) => w && !STOPWORDS.has(w))
+    .join(' ')
+    .trim();
+}
+
+function careTypeWords(levels: CareLevel[]): string {
+  const map: Record<CareLevel, string> = {
+    [CareLevel.INDEPENDENT]: 'independent living',
+    [CareLevel.ASSISTED]: 'assisted living',
+    [CareLevel.MEMORY_CARE]: 'memory care',
+    [CareLevel.SKILLED_NURSING]: 'skilled nursing',
+  };
+  return levels.map((l) => map[l]).join(', ');
+}
+
+function descriptionFor(f: MetroFacility): string {
+  return (
+    'Senior living community in ' + f.city + ', Ohio (' + f.county + ' County) ' +
+    'offering ' + careTypeWords(f.careLevel) + '. Unclaimed directory listing — ' +
+    'staged for CareLinkAI Greater-Cleveland metro coverage. Address, pricing, ' +
+    'amenities, and current availability are pending the enrich pass and operator ' +
+    'claim. The operator can claim this listing to add photos, verified details, ' +
+    'pricing, and availability.' +
+    (f.lic ? ' (ODH license ' + f.lic + ' — verify against ltc.ohio.gov.)' : '') +
+    (f.note ? ' (Note: ' + f.note + ')' : '')
+  );
+}
+
+async function discoverAndStoreWebsite(homeId: string, name: string, city: string): Promise<string> {
+  const result = await findWebsiteUrl({ name, city, state: 'OH' });
+  await sleep(PLACES_DELAY_MS);
+  if (!result) return 'no match';
+  const via = result.source === 'web_search' ? 'web' : 'places';
+  if (result.confidence === 'LOW') return `low-confidence (skipped, ${via}): ${result.url}`;
+  await prisma.assistedLivingHome.update({ where: { id: homeId }, data: { websiteUrl: result.url } });
+  return `${result.confidence} via ${via}: ${result.url}`;
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const withWebsites = process.argv.includes('--with-websites');
+  const includeUnverified = process.argv.includes('--include-unverified');
+
+  console.log(dryRun ? '=== DRY RUN — no writes ===' : '=== LIVE RUN ===');
+  if (withWebsites) {
+    if (!isAnyLookupConfigured()) {
+      console.error('ERROR: --with-websites requires GOOGLE_PLACES_API_KEY (and/or web-search fallback).');
+      process.exit(1);
+    }
+    console.log('=== Website discovery ENABLED ===');
+  }
+  console.log(`Source rows: ${METRO.length}`);
+  console.log(`SNF-primary gating: ${includeUnverified ? 'OFF (--include-unverified — seeding SNF-primary too)' : 'ON (SNF-primary held for ODH verification)'}\n`);
+
+  // Build dedupe index from ALL existing homes (any operator), keyed by normalized name.
+  const existing = await prisma.assistedLivingHome.findMany({
+    select: { name: true, address: { select: { city: true } } },
+  });
+  const existingByNorm = new Map<string, { name: string; city: string | null }>();
+  for (const h of existing) {
+    existingByNorm.set(normName(h.name), { name: h.name, city: h.address?.city ?? null });
+  }
+  console.log(`Existing homes in DB: ${existing.length} (deduping against all of them)\n`);
+
+  // Seed user + operator (shared sentinel).
+  let seedUser;
+  if (dryRun) {
+    seedUser = await prisma.user.findUnique({ where: { email: SEED_USER_EMAIL } });
+    console.log('Seed user: ' + (seedUser ? 'exists (' + seedUser.id + ')' : 'WOULD CREATE'));
+  } else {
+    seedUser = await prisma.user.upsert({
+      where: { email: SEED_USER_EMAIL },
+      update: {},
+      create: { email: SEED_USER_EMAIL, firstName: 'CareLinkAI', lastName: 'Directory (Unclaimed)', role: UserRole.OPERATOR },
+    });
+    console.log('Seed user ready: ' + seedUser.id);
+  }
+  let seedOperator;
+  if (dryRun) {
+    seedOperator = seedUser ? await prisma.operator.findUnique({ where: { userId: seedUser.id } }) : null;
+    console.log('Seed operator: ' + (seedOperator ? 'exists (' + seedOperator.id + ')' : 'WOULD CREATE') + '\n');
+  } else {
+    if (!seedUser) throw new Error('Seed user was not initialized.');
+    seedOperator = await prisma.operator.upsert({
+      where: { userId: seedUser.id },
+      update: {},
+      create: { userId: seedUser.id, companyName: SEED_OPERATOR_NAME },
+    });
+    console.log('Seed operator ready: ' + seedOperator.id + '\n');
+  }
+
+  let created = 0;
+  let skippedDup = 0;
+  let heldSnf = 0;
+  const createdRows: string[] = [];
+  const skippedRows: string[] = [];
+  const heldRows: string[] = [];
+
+  for (const f of METRO) {
+    const norm = normName(f.name);
+
+    // 1. Dedupe: matches an existing home (by normalized name) or a known rebrand alias.
+    const dupHit = existingByNorm.get(norm);
+    if (dupHit || ALIAS_SKIP.has(norm)) {
+      skippedDup++;
+      const why = dupHit ? `matches existing "${dupHit.name}"` : 'known rebrand alias';
+      skippedRows.push(`  SKIP (dup):  ${f.name} (${f.city}) — ${why}`);
+      continue;
+    }
+
+    // 2. SNF-primary gating.
+    if (f.snfPrimary && !includeUnverified) {
+      heldSnf++;
+      heldRows.push(`  HELD (SNF-primary, verify ODH): ${f.name} (${f.city}, ${f.county})${f.lic ? ' lic ' + f.lic : ''}`);
+      continue;
+    }
+
+    // 3. Create (or preview).
+    if (dryRun) {
+      createdRows.push(`  WOULD CREATE: ${f.name} (${f.city}, ${f.county}) [${f.careLevel.join(', ')}]${f.snfPrimary ? ' [SNF-primary]' : ''}`);
+      created++;
+      continue;
+    }
+    if (!seedOperator) throw new Error('Seed operator was not initialized.');
+    const home = await prisma.assistedLivingHome.create({
+      data: {
+        operatorId: seedOperator.id,
+        name: f.name,
+        description: descriptionFor(f),
+        capacity: 0, // unknown at seed time — verify in research/claim
+        status: HomeStatus.DRAFT,
+        careLevel: f.careLevel,
+      },
+    });
+    let websiteNote = '';
+    if (withWebsites) {
+      const status = await discoverAndStoreWebsite(home.id, f.name, f.city);
+      websiteNote = ' — website ' + status;
+    }
+    createdRows.push(`  CREATED: ${f.name} (${f.city}, ${f.county})${websiteNote}`);
+    // Register so a later same-norm row in this run also dedupes.
+    existingByNorm.set(norm, { name: f.name, city: f.city });
+    created++;
+  }
+
+  if (createdRows.length) {
+    console.log(`── ${dryRun ? 'Would create' : 'Created'} (${created}) ──`);
+    createdRows.forEach((r) => console.log(r));
+  }
+  if (heldRows.length) {
+    console.log(`\n── Held — SNF-primary, needs ODH verification (${heldSnf}) ──`);
+    console.log('   (re-run with --include-unverified to seed these after verifying)');
+    heldRows.forEach((r) => console.log(r));
+  }
+  if (skippedRows.length) {
+    console.log(`\n── Skipped — already seeded / rebrand (${skippedDup}) ──`);
+    skippedRows.forEach((r) => console.log(r));
+  }
+
+  console.log('\n─────────────────────────────────────────────');
+  console.log(`${dryRun ? 'Would create' : 'Created'}: ${created}`);
+  console.log(`Held (SNF-primary):          ${heldSnf}`);
+  console.log(`Skipped (dup / rebrand):     ${skippedDup}`);
+  console.log(`Source total:                ${METRO.length}`);
+  console.log('─────────────────────────────────────────────');
+
+  if (!dryRun && seedOperator) {
+    const total = await prisma.assistedLivingHome.count({ where: { operatorId: seedOperator.id } });
+    const nonDraft = await prisma.assistedLivingHome.count({ where: { operatorId: seedOperator.id, status: { not: HomeStatus.DRAFT } } });
+    console.log(`\nTotal listings under directory operator: ${total}`);
+    console.log(`Non-DRAFT (publicly visible) under directory operator: ${nonDraft}`);
+  }
+  if (dryRun) console.log('\nDRY RUN complete. No changes written. Re-run without --dry-run to seed.');
+}
+
+main()
+  .catch((e) => {
+    console.error('ERROR:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## OL-083 Part B — metro directory seed

Seeds the Cowork-compiled **6-county Greater-Cleveland RCF/AL master list** (Cuyahoga, Summit, Lorain, Lake, Geauga, Medina — 169 source rows) as **DRAFT** listings under the directory sentinel operator, so the publisher (#592) has the full metro supply to act on. Source list committed to `context/METRO_RCF_MASTER_LIST.md` for provenance.

### `scripts/seed-cleveland-metro.ts`
- **Dry-run by default**, idempotent, same sentinel operator as the Tier-A / batch-2 seeds.
- **Dedupe** against *all* existing homes by normalized facility name (stopword + `saint→st` normalization), plus a curated **alias-skip** set for known rebrands the normalizer can't equate: Anthology→Ashton, Bickford/Sunrise→Bloom.
- **SNF-primary gating:** the 20 rows the source flagged `*(SNF-primary)*` (ODH `365xxx/366xxx`, nursing-primary) are **HELD by default** and reported for ODH verification — CareLinkAI excludes skilled-nursing-only facilities. `--include-unverified` seeds them anyway.
- **168 rows** (source 169; the duplicate "O'Neill Healthcare ... North Ridgeville" campus is intentionally collapsed — documented inline).
- `careLevel` is a seed hint; `capacity` seeded `0` (unknown); address/pricing/photos come from enrich + claim.

### Run sequence (founder, on Render — all dry-run-first)
1. `npx tsx scripts/seed-cleveland-metro.ts --dry-run` → review create/held/skip lists
2. `npx tsx scripts/seed-cleveland-metro.ts` → write DRAFT rows
3. `npx tsx scripts/autopopulate-cohort.ts …` → enrich (address/description/website)
4. `npx tsx scripts/publish-directory-homes.ts` → preview → `--force` to publish

### Verification
- Standalone `tsc --noEmit` (strict) clean; `eslint` clean. No app code changed — script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_