### PR TITLE
feat(directory): persist + surface phone/email/tagline from enrich (OL-080)

### DIFF
--- a/prisma/migrations/20260624000001_home_public_contact_fields/migration.sql
+++ b/prisma/migrations/20260624000001_home_public_contact_fields/migration.sql
@@ -1,0 +1,6 @@
+-- OL-080: persist public listing contact + marketing fields the enrich pipeline
+-- already extracts (phone / contactEmail / tagline) but previously discarded.
+-- Additive + idempotent. Distinct from outreachEmail/outreachPhone (nudge channel).
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "phone" TEXT;
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "contactEmail" TEXT;
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "tagline" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -526,6 +526,12 @@ model AssistedLivingHome {
   autoPopulatedVersion    Int?             @default(0)
   preFilledFields         Json?
   aiPopulationConfidence  String?
+  // Public listing contact + marketing fields populated by the enrich pipeline
+  // (OL-080). Distinct from outreachEmail/outreachPhone below, which are the
+  // unclaimed-listing nudge channel, not public display.
+  phone                   String?
+  contactEmail            String?
+  tagline                 String?
   imageRightsAcknowledgedAt DateTime?
   enrichmentStatus        EnrichmentStatus @default(NONE)
   enrichmentStartedAt     DateTime?

--- a/scripts/autopopulate-cohort.ts
+++ b/scripts/autopopulate-cohort.ts
@@ -190,6 +190,22 @@ async function processRow(
       preFilledFields['careLevel'] = 'AI';
     }
 
+    // Public contact + marketing fields the extractor returns (OL-080). Were
+    // previously counted toward fieldsExtracted but never written, so every
+    // enriched listing was missing its phone / email / tagline.
+    if (extracted.phone?.trim()) {
+      updateData.phone = extracted.phone.trim();
+      preFilledFields['phone'] = 'AI';
+    }
+    if (extracted.contactEmail?.trim()) {
+      updateData.contactEmail = extracted.contactEmail.trim();
+      preFilledFields['contactEmail'] = 'AI';
+    }
+    if (extracted.tagline?.trim()) {
+      updateData.tagline = extracted.tagline.trim();
+      preFilledFields['tagline'] = 'AI';
+    }
+
     // Address: only fill fields that are currently empty/missing.
     const addr = extracted.address;
     const aiStreet = addr?.streetAddress?.trim() || null;

--- a/scripts/report-directory-homes.ts
+++ b/scripts/report-directory-homes.ts
@@ -13,9 +13,9 @@
  *   - Step 4: export the batch-2 set ({homeId, name, city, status}) for the
  *             Cowork ED/email contact-research pass once enrich has run.
  *
- * NOTE: there is no phone column on AssistedLivingHome, and the PR #545 enrich
- * pipeline does not persist a phone, so "phone" for the step-4 handoff comes
- * from the Cowork research pass — it is intentionally omitted here.
+ * The enrich pipeline now persists a `phone` on AssistedLivingHome (OL-080), so
+ * the step-4 handoff includes the website-scraped phone where available; blank
+ * means enrich found none and it still needs the Cowork research pass.
  *
  * City is read from the home's Address; freshly-seeded batch-2 homes show
  * "(pending)" until the enrich/Places step creates the address row.
@@ -58,6 +58,7 @@ async function main() {
       name: true,
       status: true,
       websiteUrl: true,
+      phone: true,
       autoPopulatedAt: true,
       address: { select: { city: true } },
     },
@@ -70,13 +71,14 @@ async function main() {
     city: h.address?.city ?? '(pending)',
     status: h.status,
     enriched: h.autoPopulatedAt ? 'yes' : 'no',
+    phone: h.phone ?? '',
     website: h.websiteUrl ?? '',
   }));
 
   if (tsv) {
-    console.log(['homeId', 'name', 'city', 'status', 'enriched', 'website'].join('\t'));
+    console.log(['homeId', 'name', 'city', 'status', 'enriched', 'phone', 'website'].join('\t'));
     for (const r of rows) {
-      console.log([r.homeId, r.name, r.city, r.status, r.enriched, r.website].join('\t'));
+      console.log([r.homeId, r.name, r.city, r.status, r.enriched, r.phone, r.website].join('\t'));
     }
   } else {
     console.table(rows);

--- a/src/app/api/homes/[id]/route.ts
+++ b/src/app/api/homes/[id]/route.ts
@@ -214,6 +214,8 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
       id: home.id,
       name: home.name,
       description: home.description,
+      tagline: home.tagline,
+      phone: home.phone,
       address: home.address
         ? {
             street: home.address.street,

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -809,10 +809,24 @@ export default function HomeDetailPage() {
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
                       <h1 className="text-2xl font-bold text-neutral-800 md:text-3xl">{realHome.name}</h1>
+                      {realHome.tagline && (
+                        <p className="mt-1 text-sm italic text-neutral-500">{realHome.tagline}</p>
+                      )}
                       <div className="mt-1 flex items-center">
                         <FiMapPin className="mr-1 h-4 w-4 text-neutral-500" />
                         <span className="text-sm text-neutral-600">{addrText}</span>
                       </div>
+                      {realHome.phone && (
+                        <div className="mt-1 flex items-center">
+                          <FiPhone className="mr-1 h-4 w-4 text-neutral-500" />
+                          <a
+                            href={`tel:${String(realHome.phone).replace(/[^0-9+]/g, '')}`}
+                            className="text-sm text-primary-600 hover:underline"
+                          >
+                            {realHome.phone}
+                          </a>
+                        </div>
+                      )}
                       <div className="mt-2 flex flex-wrap gap-2">
                         {(realHome.careLevel || []).map((level: string) => (
                           <span key={level} className="rounded-full bg-neutral-100 px-3 py-1 text-sm font-medium text-neutral-700">


### PR DESCRIPTION
## OL-080 — persist + surface phone / email / tagline from the enrich pipeline

### Problem
The enrich extractor (`home-profile-generator.ts`) returns `phone`, `contactEmail`, and `tagline`, but `AssistedLivingHome` had **no columns for them** and `autopopulate-cohort.ts` only counted them toward `fieldsExtracted` — then discarded them. Net effect: **all ~90 enriched directory listings are missing public phone, email, and tagline.**

### Changes
- **Schema** (`prisma/schema.prisma` + additive migration `20260624000001_home_public_contact_fields`): add `phone`, `contactEmail`, `tagline` (`String?`). Distinct from `outreachEmail`/`outreachPhone`, which are the unclaimed-listing **nudge** channel, not public display. `ADD COLUMN IF NOT EXISTS` → idempotent, runs via `migrate:deploy` on Render start.
- **Enrich** (`autopopulate-cohort.ts`): persist the three fields in `updateData` with `AI` provenance. **`capacity` deliberately left untouched** — site values conflict with DOH records (Ohman 58-vs-92, Regina 54-vs-99); that's OL-059's manual-verify job, not an auto-overwrite.
- **API** (`/api/homes/[id]`): expose `phone` + `tagline`. **`contactEmail` stays DB-only** (operator/admin handoff) to avoid turning the public directory into a spam-scrape source.
- **Public listing** (`homes/[id]/page.tsx`, real-data path): render the tagline under the name + a clickable `tel:` phone link.
- **Report script** (`report-directory-homes.ts`): emit `phone` for the step-4 Cowork handoff; dropped the now-stale "no phone column" note.

### Verification
`tsc --noEmit` + eslint clean (the 3 `<img>` warnings are pre-existing).

### After merge (backfill)
1. Render auto-deploys → migration adds the columns.
2. Re-run the text enrich to populate the ~90 reachable homes:
   ```
   npx tsx scripts/autopopulate-cohort.ts --from-db --include-unpopulated --include-active --force
   ```
   ~$8 Anthropic (scrape cache makes the re-fetch free; #602's LOW-skip guard keeps the JS-rendered homes untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_