### PR TITLE
chore(directory): archive closed/dup homes + finish Brookdale Medina North (OL-088/089/091)

### DIFF
--- a/scripts/archive-stale-directory-homes.ts
+++ b/scripts/archive-stale-directory-homes.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env npx tsx
+/**
+ * scripts/archive-stale-directory-homes.ts
+ *
+ * OL-088 + OL-091 — retire two directory rows that should never reach families:
+ *
+ *   1. OL-088 — "Altercare at Saint Joseph Center" (id cmqqrk7gu0006rlmb2nfqnrvn).
+ *      CLOSED since Nov 2019 (Crain's + Cleveland Jewish News). It was excluded from
+ *      the Batch B rebrand PR (#612) and today stays out of the public directory ONLY
+ *      because it has no street/zip (the publish gate holds it). That's incidental — if
+ *      anyone backfills an address it would publish a defunct facility. Make it explicit.
+ *
+ *   2. OL-091 — duplicate "Ohman Family Living at Briar" (id cmp71kmsl001ilpiovrsvq7zu).
+ *      An older DRAFT "(pending)" seed row with no city/address that duplicates the
+ *      ACTIVE Middlefield listing (id cmqqrllu60068rlmb2s9y5s9m, the Batch B rebrand of
+ *      "Briar Hill Health Care Residence"). The distinct Ohman properties — "Briarcliff
+ *      Manor" and "Holly Hill"/"Ohman Family Living at Holly" — are intentionally NOT
+ *      touched here.
+ *
+ * Both are set to status=INACTIVE (the retired/archived status — same one Villa Serena
+ * uses). The public directory renders only ACTIVE homes and `publish-directory-homes.ts`
+ * only promotes DRAFT→ACTIVE, so INACTIVE is permanently non-publishable + invisible,
+ * yet fully reversible (no hard delete — preserves any relations/history).
+ *
+ * SAFETY:
+ *   - Hardcoded ids, each guarded by expected name AND expected current status.
+ *   - Dry-run by default; only writes with --force.
+ *   - Idempotent: a home already INACTIVE → "unchanged".
+ *   - Refuses to touch an ACTIVE home (guard against archiving a live listing by mistake).
+ *
+ * Usage:
+ *   npx tsx scripts/archive-stale-directory-homes.ts            # DRY RUN
+ *   npx tsx scripts/archive-stale-directory-homes.ts --force    # apply
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+type Target = {
+  id: string;
+  expectName: string;
+  /** Statuses we're willing to archive from (never ACTIVE). */
+  fromStatuses: Array<'DRAFT' | 'PENDING_REVIEW' | 'SUSPENDED'>;
+  reason: string;
+};
+
+const TARGETS: Target[] = [
+  {
+    id: 'cmqqrk7gu0006rlmb2nfqnrvn',
+    expectName: 'Altercare at Saint Joseph Center',
+    fromStatuses: ['DRAFT'],
+    reason: 'OL-088 — facility CLOSED since Nov 2019 (Crain\'s + Cleveland Jewish News)',
+  },
+  {
+    id: 'cmp71kmsl001ilpiovrsvq7zu',
+    expectName: 'Ohman Family Living at Briar',
+    fromStatuses: ['DRAFT'],
+    reason: 'OL-091 — duplicate of ACTIVE Middlefield listing cmqqrllu60068rlmb2s9y5s9m',
+  },
+];
+
+async function main() {
+  const isForce = process.argv.includes('--force');
+  const dryRun = !isForce;
+
+  console.log(dryRun ? '=== DRY RUN — no writes ===' : '=== LIVE — archiving stale directory homes ===');
+  console.log(`Archive targets: ${TARGETS.length}\n`);
+
+  let willWrite = 0;
+  let unchanged = 0;
+  let skipped = 0;
+
+  for (const t of TARGETS) {
+    const home = await prisma.assistedLivingHome.findUnique({
+      where: { id: t.id },
+      select: { id: true, name: true, status: true },
+    });
+
+    if (!home) {
+      console.log(`  ⚠ SKIP "${t.expectName}" (${t.id}) — not found`);
+      skipped++;
+      continue;
+    }
+    if (home.name !== t.expectName) {
+      console.log(`  ⚠ SKIP (${t.id}) — name drift: expected "${t.expectName}", found "${home.name}"; not touching`);
+      skipped++;
+      continue;
+    }
+    if (home.status === 'INACTIVE') {
+      console.log(`  ✓ unchanged "${home.name}" — already INACTIVE`);
+      unchanged++;
+      continue;
+    }
+    if (!t.fromStatuses.includes(home.status as Target['fromStatuses'][number])) {
+      console.log(`  ⚠ SKIP "${home.name}" (${t.id}) — status=${home.status} not in [${t.fromStatuses.join(', ')}] (refusing to archive)`);
+      skipped++;
+      continue;
+    }
+
+    console.log(`  📦 ARCHIVE "${home.name}" — ${home.status} → INACTIVE`);
+    console.log(`        ${t.reason}`);
+    willWrite++;
+
+    if (!dryRun) {
+      await prisma.assistedLivingHome.update({
+        where: { id: home.id },
+        data: { status: 'INACTIVE' },
+      });
+    }
+  }
+
+  console.log('\n─────────────────────────────────────────────');
+  console.log(`${dryRun ? 'Would archive' : 'Archived'}: ${willWrite}`);
+  console.log(`Unchanged:    ${unchanged}`);
+  console.log(`Skipped:      ${skipped}`);
+  console.log('─────────────────────────────────────────────');
+
+  if (dryRun) console.log('\nDRY RUN complete. Re-run with --force to write.');
+}
+
+main()
+  .catch((e) => {
+    console.error('FATAL:', e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/fix-stale-descriptions-batch-b.ts
+++ b/scripts/fix-stale-descriptions-batch-b.ts
@@ -65,6 +65,16 @@ const FIXES: Fix[] = [
     careTypes: 'assisted living, memory care, skilled nursing',
     staleTokens: ['Weils', 'Weil'],
   },
+  {
+    // OL-089 — Brookdale Medina North → Medina Pointe Senior Living. No-op unless the
+    // seeded description actually carries the old brand token (the guard skips otherwise).
+    id: 'cmqqrlg91005krlmbyqjdxy5t',
+    name: 'Medina Pointe Senior Living',
+    city: 'Medina',
+    county: 'Medina',
+    careTypes: 'assisted living, memory care',
+    staleTokens: ['Brookdale'],
+  },
 ];
 
 async function main() {

--- a/scripts/rebrand-and-address-batch-b.ts
+++ b/scripts/rebrand-and-address-batch-b.ts
@@ -49,7 +49,8 @@ type Target = {
 };
 
 // Batch B — OPEN, rebranded, two-source-verified (2026-06-24).
-// Brookdale Medina North is intentionally NOT here (address medium-confidence; held for re-verify).
+// Brookdale Medina North added 2026-06-25 (OL-089) after its address was re-verified to two
+// independent sources (49-A Leisure Ln); it was originally held out as medium-confidence.
 const TARGETS: Target[] = [
   {
     id: 'cmqqrlgra005mrlmbn1qbtn2q', oldName: 'Brookdale Medina South', newName: 'Traditions of Medina',
@@ -105,6 +106,11 @@ const TARGETS: Target[] = [
     id: 'cmqqrkq2y002erlmbedkk2hfa', oldName: 'Briarwood', newName: 'The Briarwood Healthcare Community',
     street: '3700 Englewood Dr', city: 'Stow', state: 'OH', zipCode: '44224',
     staleTokens: [], source: 'thebriarwood.com + caring.com (open AL/MC/SNF, Stow)',
+  },
+  {
+    id: 'cmqqrlg91005krlmbyqjdxy5t', oldName: 'Brookdale Medina North', newName: 'Medina Pointe Senior Living',
+    street: '49-A Leisure Ln', city: 'Medina', state: 'OH', zipCode: '44256',
+    staleTokens: ['Brookdale'], source: 'seniorlivingguide.com (49-A Leisure Ln) + aplaceformom.com — Medina Pointe (fka Brookdale Medina North), Sinceri Senior Living (OL-089 re-verify)',
   },
 ];
 

--- a/scripts/report-directory-homes.ts
+++ b/scripts/report-directory-homes.ts
@@ -26,6 +26,11 @@
  *   npx tsx scripts/report-directory-homes.ts                 # all directory homes
  *   npx tsx scripts/report-directory-homes.ts --unenriched    # only enriched=no
  *   npx tsx scripts/report-directory-homes.ts --tsv           # tab-separated (paste to a sheet)
+ *   npx tsx scripts/report-directory-homes.ts --csv           # RFC-4180 CSV (quoted; save as a .csv)
+ *   npx tsx scripts/report-directory-homes.ts --active-only   # only status=ACTIVE (the live unclaimed listings)
+ *
+ * For the Cowork outreach handoff, the clean export is:
+ *   npx tsx scripts/report-directory-homes.ts --csv --active-only
  */
 
 import { PrismaClient } from '@prisma/client';
@@ -34,9 +39,16 @@ const prisma = new PrismaClient();
 
 const SEED_USER_EMAIL = 'directory-unclaimed@carelinkai.system';
 
+/** Quote a value for RFC-4180 CSV (wrap in quotes, double any internal quotes). */
+function csvCell(v: string): string {
+  return `"${String(v).replace(/"/g, '""')}"`;
+}
+
 async function main() {
   const unenrichedOnly = process.argv.includes('--unenriched');
   const tsv = process.argv.includes('--tsv');
+  const csv = process.argv.includes('--csv');
+  const activeOnly = process.argv.includes('--active-only');
 
   const seedUser = await prisma.user.findUnique({ where: { email: SEED_USER_EMAIL } });
   const seedOperator = seedUser
@@ -52,6 +64,7 @@ async function main() {
     where: {
       operatorId: seedOperator.id,
       ...(unenrichedOnly ? { autoPopulatedAt: null } : {}),
+      ...(activeOnly ? { status: 'ACTIVE' } : {}),
     },
     select: {
       id: true,
@@ -75,8 +88,14 @@ async function main() {
     website: h.websiteUrl ?? '',
   }));
 
-  if (tsv) {
-    console.log(['homeId', 'name', 'city', 'status', 'enriched', 'phone', 'website'].join('\t'));
+  const header = ['homeId', 'name', 'city', 'status', 'enriched', 'phone', 'website'] as const;
+  if (csv) {
+    console.log(header.map(csvCell).join(','));
+    for (const r of rows) {
+      console.log([r.homeId, r.name, r.city, r.status, r.enriched, r.phone, r.website].map(csvCell).join(','));
+    }
+  } else if (tsv) {
+    console.log(header.join('\t'));
     for (const r of rows) {
       console.log([r.homeId, r.name, r.city, r.status, r.enriched, r.phone, r.website].join('\t'));
     }
@@ -85,10 +104,14 @@ async function main() {
   }
 
   const enrichedCount = homes.filter((h) => h.autoPopulatedAt).length;
-  console.log(
-    `\n${homes.length} directory home(s)${unenrichedOnly ? ' (unenriched only)' : ''}: ` +
-    `${enrichedCount} enriched, ${homes.length - enrichedCount} not enriched.`,
-  );
+  // Suppress the trailing summary in machine-readable modes so the output is a clean paste/file.
+  if (!csv && !tsv) {
+    console.log(
+      `\n${homes.length} directory home(s)` +
+      `${unenrichedOnly ? ' (unenriched only)' : ''}${activeOnly ? ' (active only)' : ''}: ` +
+      `${enrichedCount} enriched, ${homes.length - enrichedCount} not enriched.`,
+    );
+  }
 }
 
 main()


### PR DESCRIPTION
## Directory housekeeping — OL-088 / OL-091 / OL-089

Closes the three cleanup loops from the go-live session.

### 1. Archive closed / duplicate homes (`archive-stale-directory-homes.ts`, NEW)
Sets two rows to `INACTIVE` (the retired status — same as Villa Serena; public directory shows only ACTIVE and the publisher only promotes DRAFT→ACTIVE, so INACTIVE is permanently non-publishable + invisible, yet reversible — no hard delete):
- **OL-088 — Altercare at Saint Joseph Center** — CLOSED since Nov 2019. Was held out of public only by a missing address; this makes the exclusion explicit so it can never publish if an address is later added.
- **OL-091 — duplicate "Ohman Family Living at Briar"** — older DRAFT "(pending)" seed row (no address) duplicating the ACTIVE Middlefield listing (#612 rebrand of Briar Hill). The distinct Ohman properties (Briarcliff Manor, Holly Hill) are **not** touched.

Guarded by id + expected name + non-ACTIVE status; dry-run by default; idempotent; refuses to archive an ACTIVE home.

### 2. Finish Brookdale Medina North (OL-089)
Address **re-verified to two independent sources** — **49-A Leisure Ln, Medina, OH 44256** (SeniorLivingGuide URL slug + A Place for Mom; operator Sinceri Senior Living, **Medina Pointe Senior Living**, fka Brookdale Medina North; open, AL + memory care). Originally held as medium-confidence. Now:
- Added as the **12th Batch B target** in `rebrand-and-address-batch-b.ts` (rename + verified address).
- Added to `fix-stale-descriptions-batch-b.ts` (no-op unless its seeded description names the old brand).

So it can be renamed, addressed, and published with the rest → directory **167 → 168**.

### Run after merge (Render)
```
npx tsx scripts/archive-stale-directory-homes.ts                 # dry-run, then --force
npx tsx scripts/rebrand-and-address-batch-b.ts                   # dry-run — Medina Pointe is new; rest "unchanged"
npx tsx scripts/rebrand-and-address-batch-b.ts --force
npx tsx scripts/fix-stale-descriptions-batch-b.ts                # dry-run, then --force (Medina Pointe no-op unless stale)
npx tsx scripts/fix-stale-descriptions-batch-b.ts --force
npx tsx scripts/publish-directory-homes.ts                       # dry-run, then --force  (publishes Medina Pointe)
npx tsx scripts/publish-directory-homes.ts --force
```

`tsc --noEmit` clean. All scripts dry-run by default, guarded, idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_