### PR TITLE
feat(directory): apply SEND_READY outreach backfill (send/clear/dup/hold)

### DIFF
--- a/scripts/data/outreach-send-ready.json
+++ b/scripts/data/outreach-send-ready.json
@@ -1,0 +1,633 @@
+[
+  {
+    "homeId": "cmqqrl9u4004srlmbdlrrxwzh",
+    "name": "St. Mary of the Woods",
+    "op": "send",
+    "email": "traceym@sainttherese.org",
+    "phone": "(440) 937-3111",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmp71kmtc0026lpion3ikc66y",
+    "name": "The Gardens of French Creek at Avon Oaks",
+    "op": "send",
+    "email": "nsalti@avonoaks.net",
+    "phone": "(440) 934-5204",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmqqrl7iu004irlmbfb8b7onx",
+    "name": "Avenue Assisted Living",
+    "op": "send",
+    "email": "JCoe@SprengerHealthCare.com",
+    "phone": "(440) 930-6700",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmp71kmu0002olpio2i7liyzd",
+    "name": "Pleasant Pointe Assisted Living",
+    "op": "send",
+    "email": "teresa@pleasantviewhealthcare.com",
+    "phone": "330-848-5028",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmqqrkmww0020rlmbthcvype7",
+    "name": "Park East",
+    "op": "hold"
+  },
+  {
+    "homeId": "cmql0xbos0006r7jcitqgqhds",
+    "name": "Windsor Heights",
+    "op": "send",
+    "email": "brandy.delp@sunshineret.com",
+    "phone": "(216) 245-0455",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmqqrkj50001krlmbx4qkh8jp",
+    "name": "Light of Hearts Villa",
+    "op": "send",
+    "email": "kate.mach@lightofheartsvilla.org",
+    "phone": "440.232.1991 ext 520",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmqqrklyn001wrlmbt6hki35l",
+    "name": "Oaks of Brecksville",
+    "op": "hold"
+  },
+  {
+    "homeId": "cmqqrlo85006krlmbl79j6l27",
+    "name": "Eliza at Chagrin Falls",
+    "op": "send",
+    "email": "alovano@elizajen.org",
+    "phone": "440.543.4221",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmp71kmsp001mlpiot2a118ng",
+    "name": "South Franklin Circle",
+    "op": "send",
+    "email": "communications@judsonsmartliving.org",
+    "phone": "440-457-8280",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmp71kms50014lpiooje7mtml",
+    "name": "Algart Health Care",
+    "op": "send",
+    "email": "info@algart.com",
+    "phone": "(216) 631-1550",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkd2h000urlmbsoe33ysh",
+    "name": "Eliza Jennings",
+    "op": "send",
+    "email": "lfluhart@elizajen.org",
+    "phone": "216.226.5000",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmp71kmre000ilpion9d442k6",
+    "name": "Judson Manor",
+    "op": "send",
+    "email": "communications@judsonsmartliving.org",
+    "phone": "(216) 791-2004",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmp71kmr9000elpiozlpku0wq",
+    "name": "Singleton Health Care Center",
+    "op": "send",
+    "email": "tbruno@singletonhcc.com",
+    "phone": "(216) 231-8467 ext 110",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmqqrkggg0018rlmb9ql5qbwx",
+    "name": "Judson Park",
+    "op": "send",
+    "email": "communications@judsonsmartliving.org",
+    "phone": "(216) 532-1350",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmp71kmsc001alpioawg1lbup",
+    "name": "Hilltop Village Assisted Living",
+    "op": "send",
+    "email": "info@hilltopvillage.com",
+    "phone": "216-261-8383",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkjm9001mrlmb9umruvps",
+    "name": "Marymount Place",
+    "op": "send",
+    "email": "info@marymounthealth.org",
+    "phone": "216-332-1100",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkt7m002srlmbv9kt8po5",
+    "name": "Crown Center at Laurel Lake",
+    "op": "send",
+    "email": "info@laurellake.org",
+    "phone": "330-650-0681",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrky1c003crlmbocgnuoq2",
+    "name": "Heritage of Hudson",
+    "op": "hold"
+  },
+  {
+    "homeId": "cmp71kmty002mlpion9nyi9d2",
+    "name": "The Elms Assisted Living",
+    "op": "hold"
+  },
+  {
+    "homeId": "cmqqrl8hf004mrlmbvsxilf5r",
+    "name": "Elmcroft of Lorain",
+    "op": "send",
+    "email": "contact@sinceriseniorliving.com",
+    "phone": "(440) 960-2813",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkhpb001erlmb83zsyyhk",
+    "name": "Heritage of Lyndhurst",
+    "op": "send",
+    "email": "info@heritage-rc.com",
+    "phone": "440-460-1000",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkpl2002crlmbhj7ksqix",
+    "name": "Avenue at Macedonia",
+    "op": "hold"
+  },
+  {
+    "homeId": "cmqqrleah005crlmbqbcz3m0s",
+    "name": "Lantern of Madison",
+    "op": "send",
+    "email": "info@meadowfallsseniorliving.com",
+    "phone": "(440) 428-2664",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrki6j001grlmbevwl3hue",
+    "name": "Landerbrook Transitional Care",
+    "op": "hold"
+  },
+  {
+    "homeId": "cmqqrlmby006arlmbyyuhra21",
+    "name": "Briarcliff Manor",
+    "op": "dup"
+  },
+  {
+    "homeId": "cmqqrl08g003mrlmbczapzk5t",
+    "name": "Mulberry Gardens",
+    "op": "send",
+    "email": "mulberrygardenssl@SinceriSL.com",
+    "phone": "(330) 634-9919",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrlmnv006crlmb18mwhnq5",
+    "name": "Holly Hill",
+    "op": "send",
+    "email": "info.holly@ohmanfamilyliving.com",
+    "phone": "(440) 338-8220",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmp71kms70016lpioahtq3nc0",
+    "name": "Village of the Falls",
+    "op": "clear",
+    "phone": "(440) 235-7590"
+  },
+  {
+    "homeId": "cmp71kmrh000klpiouf5sm5rk",
+    "name": "Pleasant Lake Villa",
+    "op": "send",
+    "email": "info@lhshealth.com",
+    "phone": "440-842-2273",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrl14z003qrlmby7e8l0rl",
+    "name": "Renaissance Assisted Living",
+    "op": "send",
+    "email": "info@renaissanceofrichfield.com",
+    "phone": "330-313-7000",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkfhn0014rlmbtqruq6x2",
+    "name": "Harbor Court Retirement Community",
+    "op": "dup"
+  },
+  {
+    "homeId": "cmqqrkp57002arlmbvqnyq71f",
+    "name": "The Woodlands of Shaker Heights",
+    "op": "send",
+    "email": "info@heritage-rc.com",
+    "phone": "216-751-0930",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrli42005srlmb0rd3pdrk",
+    "name": "Inn at Coal Ridge",
+    "op": "send",
+    "email": "contact@innatcoalridge.com",
+    "phone": "(330) 334-1546",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrlikp005urlmbirf806mo",
+    "name": "Liberty Residence Holdings",
+    "op": "send",
+    "email": "lmiller@woodlandsofliberty.com",
+    "phone": "(330) 336-3616",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrlji1005yrlmb0sq7gzjf",
+    "name": "Sanctuary Wadsworth",
+    "op": "send",
+    "email": "kristie.burss@sanctuaryhealthnetwork.com",
+    "phone": "330.335.1558",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmqqrk8xx000crlmbtl4lnkuw",
+    "name": "Belvedere of Westlake",
+    "op": "send",
+    "email": "ColleenN@SaintTherese.org",
+    "phone": "(440) 835-4000",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkc4w000qrlmbqrgzwpfk",
+    "name": "Devon Oaks",
+    "op": "send",
+    "email": "kcolby@elizajen.org",
+    "phone": "(216) 226-5000",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmqqrles0005erlmbl17xexe1",
+    "name": "Nason Center of Breckenridge Village",
+    "op": "hold"
+  },
+  {
+    "homeId": "cmp71kmu6002slpio3rpxs9gv",
+    "name": "Arden Courts (Bath)",
+    "op": "clear",
+    "phone": "330-668-6889"
+  },
+  {
+    "homeId": "cmqqrkqwf002irlmbc9lqw5x7",
+    "name": "Brookdale Bath",
+    "op": "send",
+    "email": "info@meadowfallsseniorliving.com",
+    "phone": "(330) 666-7011",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkkkp001qrlmbjagomjv1",
+    "name": "O'Neill Healthcare Bay Village",
+    "op": "send",
+    "email": "Dir.sales@oneillhc.com",
+    "phone": "440-808-5500",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmql0xbov0008r7jcgq2lih67",
+    "name": "Beachwood Commons",
+    "op": "send",
+    "email": "info@npseniorliving.com",
+    "phone": "216-295-1700",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkbn2000orlmbh8i5fbax",
+    "name": "Danbury Senior Living Broadview Heights",
+    "op": "send",
+    "email": "marketing@csig.com",
+    "phone": "440-577-5206",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrlh7w005orlmbdrwzx02f",
+    "name": "Danbury Brunswick",
+    "op": "send",
+    "email": "marketing@csig.com",
+    "phone": "330-302-2588",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrln04006erlmbpae67m2d",
+    "name": "Maplewood at Heather Hill",
+    "op": "send",
+    "email": "maplewoodinfo@maplewoodsl.com",
+    "phone": "440-285-3300",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmp71kmse001clpiofgsupc5e",
+    "name": "Arden Courts (Parma)",
+    "op": "clear",
+    "phone": "440-886-5858"
+  },
+  {
+    "homeId": "cmp71kmsa0018lpiojjzghsq0",
+    "name": "O'Neill Healthcare Lakewood",
+    "op": "send",
+    "email": "Dir.sales@oneillhc.com",
+    "phone": "440-808-5500",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmp71kmtv002klpio0b5064xx",
+    "name": "Cuyahoga Falls Danbury Woods",
+    "op": "dup"
+  },
+  {
+    "homeId": "cmqqrkyy9003grlmbc31bx8yt",
+    "name": "Maplewood at Cuyahoga Falls",
+    "op": "send",
+    "email": "maplewoodinfo@maplewoodsl.com",
+    "phone": "234-208-9871",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkkza001srlmbwjt84vnm",
+    "name": "O'Neill Healthcare Fairview Park",
+    "op": "send",
+    "email": "Dir.sales@oneillhc.com",
+    "phone": "440-808-5500",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkgww001arlmbbvzh32kc",
+    "name": "Kemper House Highland Heights",
+    "op": "send",
+    "email": "info@kemperhouse.com",
+    "phone": "(440) 461-0600",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmql0xbpv000ur7jcxxgh999r",
+    "name": "Vista Springs Ravinia Estate",
+    "op": "send",
+    "email": "Leads@VistaSpringsLiving.com",
+    "phone": "(216) 232-4900",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkg080016rlmbu76acaxz",
+    "name": "Haven at Lakewood",
+    "op": "send",
+    "email": "havenatlakewood.sales@npseniorliving.com",
+    "phone": "(216) 228-2266",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrljyy0060rlmbvjs0wgdy",
+    "name": "StoryPoint Medina East",
+    "op": "send",
+    "email": "marketing@csig.com",
+    "phone": "330-590-5647",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrlker0062rlmbwi0mpuvs",
+    "name": "StoryPoint Medina West",
+    "op": "send",
+    "email": "marketing@csig.com",
+    "phone": "330-661-9786",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrlclc0054rlmb2o5awfyo",
+    "name": "Danbury Mentor",
+    "op": "send",
+    "email": "marketing@csig.com",
+    "phone": "440-762-7072",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrlfa4005grlmbkwkcolv9",
+    "name": "Salida Woods Assisted Living",
+    "op": "send",
+    "email": "salidawoods.sales@npseniorliving.com",
+    "phone": "440-257-3866",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmql0xbps000sr7jcpmmboica",
+    "name": "Symphony at Mentor",
+    "op": "clear",
+    "phone": "440-207-9714"
+  },
+  {
+    "homeId": "cmqqrka8c000irlmb28e0u22z",
+    "name": "Brookdale Middleburg Heights",
+    "op": "send",
+    "email": "kcordek@paramountsl.net",
+    "phone": "440-887-1125",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmqqrllu60068rlmb2s9y5s9m",
+    "name": "Ohman Family Living at Briar",
+    "op": "send",
+    "email": "info@ohmanfamilyliving.com",
+    "phone": "440-632-5241",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrklgi001urlmbljqiw9p7",
+    "name": "O'Neill Healthcare North Olmsted",
+    "op": "send",
+    "email": "Dir.sales@oneillhc.com",
+    "phone": "440-808-5500",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrl80y004krlmb33c3lq4a",
+    "name": "Danbury North Ridgeville",
+    "op": "send",
+    "email": "marketing@csig.com",
+    "phone": "440-745-7513",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmp71kmta0024lpioz3wfhely",
+    "name": "O'Neill Healthcare North Ridgeville",
+    "op": "send",
+    "email": "Dir.sales@oneillhc.com",
+    "phone": "440-808-5500",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkinf001irlmbmyyu5cc2",
+    "name": "Legacy Place - Parma",
+    "op": "send",
+    "email": "info@lhshealth.com",
+    "phone": "440-845-0200",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmql0xbp9000gr7jcpmm4c9ps",
+    "name": "Bloom at Rocky River",
+    "op": "send",
+    "email": "cdecker@bloomseniorliving.com",
+    "phone": "440-356-9797",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmql0xbpc000ir7jc3zf5c77q",
+    "name": "Meadow Falls of Rocky River",
+    "op": "send",
+    "email": "info@meadowfallsseniorliving.com",
+    "phone": "440-356-2282",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrko6c0026rlmbp4r307ll",
+    "name": "Sunrise at Shaker Heights",
+    "op": "hold"
+  },
+  {
+    "homeId": "cmql0xboz000ar7jcfnjgumpm",
+    "name": "Solon Pointe",
+    "op": "dup"
+  },
+  {
+    "homeId": "cmqqrkna30022rlmb9tsdrvzm",
+    "name": "Solon Pointe at Emerald Ridge",
+    "op": "send",
+    "email": "info@solonpointehc.com",
+    "phone": "440-498-3000",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkrtz002mrlmbmx9iuuvz",
+    "name": "Brookdale Stow",
+    "op": "send",
+    "email": "info@edenvistastow.com",
+    "phone": "(330) 342-0934",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrkh90001crlmbnexxgwqj",
+    "name": "Kemper House Strongsville",
+    "op": "send",
+    "email": "info@kemperhouse.com",
+    "phone": "(440) 846-1100",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmql0xbpj000mr7jctdsu6m7n",
+    "name": "Vitalia Strongsville",
+    "op": "clear",
+    "phone": "(440) 878-3737"
+  },
+  {
+    "homeId": "cmqqrkxjg003arlmbw6qywbk9",
+    "name": "Heather Knoll Retirement Village",
+    "op": "hold"
+  },
+  {
+    "homeId": "cmqqrkyi2003erlmbg1lq5e3x",
+    "name": "Legacy Place - Twinsburg",
+    "op": "hold"
+  },
+  {
+    "homeId": "cmqqrkze8003irlmbe65ithsz",
+    "name": "Maplewood at Twinsburg",
+    "op": "send",
+    "email": "twinsburged@maplewoodsl.com",
+    "phone": "330-840-7404",
+    "confidence": "HIGH",
+    "inPilot": true
+  },
+  {
+    "homeId": "cmqqrlbrc0050rlmbdpf37w19",
+    "name": "Brookdale Wickliffe",
+    "op": "send",
+    "email": "info@meadowfallsseniorliving.com",
+    "phone": "(440) 943-2050",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  },
+  {
+    "homeId": "cmqqrlc5m0052rlmbbocwczdc",
+    "name": "Brookdale Willoughby",
+    "op": "send",
+    "email": "info@mapleridgeseniorliving.com",
+    "phone": "(440) 269-8600",
+    "confidence": "MEDIUM",
+    "inPilot": false
+  }
+]

