### PR TITLE
feat(outreach): harden claim-nudge sender — collapse by email + CAN-SPAM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,3 +160,7 @@ CRON_SECRET="..."
 # ------------------------------------------------------------
 # NEXT_PUBLIC_VAPID_PUBLIC_KEY="..."
 # VAPID_PRIVATE_KEY="..."
+
+# CAN-SPAM: real physical mailing address shown in cold-outreach (claim-nudge) email footers.
+# REQUIRED before scripts/send-claim-nudges.ts will --force. e.g. "1234 Main St, Cleveland, OH 44114"
+COMPANY_POSTAL_ADDRESS=""

--- a/prisma/migrations/20260626000001_email_suppression/migration.sql
+++ b/prisma/migrations/20260626000001_email_suppression/migration.sql
@@ -1,0 +1,13 @@
+-- OL-092: CAN-SPAM suppression list for cold-outreach (claim-nudge) email.
+-- Persists unsubscribes (and optionally bounces); the batch sender skips any
+-- suppressed address on every future run. Additive + idempotent.
+CREATE TABLE IF NOT EXISTS "EmailSuppression" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "reason" TEXT,
+    "source" TEXT,
+    "suppressedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "EmailSuppression_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "EmailSuppression_email_key" ON "EmailSuppression"("email");
+CREATE INDEX IF NOT EXISTS "EmailSuppression_email_idx" ON "EmailSuppression"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3117,3 +3117,16 @@ enum AccessTier {
   FULL
   READ_ONLY
 }
+
+/// CAN-SPAM suppression list for cold-outreach (claim-nudge) email. An address here is
+/// permanently skipped by the batch sender (scripts/send-claim-nudges.ts). Populated by
+/// the one-click unsubscribe route (/api/outreach/unsubscribe) and, optionally, bounces.
+model EmailSuppression {
+  id           String   @id @default(cuid())
+  email        String   @unique // always lowercased
+  reason       String? // 'unsubscribe' | 'bounce' | 'manual'
+  source       String? // e.g. 'claim-nudge'
+  suppressedAt DateTime @default(now())
+
+  @@index([email])
+}

--- a/scripts/send-claim-nudges.ts
+++ b/scripts/send-claim-nudges.ts
@@ -2,42 +2,37 @@
 /**
  * scripts/send-claim-nudges.ts
  *
- * PROACTIVE batch claim-nudge sender. The existing nudge engine
- * (src/lib/claim-engine/inquiry-claim-notification.ts) only fires reactively when a
- * family inquiry lands on an unclaimed listing. This script lets us deliberately
- * invite operators to claim their free directory listing, in controlled batches.
+ * PROACTIVE batch claim-nudge sender, COLLAPSED BY UNIQUE EMAIL. The reactive engine
+ * (src/lib/claim-engine/inquiry-claim-notification.ts) only fires on a real family
+ * inquiry; this deliberately invites operators to claim their free directory listing(s).
  *
- * It reuses the same primitives as the reactive engine — signed 45-day claim token
- * (src/lib/claim-token.ts) + the 24h `claimNudgeLastSentAt` throttle — but sends the
- * HONEST proactive copy (sendDirectoryClaimInviteEmail), NOT the "families are trying
- * to reach you" inquiry copy (which would be false with zero inquiries).
+ * KEY BEHAVIORS:
+ *   - Collapse by lower(outreachEmail): exactly ONE email per unique address, never one
+ *     per home. When an address maps to several unclaimed communities (e.g.
+ *     marketing@csig.com → many StoryPoint homes), the single email lists each community
+ *     with its OWN claim link, so the recipient claims them all from one message.
+ *   - Targets ACTIVE listings owned by the directory sentinel (truly unclaimed + public).
+ *     INACTIVE/archived homes are excluded entirely.
+ *   - Suppression: skips any address on the EmailSuppression list (unsubscribes/bounces).
+ *   - Throttle: 24h PER ADDRESS (an address is throttled if ANY of its homes was nudged
+ *     in the last 24h). On send, claimNudgeLastSentAt is stamped on every home in the group.
+ *   - CAN-SPAM: each email carries a one-click unsubscribe link (+ List-Unsubscribe header)
+ *     and the company physical address. The script REFUSES to send if COMPANY_POSTAL_ADDRESS
+ *     is unset/placeholder.
  *
- * PILOT-FIRST: defaults to the HIGH-confidence tier (named decision-makers, best
- * deliverability) so we can measure opens/claims before scaling. The loader
- * (load-directory-outreach-contacts.ts) stamped preFilledFields.outreachEmail with the
- * Cowork confidence ('HIGH'/'MEDIUM'), which is how we tier here.
- *
- * Targets: ACTIVE listings still owned by the directory sentinel operator (i.e. truly
- * unclaimed + public), with an outreachEmail set, not nudged within the throttle window.
- *
- * SAFETY:
- *   - DRY-RUN BY DEFAULT. Prints exactly who would be emailed + the claim URL. No send,
- *     no DB write. Sending requires --force.
- *   - Tiered: --tier high (default) | medium | all. `all` REQUIRES an explicit --limit
- *     so a full blast is never one keystroke away.
- *   - 24h throttle respected (won't re-nudge a recently-nudged home).
- *   - --limit N caps the batch. Email-only (no SMS) for the pilot.
+ * Tiers (by preFilledFields.outreachEmail confidence): high (default) | medium | all.
+ * DRY-RUN BY DEFAULT — prints the collapsed unique-send list (address → [homes]) and a
+ * sample rendered email; --force to actually send. `--tier all` requires an explicit --limit.
  *
  * Usage:
- *   npx tsx scripts/send-claim-nudges.ts                       # DRY RUN, high tier
- *   npx tsx scripts/send-claim-nudges.ts --limit 5             # DRY RUN, first 5 high
- *   npx tsx scripts/send-claim-nudges.ts --force               # SEND high tier
- *   npx tsx scripts/send-claim-nudges.ts --tier medium --force # SEND high+medium
- *   npx tsx scripts/send-claim-nudges.ts --tier all --limit 20 --force
+ *   npx tsx scripts/send-claim-nudges.ts                        # DRY RUN, high tier
+ *   npx tsx scripts/send-claim-nudges.ts --tier medium          # DRY RUN, high+medium
+ *   npx tsx scripts/send-claim-nudges.ts --tier medium --force  # SEND
  */
 
 import { PrismaClient } from '@prisma/client';
 import { signClaimToken, DEFAULT_CLAIM_TOKEN_TTL_HOURS } from '../src/lib/claim-token';
