### PR TITLE
fix(directory): anchor seed city+state so Places address backfill is accurate

### DIFF
--- a/scripts/autopopulate-cohort.ts
+++ b/scripts/autopopulate-cohort.ts
@@ -209,7 +209,7 @@ async function processRow(
         website: websiteUrl,
       });
       const accept = placesAddr && placesAddr.street && placesAddr.confidence !== 'LOW'
-        ? placesMatchAcceptable(placesAddr, home.address?.state ?? null)
+        ? placesMatchAcceptable(placesAddr, home.address?.state ?? null, home.address?.city ?? null)
         : { ok: false, reason: placesAddr ? `${placesAddr.confidence} confidence` : 'no match' };
       if (placesAddr && placesAddr.street && accept.ok) {
         console.log(
@@ -371,9 +371,24 @@ async function processRow(
   };
 }
 
+/** Normalize a city for comparison: lowercase, drop punctuation and the
+ * township/village/twp qualifiers Places sometimes appends (e.g. "Newbury Township"). */
+function normalizeCity(c: string): string {
+  return c
+    .toLowerCase()
+    .replace(/[.,]/g, ' ')
+    .replace(/\b(township|twp|village)\b/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 /**
  * OL-066 guard against bad Google Places matches:
- *   - If we know the home's state, reject a candidate in a different state.
+ *   - If we know the home's state, reject a candidate in a different state
+ *     (e.g. Princeton Place, Huntsburg OH → "Princeton Place of Ruston" LA).
+ *   - If we know the home's city, reject a candidate in a clearly different city
+ *     (e.g. Brookdale Willoughby → "Brookdale Mentor"). Erring toward a reject is
+ *     safe: the home is just held, not published with a wrong address.
  *   - If we DON'T know the state (no seeded address), require a HIGH match —
  *     which, with no city to anchor on, means a website-host-confirmed match —
  *     so a weak name-only MEDIUM (e.g. The Elms → Westerly, RI) is rejected.
@@ -381,9 +396,13 @@ async function processRow(
 function placesMatchAcceptable(
   placesAddr: PlaceAddressResult,
   seededState: string | null,
+  seededCity: string | null,
 ): { ok: boolean; reason?: string } {
   if (seededState && placesAddr.state && placesAddr.state.toUpperCase() !== seededState.toUpperCase()) {
     return { ok: false, reason: `Places state ${placesAddr.state} != seeded state ${seededState}` };
+  }
+  if (seededCity && placesAddr.city && normalizeCity(placesAddr.city) !== normalizeCity(seededCity)) {
+    return { ok: false, reason: `Places city ${placesAddr.city} != seeded city ${seededCity}` };
   }
   if (!seededState && placesAddr.confidence !== 'HIGH') {
     return { ok: false, reason: `no seeded state to verify and match is ${placesAddr.confidence} (need a website-confirmed HIGH)` };
@@ -442,7 +461,7 @@ async function backfillAddressViaPlaces(
   }
 
   // OL-066: guard against a wrong-location match (e.g. The Elms → Westerly RI).
-  const accept = placesMatchAcceptable(placesAddr, existing?.state ?? null);
+  const accept = placesMatchAcceptable(placesAddr, existing?.state ?? null, existing?.city ?? null);
   if (!accept.ok) {
     console.log(`  🚫 ${homeName} — rejected Places match: ${accept.reason} (matched "${placesAddr.matchedName ?? '?'}" @ "${placesAddr.formattedAddress ?? '?'}")`);
     return { status: 'skipped', homeId, homeName, reason: `Places match rejected — ${accept.reason}` };

--- a/scripts/seed-cleveland-metro.ts
+++ b/scripts/seed-cleveland-metro.ts
@@ -298,6 +298,21 @@ function descriptionFor(f: MetroFacility): string {
   );
 }
 
+/**
+ * Ensure a directory home carries at least a partial Address with its known city +
+ * state=OH (street/zip left empty). This anchors the later Google Places address
+ * backfill (autopopulate-cohort.ts --addresses-only): it makes the Places query
+ * municipality-specific and lets the match guard reject cross-state / cross-city
+ * results. The publish gate still holds the home until street + zip are filled.
+ * Returns true if it created a new partial address.
+ */
+async function ensurePartialAddress(homeId: string, city: string): Promise<boolean> {
+  const existingAddr = await prisma.address.findFirst({ where: { homeId }, select: { id: true } });
+  if (existingAddr) return false;
+  await prisma.address.create({ data: { homeId, street: '', city, state: 'OH', zipCode: '' } });
+  return true;
+}
+
 async function discoverAndStoreWebsite(homeId: string, name: string, city: string): Promise<string> {
   const result = await findWebsiteUrl({ name, city, state: 'OH' });
   await sleep(PLACES_DELAY_MS);
@@ -326,11 +341,11 @@ async function main() {
 
   // Build dedupe index from ALL existing homes (any operator), keyed by normalized name.
   const existing = await prisma.assistedLivingHome.findMany({
-    select: { name: true, address: { select: { city: true } } },
+    select: { id: true, name: true, operatorId: true, address: { select: { id: true, city: true } } },
   });
-  const existingByNorm = new Map<string, { name: string; city: string | null }>();
+  const existingByNorm = new Map<string, { id: string; name: string; operatorId: string; city: string | null; hasAddress: boolean }>();
   for (const h of existing) {
-    existingByNorm.set(normName(h.name), { name: h.name, city: h.address?.city ?? null });
+    existingByNorm.set(normName(h.name), { id: h.id, name: h.name, operatorId: h.operatorId, city: h.address?.city ?? null, hasAddress: !!h.address });
   }
   console.log(`Existing homes in DB: ${existing.length} (deduping against all of them)\n`);
 
@@ -364,6 +379,7 @@ async function main() {
   let created = 0;
   let skippedDup = 0;
   let heldSnf = 0;
+  let addressesAdded = 0;
   const createdRows: string[] = [];
   const skippedRows: string[] = [];
   const heldRows: string[] = [];
@@ -376,7 +392,21 @@ async function main() {
     if (dupHit || ALIAS_SKIP.has(norm)) {
       skippedDup++;
       const why = dupHit ? `matches existing "${dupHit.name}"` : 'known rebrand alias';
-      skippedRows.push(`  SKIP (dup):  ${f.name} (${f.city}) — ${why}`);
+      // Idempotently anchor a previously-seeded directory home that still lacks an
+      // address (e.g. the metro homes from a prior run), so the Places backfill works.
+      let anchorNote = '';
+      const canAnchor = dupHit && seedOperator && dupHit.operatorId === seedOperator.id && !dupHit.hasAddress;
+      if (canAnchor) {
+        if (dryRun) {
+          anchorNote = ' [would add city/OH anchor]';
+          addressesAdded++;
+        } else if (await ensurePartialAddress(dupHit!.id, f.city)) {
+          anchorNote = ' [+city/OH anchor]';
+          dupHit!.hasAddress = true;
+          addressesAdded++;
+        }
+      }
+      skippedRows.push(`  SKIP (dup):  ${f.name} (${f.city}) — ${why}${anchorNote}`);
       continue;
     }
 
@@ -389,8 +419,9 @@ async function main() {
 
     // 3. Create (or preview).
     if (dryRun) {
-      createdRows.push(`  WOULD CREATE: ${f.name} (${f.city}, ${f.county}) [${f.careLevel.join(', ')}]${f.snfPrimary ? ' [SNF-primary]' : ''}`);
+      createdRows.push(`  WOULD CREATE: ${f.name} (${f.city}, ${f.county}) [${f.careLevel.join(', ')}]${f.snfPrimary ? ' [SNF-primary]' : ''} (+city/OH anchor)`);
       created++;
+      addressesAdded++;
       continue;
     }
     if (!seedOperator) throw new Error('Seed operator was not initialized.');
@@ -409,9 +440,12 @@ async function main() {
       const status = await discoverAndStoreWebsite(home.id, f.name, f.city);
       websiteNote = ' — website ' + status;
     }
+    // Anchor the home's city + state=OH so the Places address backfill queries and
+    // verifies precisely (no cross-state/city matches).
+    if (await ensurePartialAddress(home.id, f.city)) addressesAdded++;
     createdRows.push(`  CREATED: ${f.name} (${f.city}, ${f.county})${websiteNote}`);
     // Register so a later same-norm row in this run also dedupes.
-    existingByNorm.set(norm, { name: f.name, city: f.city });
+    existingByNorm.set(norm, { id: home.id, name: f.name, operatorId: seedOperator.id, city: f.city, hasAddress: true });
     created++;
   }
 
@@ -433,6 +467,7 @@ async function main() {
   console.log(`${dryRun ? 'Would create' : 'Created'}: ${created}`);
   console.log(`Held (SNF-primary):          ${heldSnf}`);
   console.log(`Skipped (dup / rebrand):     ${skippedDup}`);
+  console.log(`City/OH anchors ${dryRun ? 'to add' : 'added'}:     ${addressesAdded}`);
   console.log(`Source total:                ${METRO.length}`);
   console.log('─────────────────────────────────────────────');
 


### PR DESCRIPTION
## Fix wrong/missed addresses in the directory Places backfill

The `--addresses-only` dry-run on the metro seed exposed two bugs, both rooted in the seeded homes having **no structured city/state** for the matcher:

- **Wrong matches passed (HIGH):** `Princeton Place` (Huntsburg OH) → **"Princeton Place of Ruston, LA"**; `Brookdale Willoughby` → Brookdale *Mentor's* address; `Vista Springs Macedonia` → the *Independence* facility.
- **Correct OH matches rejected:** ~40 in-state MEDIUM matches (Pleasant Pointe, Singleton, Judson Manor, East Park MC…) thrown out as *"no seeded state to verify."*

### Fix
1. **`seed-cleveland-metro.ts`** writes a **partial `Address` (known city + `state=OH`, empty street/zip)** for each directory home — on create *and* idempotently for the already-seeded 118 on re-run (scoped to the directory sentinel operator). This makes the Places query municipality-specific *and* gives the guard an anchor. The publish gate still holds the home until street+zip are filled.
2. **`placesMatchAcceptable`** now verifies **city as well as state** (normalized; strips township/village qualifiers), rejecting cross-state and cross-city matches. Erring toward *reject* is safe — the home is held, never published with a wrong address.

### Effect on the dry-run
- `Princeton Place` → rejected (state LA ≠ OH).
- `Brookdale Willoughby` → now queries "…Willoughby OH" and resolves correctly (or is held), not Mentor.
- `Pleasant Pointe`, `Singleton`, etc. → now accepted (OH anchor present).
- A few true border-city homes may be **held** (safe) rather than published with an uncertain address — fixable later or on operator claim.

### Re-run sequence (founder, on the new deploy)
```
npx tsx scripts/seed-cleveland-metro.ts --dry-run     # shows ~118 "would add city/OH anchor"
npx tsx scripts/seed-cleveland-metro.ts               # adds the anchors (idempotent; no --with-websites needed)
npx tsx scripts/autopopulate-cohort.ts --from-db --include-unpopulated --addresses-only --dry-run   # now precise
npx tsx scripts/autopopulate-cohort.ts --from-db --include-unpopulated --addresses-only --force
npx tsx scripts/publish-directory-homes.ts            # preview → --force
```

Typechecks clean (project paths inherited); eslint clean. Script-only, no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_