### PR TITLE
feat(directory): claim-funnel tracker + rebrand renames (pilot follow-ups)

### DIFF
--- a/scripts/rename-rebranded-homes.ts
+++ b/scripts/rename-rebranded-homes.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env npx tsx
+/**
+ * scripts/rename-rebranded-homes.ts
+ *
+ * Display-name cleanup for ACTIVE directory listings still showing a defunct brand.
+ * The Cowork outreach-research pass (2026-06-25) flagged 21 listings whose seeded name
+ * is outdated; this renames the 12 with a clear, current operator name so families see
+ * the brand they'll actually find. (Held: "Brookdale Richmond Heights → Richmond Heights
+ * Place" — Cowork marked it "confirm operator". Excluded: "Harbor Court → Meadow Falls of
+ * Rocky River", handled as a duplicate by dedupe-directory-homes.ts. The other 7 flagged
+ * rows already show their current name.)
+ *
+ * NAME ONLY: these are same-location rebrands, so the verified address already on the
+ * listing is unchanged. Home detail routes are id-based and `name` is non-unique, so a
+ * rename is non-breaking and reversible. Source for each new name is Cowork's research
+ * (single-source) — the dry-run is the review gate before --force.
+ *
+ * SAFETY:
+ *   - Hardcoded ids; each guarded by the expected OLD name AND status=ACTIVE.
+ *   - Accepts the new name too (idempotent re-run → "unchanged").
+ *   - Dry-run by default; only writes with --force.
+ *   - Marks name VERIFIED in preFilledFields.
+ *
+ * Usage:
+ *   npx tsx scripts/rename-rebranded-homes.ts            # DRY RUN
+ *   npx tsx scripts/rename-rebranded-homes.ts --force    # apply
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+type Rename = { id: string; oldName: string; newName: string; note: string };
+
+const RENAMES: Rename[] = [
+  { id: 'cmqqrkuns002yrlmb13y1glzr', oldName: 'Gables of Hudson', newName: 'Hudson Grande Senior Living', note: 'Arrow Senior Living' },
+  { id: 'cmqqrl8hf004mrlmbvsxilf5r', oldName: 'Elmcroft of Lorain', newName: 'Lorain Estates Senior Living', note: 'Sinceri Senior Living' },
+  { id: 'cmqqrleah005crlmbqbcz3m0s', oldName: 'Lantern of Madison', newName: 'Meadow Falls of Madison', note: 'Meadow Falls Senior Living' },
+  { id: 'cmqqrk8xx000crlmbtl4lnkuw', oldName: 'Belvedere of Westlake', newName: 'Saint Therese of Westlake', note: 'acquired ~May 2025; 29591 Detroit Rd' },
+  { id: 'cmqqrkqwf002irlmbc9lqw5x7', oldName: 'Brookdale Bath', newName: 'Meadow Falls of Bath', note: 'Brookdale divestiture' },
+  { id: 'cmqqrkqja002grlmbkm2gfnvo', oldName: 'Brookdale Barberton', newName: 'Barberton Pointe Senior Living', note: 'Sinceri; 487 Austin Dr' },
+  { id: 'cmqqrlbal004yrlmbj9pskeq6', oldName: 'Brookdale Newell Creek', newName: 'The Enclave of Newell Creek', note: 'Bridge Senior Living; 7900 Center St' },
+  { id: 'cmqqrka8c000irlmb28e0u22z', oldName: 'Brookdale Middleburg Heights', newName: 'Middleburg Heights Assisted Living', note: 'independent, ex-Paramount; 15435 Bagley Rd' },
+  { id: 'cmqqrkrtz002mrlmbmx9iuuvz', oldName: 'Brookdale Stow', newName: 'Eden Vista Stow', note: 'Vista Senior Living Mgmt; 5511 Fishcreek Rd' },
+  { id: 'cmqqrlbrc0050rlmbdpf37w19', oldName: 'Brookdale Wickliffe', newName: 'Meadow Falls of Wickliffe', note: '30630 Ridge Rd' },
+  { id: 'cmqqrlc5m0052rlmbbocwczdc', oldName: 'Brookdale Willoughby', newName: 'Maple Ridge Senior Living', note: 'Vista; 35300 Kaiser Ct' },
+  { id: 'cmqqrkezr0012rlmbafv7zu32', oldName: 'HarborChase of Shaker Heights', newName: 'StoryPoint Shaker Heights', note: '17000 Van Aken Blvd' },
+];
+
+async function main() {
+  const isForce = process.argv.includes('--force');
+  const dryRun = !isForce;
+
+  console.log(dryRun ? '=== DRY RUN — no writes ===' : '=== LIVE — renaming rebranded listings ===');
+  console.log(`Rebrand renames: ${RENAMES.length}\n`);
+
+  let willWrite = 0;
+  let unchanged = 0;
+  let skipped = 0;
+
+  for (const r of RENAMES) {
+    const home = await prisma.assistedLivingHome.findUnique({
+      where: { id: r.id },
+      select: { id: true, name: true, status: true, preFilledFields: true },
+    });
+
+    if (!home) {
+      console.log(`  ⚠ SKIP "${r.oldName}" (${r.id}) — not found`);
+      skipped++;
+      continue;
+    }
+    if (home.name === r.newName) {
+      console.log(`  ✓ unchanged "${r.newName}" — already renamed`);
+      unchanged++;
+      continue;
+    }
+    if (home.name !== r.oldName) {
+      console.log(`  ⚠ SKIP (${r.id}) — name drift: expected "${r.oldName}", found "${home.name}"; not touching`);
+      skipped++;
+      continue;
+    }
+    if (home.status !== 'ACTIVE') {
+      console.log(`  ⚠ SKIP "${home.name}" (${r.id}) — status=${home.status} (only ACTIVE)`);
+      skipped++;
+      continue;
+    }
+
+    console.log(`  🔄 "${home.name}" → "${r.newName}"   (${r.note})`);
+    willWrite++;
+
+    if (!dryRun) {
+      const prov = (home.preFilledFields as Record<string, string> | null) ?? {};
+      prov.name = 'VERIFIED';
+      await prisma.assistedLivingHome.update({
+        where: { id: home.id },
+        data: { name: r.newName, preFilledFields: prov },
+      });
+    }
+  }
+
+  console.log('\n─────────────────────────────────────────────');
+  console.log(`${dryRun ? 'Would rename' : 'Renamed'}: ${willWrite}`);
+  console.log(`Unchanged:    ${unchanged}`);
+  console.log(`Skipped:      ${skipped}`);
+  console.log('─────────────────────────────────────────────');
+  if (dryRun) console.log('\nDRY RUN complete. Re-run with --force to write.');
+}
+
+main()
+  .catch((e) => {
+    console.error('FATAL:', e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/report-claim-funnel.ts
+++ b/scripts/report-claim-funnel.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env npx tsx
+/**
+ * scripts/report-claim-funnel.ts
+ *
+ * Read-only tracker for the proactive claim-nudge pilot (send-claim-nudges.ts).
+ * Answers: of the listings we've nudged, how many have been CLAIMED?
+ *
+ * A directory listing is "claimed" when its ownership transfers off the directory
+ * sentinel operator (directory-unclaimed@carelinkai.system) to a real operator — so
+ * we look at EVERY home that has a claimNudgeLastSentAt stamp (claimed homes have
+ * left the sentinel, so we can't filter by the sentinel operator), and classify by
+ * current owner.
+ *
+ * Note: open/click metrics live in Resend, not our DB — check the Resend dashboard
+ * for those. This reports the metric that matters: claims (the conversion).
+ *
+ * Writes nothing. Safe to run anytime.
+ *
+ * Usage:
+ *   npx tsx scripts/report-claim-funnel.ts            # summary + claimed list
+ *   npx tsx scripts/report-claim-funnel.ts --tsv      # tab-separated rows
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const DIRECTORY_UNCLAIMED_EMAIL = 'directory-unclaimed@carelinkai.system';
+
+async function main() {
+  const tsv = process.argv.includes('--tsv');
+
+  const homes = await prisma.assistedLivingHome.findMany({
+    where: { claimNudgeLastSentAt: { not: null } },
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      outreachEmail: true,
+      claimNudgeLastSentAt: true,
+      operator: { select: { user: { select: { email: true } } } },
+    },
+    orderBy: { claimNudgeLastSentAt: 'desc' },
+  });
+
+  const rows = homes.map((h) => {
+    const owner = (h.operator?.user?.email ?? '').toLowerCase();
+    const claimed = owner !== DIRECTORY_UNCLAIMED_EMAIL;
+    return {
+      homeId: h.id,
+      name: h.name,
+      status: h.status,
+      claimed: claimed ? 'CLAIMED' : 'pending',
+      owner: claimed ? owner : '(unclaimed)',
+      nudgedAt: h.claimNudgeLastSentAt ? h.claimNudgeLastSentAt.toISOString().slice(0, 10) : '',
+      outreachEmail: h.outreachEmail ?? '',
+    };
+  });
+
+  const claimed = rows.filter((r) => r.claimed === 'CLAIMED');
+
+  if (tsv) {
+    console.log(['homeId', 'name', 'status', 'claimed', 'owner', 'nudgedAt', 'outreachEmail'].join('\t'));
+    for (const r of rows) {
+      console.log([r.homeId, r.name, r.status, r.claimed, r.owner, r.nudgedAt, r.outreachEmail].join('\t'));
+    }
+    return;
+  }
+
+  console.log('=== Claim-nudge funnel ===\n');
+  console.log(`Nudged (total):  ${rows.length}`);
+  console.log(`Claimed:         ${claimed.length}`);
+  const rate = rows.length ? ((claimed.length / rows.length) * 100).toFixed(1) : '0.0';
+  console.log(`Claim rate:      ${rate}%\n`);
+
+  if (claimed.length) {
+    console.log('🎉 Claimed listings:');
+    for (const r of claimed) {
+      console.log(`  ✓ "${r.name}" — claimed by ${r.owner} (nudged ${r.nudgedAt})`);
+    }
+    console.log('');
+  }
+
+  console.log('Still pending (nudged, not yet claimed):');
+  for (const r of rows.filter((r) => r.claimed !== 'CLAIMED')) {
+    console.log(`  · "${r.name}" — ${r.outreachEmail} (nudged ${r.nudgedAt})`);
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error('ERROR:', e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Pilot follow-ups: claim tracker + rebrand renames

### 1. Claim-funnel tracker (`report-claim-funnel.ts`)
Read-only. Of the listings we've nudged (`claimNudgeLastSentAt` set), how many have been **claimed** — i.e. ownership transferred off the directory sentinel operator. Reports count + claim rate + the won listings. Run it in a few days to measure the 13-home pilot before scaling to the MEDIUM tier.
```
npx tsx scripts/report-claim-funnel.ts
```
*(Opens/clicks live in Resend's dashboard, not our DB — this tracks claims, the conversion that matters.)*

### 2. Rebrand renames (`rename-rebranded-homes.ts`)
Cowork flagged 21 listings with outdated names. This renames the **12 clear ones** to the current operator brand so families see the name they'll actually find:

| Old (showing now) | → New |
|---|---|
| Gables of Hudson | Hudson Grande Senior Living |
| Elmcroft of Lorain | Lorain Estates Senior Living |
| Lantern of Madison | Meadow Falls of Madison |
| Belvedere of Westlake | Saint Therese of Westlake |
| Brookdale Bath | Meadow Falls of Bath |
| Brookdale Barberton | Barberton Pointe Senior Living |
| Brookdale Newell Creek | The Enclave of Newell Creek |
| Brookdale Middleburg Heights | Middleburg Heights Assisted Living |
| Brookdale Stow | Eden Vista Stow |
| Brookdale Wickliffe | Meadow Falls of Wickliffe |
| Brookdale Willoughby | Maple Ridge Senior Living |
| HarborChase of Shaker Heights | StoryPoint Shaker Heights |

**Name-only** (same-location rebrands; verified addresses unchanged). id-routed + non-unique name → non-breaking, reversible. Guarded by id + expected old name + status=ACTIVE; dry-run by default.

**Held:** "Brookdale Richmond Heights → Richmond Heights Place" (Cowork marked "confirm operator"). **Excluded:** "Harbor Court → Meadow Falls of Rocky River" (handled as a dup in #617). The other 7 flagged rows already show their current name.

> Source for the new names is Cowork's single-source research — the **dry-run is the review gate**.

### Run after merge (Render)
```
npx tsx scripts/rename-rebranded-homes.ts            # dry-run — review the 12
npx tsx scripts/rename-rebranded-homes.ts --force
```

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_