--- a/scripts/load-outreach-send-ready.ts
+++ b/scripts/load-outreach-send-ready.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env npx tsx
+/**
+ * scripts/load-outreach-send-ready.ts
+ *
+ * Applies the curated SEND_READY outreach backfill (Cowork research, 2026-06-25)
+ * to the directory listings, keyed by homeId. Source of record:
+ * scripts/data/outreach-send-ready.json (generated from
+ * CareLinkAI_directory_outreach_SEND_READY.csv).
+ *
+ * Per-row operation ("op"):
+ *   - send  → overwrite outreachEmail + outreachPhone with the research-verified
+ *             values (replaces any old/guessed value). preFilledFields.outreachEmail
+ *             stamped with the confidence (HIGH/MEDIUM) so the tiered sender can use it.
+ *   - clear → outreachEmail = null (these 5 HARD-BOUNCED in Resend: dead promedica.org
+ *             inboxes / guessed patterns). Keep phone → CALL-ONLY. Stamp 'BOUNCED-CLEARED'.
+ *             These take precedence over anything else.
+ *   - dup   → duplicate listing already archived INACTIVE (#617). Verify INACTIVE and
+ *             null outreachEmail so the claim engine can never invite the twin. 'DUP-SUPPRESSED'.
+ *   - hold  → null outreachEmail so a `--tier medium` sweep cannot invite it before the
+ *             founder confirms scope (SNF-vs-AL / possible-dup). Phone untouched. 'HOLD-REVIEW'.
+ *
+ * CALL-ONLY rows (no email) are NOT in the JSON — their phones were already loaded
+ * (#616) and are left untouched.
+ *
+ * The 46 "scale wave" SEND rows (SEND minus the 13-home pilot) get their CONTACTS
+ * loaded here, but NOTHING is sent — sending is a separate step (send-claim-nudges.ts),
+ * held until the founder gives the go.
+ *
+ * SAFETY: scoped to the directory-seed operator's homes only; dry-run by default;
+ * idempotent; --force to write.
+ *
+ * Usage:
+ *   npx tsx scripts/load-outreach-send-ready.ts            # DRY RUN
+ *   npx tsx scripts/load-outreach-send-ready.ts --force    # apply
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const prisma = new PrismaClient();
+
+const SEED_USER_EMAIL = 'directory-unclaimed@carelinkai.system';
+const DATA_FILE = join(__dirname, 'data', 'outreach-send-ready.json');
+
+type Rec = {
+  homeId: string;
+  name: string;
+  op: 'send' | 'clear' | 'dup' | 'hold';
+  email?: string;
+  phone?: string | null;
+  confidence?: string;
+  inPilot?: boolean;
+};
+
+async function main() {
+  const isForce = process.argv.includes('--force');
+  const dryRun = !isForce;
+  const recs: Rec[] = JSON.parse(readFileSync(DATA_FILE, 'utf8'));
+
+  console.log(dryRun ? '=== DRY RUN — no writes ===' : '=== LIVE — applying SEND_READY backfill ===');
+  console.log(`Source: ${DATA_FILE}\nRows: ${recs.length}\n`);
+
+  const seedUser = await prisma.user.findUnique({ where: { email: SEED_USER_EMAIL } });
+  const seedOperator = seedUser ? await prisma.operator.findUnique({ where: { userId: seedUser.id } }) : null;
+  if (!seedOperator) {
+    console.error('Directory seed operator not found — aborting.');
+    process.exit(1);
+  }
+
+  const counts = { send: 0, clear: 0, dup: 0, hold: 0, skipped: 0 };
+  let scaleWaveLoaded = 0;
+  let pilotRefreshed = 0;
+
+  for (const op of ['send', 'clear', 'dup', 'hold'] as const) {
+    const group = recs.filter((r) => r.op === op);
+    if (!group.length) continue;
+    console.log(`── ${op.toUpperCase()} (${group.length}) ──`);
+
+    for (const r of group) {
+      const home = await prisma.assistedLivingHome.findUnique({
+        where: { id: r.homeId },
+        select: { id: true, name: true, status: true, operatorId: true, outreachEmail: true, outreachPhone: true, preFilledFields: true },
+      });
+      if (!home) { console.log(`  ⚠ SKIP ${r.name} (${r.homeId}) — not found`); counts.skipped++; continue; }
+      if (home.operatorId !== seedOperator.id) {
+        console.log(`  ⚠ SKIP ${home.name} — not a directory-seed home (claimed/owner drift)`); counts.skipped++; continue;
+      }
+
+      const prov = (home.preFilledFields as Record<string, string> | null) ?? {};
+      let nextEmail = home.outreachEmail;
+      let nextPhone = home.outreachPhone;
+
+      if (op === 'send') {
+        nextEmail = r.email!;
+        if (r.phone) nextPhone = r.phone;
+        prov.outreachEmail = r.confidence ?? 'MEDIUM';
+        if (r.phone) prov.outreachPhone = 'RESEARCHED';
+        console.log(`  ✉ ${home.name} ← ${r.email} [${r.confidence}]${r.inPilot ? '  (pilot)' : '  (scale-wave)'}`);
+        if (r.inPilot) pilotRefreshed++; else scaleWaveLoaded++;
+      } else if (op === 'clear') {
+        nextEmail = null;
+        if (r.phone) nextPhone = r.phone;
+        prov.outreachEmail = 'BOUNCED-CLEARED';
+        console.log(`  🚫 ${home.name} — email cleared (hard-bounced); CALL-ONLY ${nextPhone ?? ''}`);
+      } else if (op === 'dup') {
+        nextEmail = null;
+        prov.outreachEmail = 'DUP-SUPPRESSED';
+        const flag = home.status === 'INACTIVE' ? 'INACTIVE ✓' : `⚠ status=${home.status} (expected INACTIVE)`;
+        console.log(`  ♊ ${home.name} — email cleared; ${flag}`);
+      } else { // hold
+        nextEmail = null;
+        prov.outreachEmail = 'HOLD-REVIEW';
+        console.log(`  ⏸ ${home.name} — email cleared (held for review)`);
+      }
+      counts[op]++;
+
+      if (!dryRun) {
+        await prisma.assistedLivingHome.update({
+          where: { id: home.id },
+          data: { outreachEmail: nextEmail, outreachPhone: nextPhone, preFilledFields: prov },
+        });
+      }
+    }
+    console.log('');
+  }
+
+  console.log('─────────────────────────────────────────────');
+  console.log(`SEND (email+phone set):   ${counts.send}   → ${pilotRefreshed} pilot, ${scaleWaveLoaded} scale-wave`);
+  console.log(`CLEAR (bounced→CALL-ONLY):${counts.clear}`);
+  console.log(`DUP (suppressed):         ${counts.dup}`);
+  console.log(`HOLD (suppressed):        ${counts.hold}`);
+  if (counts.skipped) console.log(`Skipped:                  ${counts.skipped}`);
+  console.log('─────────────────────────────────────────────');
+  console.log(`\nScale wave = ${scaleWaveLoaded} contacts LOADED but NOT sent. Sending is held for your go`);
+  console.log(`(run send-claim-nudges.ts --tier medium --force only when you say so).`);
+  if (dryRun) console.log('\nDRY RUN complete. Re-run with --force to write.');
+}
+
+main()
+  .catch((e) => { console.error('FATAL:', e); process.exit(1); })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Apply SEND_READY outreach backfill (send / clear / dup / hold)

Applies the curated `CareLinkAI_directory_outreach_SEND_READY.csv` (Cowork research), keyed by `homeId`, via `send_action`. Source of record: `scripts/data/outreach-send-ready.json`.

### Operations (counts match the spec)
| op | n | what |
|---|---|---|
| **SEND** | 59 | overwrite `outreachEmail` + `outreachPhone` with research-verified values (**13 pilot** already sent + **46 scale wave**) |
| **CLEAR** | 5 | null `outreachEmail` on the hard-bounced addresses → CALL-ONLY (Arden Courts Parma/Bath, Vitalia Strongsville, Village of the Falls, Symphony at Mentor); keep phone; **takes precedence** |
| **DUP** | 4 | the twins already archived INACTIVE in #617 — null their email so the claim engine can't invite both (Briarcliff Manor, Harbor Court, Solon Pointe, Cuyahoga Falls Danbury Woods) |
| **HOLD** | 10 | null `outreachEmail` (7 possible-SNF + 3 possible-dup) so a `--tier medium` sweep can't invite them before you confirm scope; reversible |

82 CALL-ONLY rows (no email) are untouched — their phones were loaded in #616.

### Important
- **Scale wave (46) is LOADED but NOT sent.** The loader only writes contact data; sending stays held until you run `send-claim-nudges.ts`. The 13-pilot rows are already throttled (won't re-send).
- **HOLD/DUP emails are nulled** specifically so the medium-tier sweep can't reach them — the only way to enforce "do not invite" given the sweep-style sender. Fully reversible (reload from CSV after you confirm scope).
- Provenance stamped in `preFilledFields.outreachEmail`: confidence (`HIGH`/`MEDIUM`) / `BOUNCED-CLEARED` / `DUP-SUPPRESSED` / `HOLD-REVIEW`.
- Scoped to the directory-seed operator; dry-run by default; idempotent.

### Resend suppression (your side)
I can't read/modify Resend's suppression list from this env. Resend auto-suppresses hard bounces, and nulling these emails means our sender never attempts them — but confirm the 7 bounced addresses in your Resend dashboard's Suppressions for belt-and-suspenders.

### Run after merge (Render)
```
npx tsx scripts/load-outreach-send-ready.ts            # dry-run — review send/clear/dup/hold
npx tsx scripts/load-outreach-send-ready.ts --force
```

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_