### PR TITLE
fix(enrich): don't persist sparse LOW-confidence extractions

### DIFF
--- a/scripts/autopopulate-cohort.ts
+++ b/scripts/autopopulate-cohort.ts
@@ -267,7 +267,13 @@ async function processRow(
       console.log(`    Notes: ${extracted.extractionNotes}`);
     }
 
-    if (!dryRun) {
+    // Don't persist sparse/LOW-confidence extractions. These come from empty or
+    // JS-rendered pages where the model falls back to an "UNKNOWN" placeholder
+    // description (a truthy string that would otherwise overwrite the listing and
+    // stamp autoPopulatedAt, permanently hiding the home from --resume retries).
+    // Skipping the write leaves the home DRAFT and un-stamped for a later re-scrape;
+    // it is still reported as `sparse` in the run summary below.
+    if (!dryRun && extracted.extractionConfidence !== 'LOW') {
       await prisma.assistedLivingHome.update({ where: { id: homeId }, data: updateData });
 
       // Upsert address — fill empty street/zip from the AI scrape or Places fallback.


### PR DESCRIPTION
## Problem found during the directory text-enrich (Step 2 of "richer listings")

Running `autopopulate-cohort.ts --from-db --include-unpopulated --include-active` as a dry-run over the 105 Greater-Cleveland directory homes returned:

```
105 facilities processed: 91 succeeded, 12 sparse, 2 blocked, 0 skipped
```

The **12 sparse** homes all came back from **empty `<html></html>`** pages (JS-rendered or bot-blocked sites). For those, the extractor falls back to a literal `"UNKNOWN"` placeholder description — that's the single "field" each sparse home reported.

The write path persists `description` whenever it's truthy, and `"UNKNOWN"` is truthy:

```ts
if (extracted.description) {            // "UNKNOWN" is truthy
  updateData.description = extracted.description;
}
...
if (!dryRun) {
  await prisma.assistedLivingHome.update({ ... });   // also stamps autoPopulatedAt
}
```

So `--force` would have **(a)** written a public listing description of `"UNKNOWN"`, and **(b)** stamped `autoPopulatedAt`, which makes `--resume` skip the home forever — blocking any future re-scrape. Net degradation, not enrichment. (`home-profile-generator.ts` does no sentinel-handling of `"UNKNOWN"` — it's `String(raw.description ?? '')`.)

## Fix

One-line guard on the DB write:

```ts
if (!dryRun && extracted.extractionConfidence !== 'LOW') {
```

Sparse/LOW-confidence homes are left **DRAFT and un-stamped** so they can be retried later with a better scrape strategy, and they're still reported in the run summary's `sparse` bucket. HIGH/MEDIUM extractions are unaffected — the 91 good homes still write normally.

Typechecks clean (`tsc --noEmit`); eslint clean. Script-only, no schema/runtime-path change for the success case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_