+import { signUnsubscribeToken } from '../src/lib/unsubscribe-token';
 import { sendDirectoryClaimInviteEmail } from '../src/lib/email';
 
 const prisma = new PrismaClient();
@@ -50,15 +45,31 @@ function argValue(flag: string): string | undefined {
   return i >= 0 ? process.argv[i + 1] : undefined;
 }
 
-function buildClaimUrl(homeId: string, operatorEmail: string, secret: string): string {
+function appUrl(): string {
+  return (process.env['NEXT_PUBLIC_APP_URL'] || process.env['NEXTAUTH_URL'] || 'https://getcarelinkai.com').replace(/\/$/, '');
+}
+
+function claimUrl(homeId: string, operatorEmail: string, secret: string): string {
   const now = Math.floor(Date.now() / 1000);
   const token = signClaimToken(
     { operatorEmail: operatorEmail.toLowerCase(), homeId, clevelandFounder: true, iat: now, exp: now + DEFAULT_CLAIM_TOKEN_TTL_HOURS * 3600 },
     secret,
   );
-  const appUrl = process.env['NEXT_PUBLIC_APP_URL'] || process.env['NEXTAUTH_URL'] || 'https://getcarelinkai.com';
-  return `${appUrl.replace(/\/$/, '')}/auth/register?role=OPERATOR&claimToken=${encodeURIComponent(token)}`;
+  return `${appUrl()}/auth/register?role=OPERATOR&claimToken=${encodeURIComponent(token)}`;
 }
+
+function unsubscribeUrl(email: string, secret: string): string {
+  return `${appUrl()}/api/outreach/unsubscribe?token=${encodeURIComponent(signUnsubscribeToken(email, secret))}`;
+}
+
+/** A real postal address must be configured for CAN-SPAM. Reject obvious placeholders. */
+function postalAddressOrNull(): string | null {
+  const v = (process.env['COMPANY_POSTAL_ADDRESS'] || '').trim();
+  if (!v || /your address|placeholder|street address|123 /i.test(v)) return null;
+  return v;
+}
+
+type HomeRow = { id: string; name: string; outreachEmail: string; claimNudgeLastSentAt: Date | null; preFilledFields: unknown };
 
 async function main() {
   const isForce = process.argv.includes('--force');
@@ -67,94 +78,117 @@ async function main() {
   const limitRaw = argValue('--limit');
   const limit = limitRaw ? parseInt(limitRaw, 10) : undefined;
 
-  if (!['high', 'medium', 'all'].includes(tier)) {
-    console.error(`Invalid --tier "${tier}" (use: high | medium | all)`);
-    process.exit(1);
-  }
-  if (tier === 'all' && !limit) {
-    console.error('Refusing "--tier all" without an explicit --limit (guards against a full blast). Add e.g. --limit 20.');
-    process.exit(1);
-  }
-
-  console.log(dryRun ? '=== DRY RUN — no emails sent ===' : '=== LIVE — sending claim invites ===');
-  console.log(`Tier: ${tier}${limit ? `  ·  limit: ${limit}` : ''}\n`);
-
-  const seedUser = await prisma.user.findUnique({ where: { email: DIRECTORY_UNCLAIMED_EMAIL } });
-  const seedOperator = seedUser
-    ? await prisma.operator.findUnique({ where: { userId: seedUser.id } })
-    : null;
-  if (!seedOperator) {
-    console.error('Directory seed operator not found — aborting.');
-    process.exit(1);
-  }
+  if (!['high', 'medium', 'all'].includes(tier)) { console.error(`Invalid --tier "${tier}"`); process.exit(1); }
+  if (tier === 'all' && !limit) { console.error('Refusing "--tier all" without --limit.'); process.exit(1); }
 
   const secret = process.env['NEXTAUTH_SECRET'] || '';
-  if (!secret) {
-    console.error('NEXTAUTH_SECRET not set — cannot mint claim links. Aborting.');
+  if (!secret) { console.error('NEXTAUTH_SECRET not set — aborting.'); process.exit(1); }
+
+  const postalAddress = postalAddressOrNull();
+  if (!dryRun && !postalAddress) {
+    console.error('\n⛔ COMPANY_POSTAL_ADDRESS is not set (or is a placeholder).');
+    console.error('   CAN-SPAM requires a real physical mailing address in every cold email.');
+    console.error('   Set COMPANY_POSTAL_ADDRESS in Render env, then re-run with --force.\n');
     process.exit(1);
   }
+  const addrForRender = postalAddress ?? '«SET COMPANY_POSTAL_ADDRESS BEFORE --force»';
 
-  const throttleCutoff = new Date(Date.now() - THROTTLE_HOURS * 3600 * 1000);
+  console.log(dryRun ? '=== DRY RUN — no emails sent ===' : '=== LIVE — sending claim invites ===');
+  console.log(`Tier: ${tier}${limit ? `  ·  limit (unique sends): ${limit}` : ''}\n`);
 
-  const homes = await prisma.assistedLivingHome.findMany({
-    where: {
-      operatorId: seedOperator.id,
-      status: 'ACTIVE',
-      outreachEmail: { not: null },
-      OR: [{ claimNudgeLastSentAt: null }, { claimNudgeLastSentAt: { lt: throttleCutoff } }],
-    },
+  const seedUser = await prisma.user.findUnique({ where: { email: DIRECTORY_UNCLAIMED_EMAIL } });
+  const seedOperator = seedUser ? await prisma.operator.findUnique({ where: { userId: seedUser.id } }) : null;
+  if (!seedOperator) { console.error('Directory seed operator not found — aborting.'); process.exit(1); }
+
+  // Suppression set (unsubscribes / bounces) — lowercased.
+  const suppressed = new Set((await prisma.emailSuppression.findMany({ select: { email: true } })).map((s) => s.email.toLowerCase()));
+
+  const homes = (await prisma.assistedLivingHome.findMany({
+    where: { operatorId: seedOperator.id, status: 'ACTIVE', outreachEmail: { not: null } },
     select: { id: true, name: true, outreachEmail: true, claimNudgeLastSentAt: true, preFilledFields: true },
     orderBy: { name: 'asc' },
-  });
+  })) as HomeRow[];
 
-  const tierAllows = (conf: string | undefined): boolean => {
-    if (tier === 'all') return true;
-    if (tier === 'medium') return conf === 'HIGH' || conf === 'MEDIUM';
-    return conf === 'HIGH';
-  };
+  const tierAllows = (conf: string | undefined): boolean =>
+    tier === 'all' ? true : tier === 'medium' ? conf === 'HIGH' || conf === 'MEDIUM' : conf === 'HIGH';
 
-  let eligible = homes.filter((h) => {
-    const conf = (h.preFilledFields as Record<string, string> | null)?.outreachEmail;
-    return tierAllows(conf);
-  });
-  const totalEligible = eligible.length;
-  if (limit) eligible = eligible.slice(0, limit);
+  const eligibleHomes = homes.filter((h) => tierAllows((h.preFilledFields as Record<string, string> | null)?.outreachEmail));
 
-  let sent = 0;
-  let failed = 0;
+  // Collapse by lower(email).
+  const groups = new Map<string, HomeRow[]>();
+  for (const h of eligibleHomes) {
+    const key = h.outreachEmail.trim().toLowerCase();
+    (groups.get(key) ?? groups.set(key, []).get(key)!).push(h);
+  }
 
-  for (const h of eligible) {
-    const email = h.outreachEmail!.trim();
-    const conf = (h.preFilledFields as Record<string, string> | null)?.outreachEmail ?? '?';
-    const claimUrl = buildClaimUrl(h.id, email, secret);
+  const cutoff = Date.now() - THROTTLE_HOURS * 3600 * 1000;
+  let suppressedCount = 0, throttledCount = 0;
+  const sendable: { email: string; homes: HomeRow[] }[] = [];
+  for (const [email, grp] of groups) {
+    if (suppressed.has(email)) { suppressedCount++; continue; }
+    const lastSent = grp.reduce<number>((mx, h) => Math.max(mx, h.claimNudgeLastSentAt ? h.claimNudgeLastSentAt.getTime() : 0), 0);
+    if (lastSent > cutoff) { throttledCount++; continue; }
+    sendable.push({ email, homes: grp });
+  }
+  sendable.sort((a, b) => a.email.localeCompare(b.email));
+  const batch = limit ? sendable.slice(0, limit) : sendable;
 
-    if (dryRun) {
-      console.log(`  ✉ WOULD SEND → ${email} [${conf}]  "${h.name}"`);
-      continue;
-    }
+  console.log(`Collapse: ${eligibleHomes.length} homes → ${groups.size} unique addresses ` +
+    `(${suppressedCount} suppressed, ${throttledCount} throttled) → ${sendable.length} sendable${limit ? `, ${batch.length} this batch` : ''}\n`);
 
-    const ok = await sendDirectoryClaimInviteEmail({ facilityName: h.name, toEmail: email, claimUrl });
+  console.log('── Unique sends (address → communities) ──');
+  for (const g of batch) {
+    console.log(`  ✉ ${g.email}  (${g.homes.length} ${g.homes.length > 1 ? 'communities' : 'community'})`);
+    for (const h of g.homes) console.log(`       • ${h.name}`);
+  }
+
+  // Sample rendered email (first multi-home group if any, else first group).
+  const sample = batch.find((g) => g.homes.length > 1) ?? batch[0];
+  if (sample) {
+    const comms = sample.homes.map((h) => ({ name: h.name, claimUrl: claimUrl(h.id, sample.email, secret) }));
+    const unsub = unsubscribeUrl(sample.email, secret);
+    console.log('\n── Sample rendered email (text) ──');
+    console.log(`To: ${sample.email}`);
+    console.log(`Subject: ${comms.length > 1 ? `Claim your ${comms.length} free CareLinkAI listings` : `Claim your free CareLinkAI listing for ${comms[0].name}`}`);
+    console.log('List-Unsubscribe: <' + unsub + '>, <mailto:noreply@getcarelinkai.com?subject=unsubscribe>');
+    console.log('---');
+    console.log(`${comms.length > 1 ? 'Your communities are' : `${comms[0].name} is`} listed on CareLinkAI…\n`);
+    for (const c of comms) console.log(`• ${c.name}: ${c.claimUrl}`);
+    console.log(`\n---\nCareLinkAI · ${addrForRender}\nUnsubscribe: ${unsub}`);
+  }
+
+  if (dryRun) {
+    console.log('\n─────────────────────────────────────────────');
+    console.log(`Would send: ${batch.length} emails to ${batch.length} unique addresses (${batch.reduce((n, g) => n + g.homes.length, 0)} homes)`);
+    console.log('─────────────────────────────────────────────');
+    console.log('\nDRY RUN complete. Re-run with --force to send.');
+    if (!postalAddress) console.log('⚠ Set COMPANY_POSTAL_ADDRESS (real mailing address) before --force — required for CAN-SPAM.');
+    return;
+  }
+
+  let sent = 0, failed = 0, homesSent = 0;
+  for (const g of batch) {
+    const comms = g.homes.map((h) => ({ name: h.name, claimUrl: claimUrl(h.id, g.email, secret) }));
+    const ok = await sendDirectoryClaimInviteEmail({
+      toEmail: g.email,
+      communities: comms,
+      unsubscribeUrl: unsubscribeUrl(g.email, secret),
+      postalAddress: postalAddress!,
+    });
     if (ok) {
-      await prisma.assistedLivingHome.update({ where: { id: h.id }, data: { claimNudgeLastSentAt: new Date() } });
-      console.log(`  ✅ SENT → ${email} [${conf}]  "${h.name}"`);
-      sent++;
+      await prisma.assistedLivingHome.updateMany({ where: { id: { in: g.homes.map((h) => h.id) } }, data: { claimNudgeLastSentAt: new Date() } });
+      console.log(`  ✅ SENT → ${g.email} (${g.homes.length} home${g.homes.length > 1 ? 's' : ''})`);
+      sent++; homesSent += g.homes.length;
     } else {
-      console.log(`  ❌ FAILED → ${email}  "${h.name}" (left un-throttled to retry)`);
+      console.log(`  ❌ FAILED → ${g.email} (left un-throttled to retry)`);
       failed++;
     }
   }
-
   console.log('\n─────────────────────────────────────────────');
-  console.log(`Eligible (tier=${tier}, not throttled): ${totalEligible}`);
-  console.log(`${dryRun ? 'Would send' : 'Sent'}: ${dryRun ? eligible.length : sent}`);
-  if (!dryRun && failed) console.log(`Failed:    ${failed}`);
+  console.log(`Sent: ${sent} emails  ·  ${homesSent} homes  ·  ${failed} failed`);
   console.log('─────────────────────────────────────────────');
-  if (dryRun) console.log('\nDRY RUN complete. Re-run with --force to actually send.');
 }
 
 main()
-  .catch((e) => {
-    console.error('FATAL:', e);
-    process.exit(1);
-  })
+  .catch((e) => { console.error('FATAL:', e); process.exit(1); })
   .finally(() => prisma.$disconnect());

--- a/src/app/api/outreach/unsubscribe/route.ts
+++ b/src/app/api/outreach/unsubscribe/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { verifyUnsubscribeToken } from '@/lib/unsubscribe-token';
+
+/**
+ * One-click unsubscribe for cold-outreach (claim-nudge) email — CAN-SPAM / RFC 8058.
+ *
+ * - GET  (clicked link in the email body): suppresses + renders a confirmation page.
+ * - POST (List-Unsubscribe-Post one-click from Gmail/Apple Mail): suppresses + 200.
+ *
+ * Suppressing is idempotent (upsert) and immediate (well under the 10-business-day
+ * rule). The batch sender (scripts/send-claim-nudges.ts) skips any suppressed address
+ * on every future run. No auth — the signed token IS the authorization.
+ */
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+async function suppress(token: string | null): Promise<string | null> {
+  if (!token) return null;
+  const secret = process.env['NEXTAUTH_SECRET'] || '';
+  if (!secret) return null;
+  const payload = verifyUnsubscribeToken(token, secret);
+  if (!payload) return null;
+  const email = payload.email.toLowerCase();
+  await prisma.emailSuppression.upsert({
+    where: { email },
+    update: { reason: 'unsubscribe' },
+    create: { email, reason: 'unsubscribe', source: 'claim-nudge' },
+  });
+  return email;
+}
+
+function page(title: string, body: string, status: number): NextResponse {
+  const html = `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><title>${title}</title></head>
+<body style="font-family:Arial,sans-serif;color:#1f2937;max-width:520px;margin:64px auto;padding:0 20px;text-align:center;line-height:1.6">
+  <h2 style="color:#0d9488">${title}</h2>
+  <p>${body}</p>
+  <p style="color:#9ca3af;font-size:13px">CareLinkAI · Cleveland, OH</p>
+</body></html>`;
+  return new NextResponse(html, { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
+export async function GET(req: NextRequest) {
+  const email = await suppress(new URL(req.url).searchParams.get('token'));
+  if (email) {
+    return page('You’re unsubscribed', `We won’t email <strong>${email}</strong> about CareLinkAI directory listings again.`, 200);
+  }
+  return page('Link invalid', 'This unsubscribe link is invalid. Reply to the email and we’ll remove you manually.', 400);
+}
+
+export async function POST(req: NextRequest) {
+  const email = await suppress(new URL(req.url).searchParams.get('token'));
+  return NextResponse.json({ ok: Boolean(email) }, { status: email ? 200 : 400 });
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -250,44 +250,72 @@ export async function sendInquiryClaimNudgeEmail(args: {
  * PROACTIVE directory claim invite (distinct from sendInquiryClaimNudgeEmail).
  *
  * Used by the batch claim-nudge sender to invite an operator to claim their free
- * directory listing — BEFORE any family inquiry exists. The copy is therefore
- * honest about the context: it does NOT claim "families are trying to reach you"
- * (that wording belongs only to the inquiry-triggered nudge). It states plainly
- * that the facility is listed and can be claimed for free.
+ * directory listing(s) — BEFORE any family inquiry exists. Copy is honest about the
+ * context (it does NOT say "families are trying to reach you").
  *
- * Includes a clear opt-out line (reply to be removed) and the sender identity for
- * basic CAN-SPAM hygiene. Fire-and-forget: returns false on any failure.
+ * COLLAPSED BY ADDRESS: one email per unique recipient. When the recipient operates
+ * multiple unclaimed communities (e.g. a corporate marketing inbox), every community is
+ * listed with its OWN claim link, so the recipient can claim all of them from one email.
+ *
+ * CAN-SPAM: includes a working one-click unsubscribe link, the company physical mailing
+ * address (caller-supplied — the batch sender refuses to run if it's unset), and clear
+ * sender identity. Sets the List-Unsubscribe + List-Unsubscribe-Post (RFC 8058) headers
+ * so Gmail/Apple Mail render a native one-click unsubscribe. Returns false on any failure.
  */
 export async function sendDirectoryClaimInviteEmail(args: {
-  facilityName: string;
   toEmail: string;
-  claimUrl: string;
+  communities: { name: string; claimUrl: string }[];
+  unsubscribeUrl: string;
+  postalAddress: string;
 }): Promise<boolean> {
-  const facilityName = args.facilityName?.trim() || 'your community';
+  const communities = (args.communities ?? []).filter((c) => c?.name && c?.claimUrl);
+  if (communities.length === 0) return false;
+  const multi = communities.length > 1;
   try {
     if (!process.env.RESEND_API_KEY) {
       console.error('[Resend] RESEND_API_KEY not configured — skipping directory claim invite');
       return false;
     }
-    const safeFacility = escapeHtml(facilityName);
-    const subject = `Claim your free ${APP_NAME} listing for ${facilityName}`;
+    const subject = multi
+      ? `Claim your ${communities.length} free ${APP_NAME} listings`
+      : `Claim your free ${APP_NAME} listing for ${communities[0].name}`;
+
+    const intro =
+      `${multi ? 'Your communities are' : `${communities[0].name} is`} listed on CareLinkAI, the ` +
+      `senior-care discovery platform helping Greater Cleveland families find assisted living and memory care.`;
+    const ask = multi
+      ? `Claim each free listing (about 2 minutes each) to manage the profile, add photos and details, and respond to family inquiries:`
+      : `Claim your free listing in about 2 minutes to manage your profile, add photos and details, and respond to family inquiries:`;
+
+    // ----- plain text -----
+    const textLines = communities.map((c) => `• ${c.name}: ${c.claimUrl}`).join('\n');
     const text =
-      `${facilityName} is listed on CareLinkAI, the senior-care discovery platform helping ` +
-      `Greater Cleveland families find assisted living and memory care.\n\n` +
-      `Claim your free listing in about 2 minutes to manage your profile, add photos and ` +
-      `details, and respond to family inquiries:\n${args.claimUrl}\n\n` +
-      `There is no cost to claim or to keep your listing. If you're not the right person at ` +
-      `${facilityName}, please forward this to whoever manages marketing or admissions.\n\n` +
-      `If you'd prefer not to receive these, just reply "remove" and we'll take you off the list.\n` +
-      `— The CareLinkAI team, Cleveland, OH`;
+      `${intro}\n\n${ask}\n\n${textLines}\n\n` +
+      `There is no cost to claim or to keep a listing. If you're not the right person, please ` +
+      `forward this to whoever manages marketing or admissions.\n\n` +
+      `---\n` +
+      `${APP_NAME} · ${args.postalAddress}\n` +
+      `Unsubscribe (you won't be emailed about these listings again): ${args.unsubscribeUrl}`;
+
+    // ----- html -----
+    const ctas = communities
+      .map(
+        (c) =>
+          `<p style="margin:10px 0"><a href="${escapeHtml(c.claimUrl)}" style="display:inline-block;background:#0d9488;color:#fff;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:600">Claim ${escapeHtml(c.name)}</a></p>`,
+      )
+      .join('\n');
     const html = `
 <!DOCTYPE html>
 <html><body style="font-family:Arial,sans-serif;color:#1f2937;line-height:1.5">
-  <p><strong>${safeFacility}</strong> is listed on CareLinkAI, the senior-care discovery platform helping Greater Cleveland families find assisted living and memory care.</p>
-  <p>Claim your free listing in about 2 minutes to manage your profile, add photos and details, and respond to family inquiries:</p>
-  <p><a href="${escapeHtml(args.claimUrl)}" style="display:inline-block;background:#0d9488;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600">Claim ${safeFacility}</a></p>
-  <p style="color:#6b7280;font-size:13px">There is no cost to claim or to keep your listing. If you're not the right person at ${safeFacility}, please forward this to whoever manages marketing or admissions.</p>
-  <p style="color:#9ca3af;font-size:12px">If you'd prefer not to receive these, just reply &ldquo;remove&rdquo; and we'll take you off the list.<br/>— The CareLinkAI team, Cleveland, OH</p>
+  <p>${escapeHtml(intro)}</p>
+  <p>${escapeHtml(ask)}</p>
+  ${ctas}
+  <p style="color:#6b7280;font-size:13px">There is no cost to claim or to keep a listing. If you're not the right person, please forward this to whoever manages marketing or admissions.</p>
+  <hr style="border:none;border-top:1px solid #e5e7eb;margin:20px 0"/>
+  <p style="color:#9ca3af;font-size:12px">
+    ${APP_NAME} · ${escapeHtml(args.postalAddress)}<br/>
+    <a href="${escapeHtml(args.unsubscribeUrl)}" style="color:#9ca3af">Unsubscribe</a> — you won't be emailed about these listings again.
+  </p>
 </body></html>`;
 
     const { data, error } = await resend.emails.send({
@@ -296,13 +324,17 @@ export async function sendDirectoryClaimInviteEmail(args: {
       subject,
       text,
       html,
+      headers: {
+        'List-Unsubscribe': `<${args.unsubscribeUrl}>, <mailto:${FROM_EMAIL}?subject=unsubscribe>`,
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+      },
     });
 
     if (error) {
       console.error('[Resend] Error sending directory claim invite:', error);
       captureError(
         error instanceof Error ? error : new Error(String((error as { message?: string })?.message ?? error)),
-        { tags: { feature: 'directory-claim-invite' }, extra: { facilityName } }
+        { tags: { feature: 'directory-claim-invite' }, extra: { toEmail: args.toEmail, count: communities.length } }
       );
       return false;
     }
@@ -312,7 +344,7 @@ export async function sendDirectoryClaimInviteEmail(args: {
     console.error('[Resend] Exception sending directory claim invite:', error);
     captureError(error instanceof Error ? error : new Error(String(error)), {
       tags: { feature: 'directory-claim-invite' },
-      extra: { facilityName },
+      extra: { toEmail: args.toEmail },
     });
     return false;
   }

--- a/src/lib/unsubscribe-token.ts
+++ b/src/lib/unsubscribe-token.ts
@@ -1,0 +1,58 @@
+import crypto from 'crypto';
+
+/**
+ * Signed, unforgeable email-unsubscribe tokens for cold-outreach (claim-nudge) email.
+ * Mirrors src/lib/claim-token.ts (HMAC-SHA256 over a base64url payload, signed with
+ * NEXTAUTH_SECRET). Deliberately has NO expiry — an unsubscribe link must keep working
+ * indefinitely (CAN-SPAM / RFC 8058), and a token only ever ADDS a suppression, so a
+ * long-lived link carries no risk.
+ */
+
+export interface UnsubscribeTokenPayload {
+  email: string; // always lowercased
+  iat: number;
+  type: 'unsubscribe';
+}
+
+function toBase64url(input: string): string {
+  return Buffer.from(input).toString('base64url');
+}
+function fromBase64url(input: string): string {
+  return Buffer.from(input, 'base64url').toString('utf-8');
+}
+function hmac(data: string, secret: string): string {
+  return crypto.createHmac('sha256', secret).update(data).digest('base64url');
+}
+
+/** Sign an unsubscribe token for an email. Returns `<data>.<signature>`. */
+export function signUnsubscribeToken(email: string, secret: string): string {
+  const payload: UnsubscribeTokenPayload = {
+    email: email.toLowerCase(),
+    iat: Math.floor(Date.now() / 1000),
+    type: 'unsubscribe',
+  };
+  const data = toBase64url(JSON.stringify(payload));
+  return `${data}.${hmac(data, secret)}`;
+}
+
+/** Verify an unsubscribe token. Returns the payload, or null if invalid. */
+export function verifyUnsubscribeToken(token: string, secret: string): UnsubscribeTokenPayload | null {
+  const parts = token.split('.');
+  if (parts.length !== 2) return null;
+  const [data, sig] = parts;
+  const expectedSig = hmac(data, secret);
+  try {
+    if (!crypto.timingSafeEqual(Buffer.from(sig, 'base64url'), Buffer.from(expectedSig, 'base64url'))) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(fromBase64url(data)) as UnsubscribeTokenPayload;
+    if (payload.type !== 'unsubscribe' || !payload.email) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Harden the claim-nudge sender before any `--tier medium` run

Implements the two requested changes + the dry-run. Required before scaling to the 46 MEDIUM contacts.

### A) Collapse by unique email
`scripts/send-claim-nudges.ts` now builds the send list from ACTIVE unclaimed homes at the target tier, **groups by `lower(outreachEmail)`, and sends exactly ONE email per address** — never one-per-home. A shared inbox gets a single email that **lists each of its communities with its own claim link**, so the recipient claims them all from one message.

**Collapse preview (medium tier, from SEND_READY): 59 homes → 41 unique sends (18 redundant emails eliminated).** Largest folds:
- `marketing@csig.com` → 6 StoryPoint/Danbury communities
- `Dir.sales@oneillhc.com` → 5 O'Neill
- `info@meadowfallsseniorliving.com` → 4 · `communications@judsonsmartliving.org` → 3 · Heritage / LHS / Maplewood / Kemper → 2 each

- INACTIVE/archived homes excluded entirely.
- **24h throttle is now per-address** (an address is throttled if any of its homes was nudged in the last 24h; on send, `claimNudgeLastSentAt` is stamped on every home in the group).
- Logs `N homes → M unique sends`.

### B) CAN-SPAM compliance
- **`EmailSuppression` model** (+ additive migration `20260626000001_email_suppression`) — persisted opt-outs; the sender **skips any suppressed address on every run**.
- **One-click unsubscribe** route `GET/POST /api/outreach/unsubscribe` backed by signed HMAC tokens (`src/lib/unsubscribe-token.ts`); suppresses immediately (well under the 10-business-day rule).
- Email now sets **`List-Unsubscribe` + `List-Unsubscribe-Post` (RFC 8058)** headers so Gmail/Apple render a native one-click unsubscribe, plus a working in-body unsubscribe link, the **company physical mailing address**, and clear `CareLinkAI` sender identity (honest subject/from).

### ⚠️ Action required before you can send
There is **no real company postal address anywhere in the codebase** (the privacy page even has a stray "San Francisco, CA"). I did **not** fabricate one. Set **`COMPANY_POSTAL_ADDRESS`** (real mailing address, e.g. a registered PO box) in Render env — **the sender refuses to `--force` until it's set** (placeholder values rejected).

### Note — multi-listing claim backend
The email hands one operator several claim links (one per home). Confirm the claim flow lets a single account claim **multiple** homes in sequence (the `seededHomeId` check is per-home — see OL-087). If it currently allows only one claim per account, that's a small follow-up so multi-claim actually completes.

### Dry-run (sample email attached in chat)
```
npx tsx scripts/send-claim-nudges.ts --tier medium          # collapsed list + sample email, NO send
npx tsx scripts/send-claim-nudges.ts --tier medium --force  # only after COMPANY_POSTAL_ADDRESS is set
```

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_