### PR TITLE
feat(directory): rename + verified address for 11 rebranded homes (Batch B)

### DIFF
--- a/scripts/rebrand-and-address-batch-b.ts
+++ b/scripts/rebrand-and-address-batch-b.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env npx tsx
+/**
+ * scripts/rebrand-and-address-batch-b.ts
+ *
+ * OL-059/OL-083 — Batch B. Directory DRAFT homes whose seeded brand has since been
+ * renamed/sold. The home is still a real, currently-OPEN AL/MC facility at the same
+ * (or corrected) location — it just trades under a new name now. We update BOTH the
+ * display name AND the full verified address so the public directory shows the
+ * facility families will actually find, not a defunct brand.
+ *
+ * All names + addresses were human-verified against the operator's own site + a
+ * second independent source (Ohio DOH / Caring.com / A Place for Mom / rebrand
+ * announcement). Renaming is safe: home detail routes are id-based, `name` is not
+ * unique, and these directory homes have no slug.
+ *
+ * STALE-DESCRIPTION GUARD: the seeded description/amenities were written for the OLD
+ * brand. On dry-run we scan the description for the old brand token(s) and print a
+ * ⚠ when found, so a stale "Welcome to <old name>…" can be fixed before going live.
+ * (This script does NOT rewrite descriptions — it only flags.)
+ *
+ * SAFETY:
+ *   - Hardcoded ids; each guarded by the expected OLD name AND status=DRAFT.
+ *   - Dry-run by default; only writes with --force.
+ *   - Idempotent: a home already at the new name + target address → "unchanged".
+ *   - Marks name + address fields VERIFIED in preFilledFields.
+ *
+ * Usage:
+ *   npx tsx scripts/rebrand-and-address-batch-b.ts            # DRY RUN
+ *   npx tsx scripts/rebrand-and-address-batch-b.ts --force    # apply
+ *
+ * After --force, review any ⚠ stale descriptions, then run publish-directory-homes.ts.
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+type Target = {
+  id: string;
+  oldName: string;
+  newName: string;
+  street: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  /** Tokens that, if present in the description, mean it still names the old brand. */
+  staleTokens: string[];
+  source: string;
+};
+
+// Batch B — OPEN, rebranded, two-source-verified (2026-06-24).
+// Brookdale Medina North is intentionally NOT here (address medium-confidence; held for re-verify).
+const TARGETS: Target[] = [
+  {
+    id: 'cmqqrlgra005mrlmbn1qbtn2q', oldName: 'Brookdale Medina South', newName: 'Traditions of Medina',
+    street: '100 High Point Dr', city: 'Medina', state: 'OH', zipCode: '44256',
+    staleTokens: ['Brookdale'], source: 'seniorcareauthority.com — Traditions of Medina (fka Brookdale Medina South)',
+  },
+  {
+    id: 'cmqqrlhn9005qrlmbdh0rhweq', oldName: 'Elmcroft of Medina', newName: 'Broadway Creek Senior Living',
+    street: '1046 N Jefferson St', city: 'Medina', state: 'OH', zipCode: '44256',
+    staleTokens: ['Elmcroft'], source: 'seniorhousingnet.com — elmcroft-of-medina → Broadway Creek',
+  },
+  {
+    id: 'cmqqrku5t002wrlmbu3agw9px', oldName: 'Elmcroft of Sagamore Hills', newName: 'Majestic Care of Sagamore Hills',
+    street: '997 W Aurora Rd', city: 'Northfield', state: 'OH', zipCode: '44067',
+    staleTokens: ['Elmcroft'], source: 'majesticcare.com/location/sagamore-hills-assisted-living',
+  },
+  {
+    id: 'cmqqrkhpb001erlmb83zsyyhk', oldName: 'Kindred Living at The Fountains', newName: 'Heritage of Lyndhurst',
+    street: '1555 Brainard Rd', city: 'Lyndhurst', state: 'OH', zipCode: '44124',
+    staleTokens: ['Kindred', 'Fountains', 'Regent'], source: 'seniorcareauthority.com — Heritage of Lyndhurst (formerly Regent of Lyndhurst)',
+  },
+  {
+    id: 'cmqqrlo85006krlmbl79j6l27', oldName: 'Weils of Bainbridge', newName: 'Eliza at Chagrin Falls',
+    street: '16695 Chillicothe Rd', city: 'Chagrin Falls', state: 'OH', zipCode: '44023',
+    staleTokens: ['Weils', 'Weil'], source: 'elizachagrinfalls.elizajennings.org (formerly The Weils)',
+  },
+  {
+    id: 'cmqqrk9cz000erlmbnqt13awu', oldName: 'Berea Lake Towers Retirement Community', newName: 'Generations Senior Living of Berea',
+    street: '4 Berea Commons', city: 'Berea', state: 'OH', zipCode: '44017',
+    staleTokens: ['Berea Lake Towers', 'Lake Towers'], source: 'generationshcm.com/rebranding-of-berea-lake-towers-and-crystal-waters',
+  },
+  {
+    id: 'cmqqrkdko000wrlmbua2b3sjo', oldName: 'Emerald Village Senior Living', newName: 'Otterbein North Olmsted SeniorLife Community',
+    street: '30344 Lorain Rd', city: 'North Olmsted', state: 'OH', zipCode: '44070',
+    staleTokens: ['Emerald Village', 'Vista Prairie'], source: 'otterbein.org/find-a-location/north-olmsted (acq. from Vista Prairie 2025)',
+  },
+  {
+    id: 'cmqqrllu60068rlmb2s9y5s9m', oldName: 'Briar Hill Health Care Residence', newName: 'Ohman Family Living at Briar',
+    street: '15950 Pierce St', city: 'Middlefield', state: 'OH', zipCode: '44062',
+    staleTokens: ['Briar Hill'], source: 'ohmanfamilyliving.com/briar (same Medicare ID 365937 as Briar Hill)',
+  },
+  {
+    id: 'cmqqrkwlr0036rlmbpauvg0ag', oldName: "Greenfield Estate Alzheimer's Special Care Center", newName: 'The Ridge at Copley',
+    street: '3522 Commercial Dr', city: 'Akron', state: 'OH', zipCode: '44333',
+    staleTokens: ['Greenfield', 'Anthem'], source: 'ridgeatcopley.com (Greenfield Estates → Anthem Memory Care → The Ridge at Copley)',
+  },
+  {
+    id: 'cmqqrl4xl0046rlmbmbb0aj2d', oldName: 'Vista Springs Macedonia', newName: 'Summit Corners',
+    street: '8400 S Bedford Rd', city: 'Macedonia', state: 'OH', zipCode: '44056',
+    staleTokens: ['Vista Springs', 'American House'], source: 'sonidaseniorliving.com/community/summit-corners (Vista Springs → American House → Summit Corners)',
+  },
+  {
+    id: 'cmqqrkq2y002erlmbedkk2hfa', oldName: 'Briarwood', newName: 'The Briarwood Healthcare Community',
+    street: '3700 Englewood Dr', city: 'Stow', state: 'OH', zipCode: '44224',
+    staleTokens: [], source: 'thebriarwood.com + caring.com (open AL/MC/SNF, Stow)',
+  },
+];
+
+const ADDR_FIELDS = ['street', 'city', 'state', 'zipCode'] as const;
+
+async function main() {
+  const isForce = process.argv.includes('--force');
+  const dryRun = !isForce;
+
+  console.log(dryRun ? '=== DRY RUN — no writes ===' : '=== LIVE — renaming + writing verified addresses ===');
+  console.log(`Batch B: ${TARGETS.length} OPEN, rebranded, two-source-verified homes\n`);
+
+  let willWrite = 0;
+  let unchanged = 0;
+  let skipped = 0;
+  const staleDescriptions: string[] = [];
+
+  for (const t of TARGETS) {
+    const home = await prisma.assistedLivingHome.findUnique({
+      where: { id: t.id },
+      select: {
+        id: true, name: true, status: true, description: true, preFilledFields: true,
+        address: { select: { id: true, street: true, city: true, state: true, zipCode: true } },
+      },
+    });
+
+    if (!home) {
+      console.log(`  ⚠ SKIP "${t.oldName}" (${t.id}) — not found`);
+      skipped++;
+      continue;
+    }
+    // Accept either the old name (not yet applied) or the new name (idempotent re-run).
+    if (home.name !== t.oldName && home.name !== t.newName) {
+      console.log(`  ⚠ SKIP "${home.name}" (${t.id}) — name drift (expected "${t.oldName}"); not touching`);
+      skipped++;
+      continue;
+    }
+    if (home.status !== 'DRAFT') {
+      console.log(`  ⚠ SKIP "${home.name}" (${t.id}) — status=${home.status} (only DRAFT)`);
+      skipped++;
+      continue;
+    }
+
+    // Stale-description scan (uses current description regardless of write).
+    const desc = (home.description ?? '').toLowerCase();
+    const hitTokens = t.staleTokens.filter((tok) => desc.includes(tok.toLowerCase()));
+    if (hitTokens.length > 0) {
+      staleDescriptions.push(`${t.newName} — description still mentions: ${hitTokens.join(', ')}`);
+    }
+
+    const a = home.address;
+    const nameMatches = home.name === t.newName;
+    const addrMatches = a && a.street === t.street && a.city === t.city && a.state === t.state && a.zipCode === t.zipCode;
+    if (nameMatches && addrMatches) {
+      console.log(`  ✓ unchanged "${t.newName}" — ${t.street}, ${t.city}, ${t.state} ${t.zipCode}`);
+      unchanged++;
+      continue;
+    }
+
+    console.log(`  🔄 "${home.name}" → "${t.newName}"`);
+    console.log(`        addr → ${t.street}, ${t.city}, ${t.state} ${t.zipCode}` + (a?.street || a?.city ? `   (was: ${a?.street ?? '—'}, ${a?.city ?? '—'} ${a?.zipCode ?? '—'})` : ''));
+    console.log(`        src: ${t.source}`);
+    if (hitTokens.length > 0) console.log(`        ⚠ description still names old brand: ${hitTokens.join(', ')}`);
+    willWrite++;
+
+    if (!dryRun) {
+      if (a) {
+        await prisma.address.update({
+          where: { id: a.id },
+          data: { street: t.street, city: t.city, state: t.state, zipCode: t.zipCode },
+        });
+      } else {
+        await prisma.address.create({
+          data: { homeId: home.id, street: t.street, city: t.city, state: t.state, zipCode: t.zipCode },
+        });
+      }
+      const prov = (home.preFilledFields as Record<string, string> | null) ?? {};
+      prov.name = 'VERIFIED';
+      for (const f of ADDR_FIELDS) prov[f] = 'VERIFIED';
+      await prisma.assistedLivingHome.update({
+        where: { id: home.id },
+        data: { name: t.newName, preFilledFields: prov },
+      });
+    }
+  }
+
+  console.log('\n─────────────────────────────────────────────');
+  console.log(`${dryRun ? 'Would write' : 'Wrote'}: ${willWrite}`);
+  console.log(`Unchanged:  ${unchanged}`);
+  console.log(`Skipped:    ${skipped}`);
+  console.log('─────────────────────────────────────────────');
+
+  if (staleDescriptions.length > 0) {
+    console.log(`\n⚠ ${staleDescriptions.length} description(s) still reference the old brand — review before publishing:`);
+    for (const s of staleDescriptions) console.log(`  - ${s}`);
+  }
+
+  if (dryRun) console.log('\nDRY RUN complete. Re-run with --force to write, then review ⚠ descriptions and run publish-directory-homes.ts.');
+}
+
+main()
+  .catch((e) => {
+    console.error('FATAL:', e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Rename + verified address — Batch B (rebranded homes)

Per founder decision. Eleven directory DRAFT homes were seeded under brands that have since been **renamed or sold**. Each is still a real, currently-OPEN AL/MC facility at the same (or corrected) location — so we update **both** the display name **and** the full verified address, and the public directory shows the name families will actually find.

| Seeded name | → Now | Verified address |
|---|---|---|
| Brookdale Medina South | Traditions of Medina | 100 High Point Dr, Medina 44256 |
| Elmcroft of Medina | Broadway Creek Senior Living | 1046 N Jefferson St, Medina 44256 |
| Elmcroft of Sagamore Hills | Majestic Care of Sagamore Hills | 997 W Aurora Rd, Northfield 44067 |
| Kindred Living at The Fountains | Heritage of Lyndhurst | 1555 Brainard Rd, Lyndhurst 44124 |
| Weils of Bainbridge | Eliza at Chagrin Falls | 16695 Chillicothe Rd, Chagrin Falls 44023 |
| Berea Lake Towers | Generations Senior Living of Berea | 4 Berea Commons, Berea 44017 |
| Emerald Village Senior Living | Otterbein North Olmsted SeniorLife | 30344 Lorain Rd, North Olmsted 44070 |
| Briar Hill Health Care Residence | Ohman Family Living at Briar | 15950 Pierce St, Middlefield 44062 |
| Greenfield Estate Alz. Care | The Ridge at Copley | 3522 Commercial Dr, Akron 44333 |
| Vista Springs Macedonia | Summit Corners | 8400 S Bedford Rd, Macedonia 44056 |
| Briarwood | The Briarwood Healthcare Community | 3700 Englewood Dr, Stow 44224 |

All verified against the operator's own site + a second independent source. Renaming is safe — home detail routes are id-based, `name` is not unique, and these directory homes have no slug.

### Stale-description guard
The seeded descriptions were written for the **old** brand. On dry-run the script scans each description for the old brand token(s) and prints a ⚠ when found, so a "Welcome to &lt;old name&gt;…" can be fixed before going live. The script **flags, never rewrites**.

### Safety
id + expected-old-name + `status=DRAFT` guarded · dry-run by default · idempotent · provenance `VERIFIED`.

### Run after merge (Render)
```
npx tsx scripts/rebrand-and-address-batch-b.ts            # dry-run — review ⚠ stale descriptions
npx tsx scripts/rebrand-and-address-batch-b.ts --force    # rename + write addresses
npx tsx scripts/publish-directory-homes.ts --force        # take them live
```

### Held (not in this PR)
- **Brookdale Medina North** → Medina Pointe Senior Living (address medium-confidence — re-verify before publish)
- **Altercare at Saint Joseph Center** → **CLOSED since Nov 2019** (Crain's + Cleveland Jewish News) — should be archived, not published
- **Princeton Place** → no confident OH facility
- **The Montefiore Home** → rebranded to skilled-nursing (out of AL/RCF scope)

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_