### PR TITLE
feat(claim): multi-home claim from one collapsed email (/claim landing)

### DIFF
--- a/scripts/send-claim-nudges.ts
+++ b/scripts/send-claim-nudges.ts
@@ -55,7 +55,9 @@ function claimUrl(homeId: string, operatorEmail: string, secret: string): string
     { operatorEmail: operatorEmail.toLowerCase(), homeId, clevelandFounder: true, iat: now, exp: now + DEFAULT_CLAIM_TOKEN_TTL_HOURS * 3600 },
     secret,
   );
-  return `${appUrl()}/auth/register?role=OPERATOR&claimToken=${encodeURIComponent(token)}`;
+  // → /claim landing page: works for first-timers (redirects to register/redeem) AND for
+  //   already-signed-in operators (re-arm + claim), so one collapsed email can claim many homes.
+  return `${appUrl()}/claim?token=${encodeURIComponent(token)}`;
 }
 
 function unsubscribeUrl(email: string, secret: string): string {

--- a/src/app/claim/ClaimConfirm.tsx
+++ b/src/app/claim/ClaimConfirm.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+/**
+ * Confirm step for a token-authorized claim. Re-arms the operator's seededHomeId via the
+ * existing POST /api/operator/claim, then routes into the onboarding claim UI (step 2),
+ * which collects the image-rights acknowledgment and performs the ownership transfer.
+ * Explicit button (no claim-on-page-load side effect).
+ */
+export default function ClaimConfirm({ token, homeName }: { token: string; homeName: string }) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function start() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/operator/claim', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Could not start the claim. Please try again.');
+      router.push('/operator/onboarding/2');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong.');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="text-center">
+      <h1 className="text-2xl font-semibold text-slate-900">Claim {homeName}</h1>
+      <p className="mt-3 text-slate-600">
+        You’re claiming this CareLinkAI listing for your account. On the next screen you’ll review the
+        details and confirm — there’s no cost to claim or keep your listing.
+      </p>
+      {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
+      <button
+        onClick={start}
+        disabled={loading}
+        className="mt-6 inline-block rounded-lg bg-teal-600 px-6 py-3 font-semibold text-white hover:bg-teal-700 disabled:opacity-60"
+      >
+        {loading ? 'Starting…' : `Claim ${homeName}`}
+      </button>
+    </div>
+  );
+}

--- a/src/app/claim/page.tsx
+++ b/src/app/claim/page.tsx
@@ -1,0 +1,98 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { verifyClaimToken } from '@/lib/claim-token';
+import ClaimConfirm from './ClaimConfirm';
+
+/**
+ * Public claim landing — the target of the proactive claim-nudge email links
+ * (/claim?token=...). Lets ONE operator claim MULTIPLE seeded listings from a single
+ * collapsed email (each link carries its own home's signed token).
+ *
+ * Routing:
+ *   - invalid/expired token        → friendly notice
+ *   - not signed in                → fall through to the existing register/redeem flow
+ *                                    (/auth/register?claimToken=…) — unchanged for new operators
+ *   - signed in as a DIFFERENT user → notice (use the link from the addressed inbox)
+ *   - signed in as the addressed operator → confirm + re-arm seededHomeId via the existing
+ *                                    /api/operator/claim, then onboarding step 2 claims it
+ *                                    (with the image-rights ack). Safe: only offered when the
+ *                                    home is still owned by the directory sentinel (unclaimed).
+ */
+
+export const dynamic = 'force-dynamic';
+
+const DIRECTORY_UNCLAIMED_EMAIL = 'directory-unclaimed@carelinkai.system';
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="mx-auto flex min-h-[70vh] max-w-lg items-center px-6">
+      <div className="w-full rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">{children}</div>
+    </main>
+  );
+}
+
+function Notice({ title, body }: { title: string; body: string }) {
+  return (
+    <Shell>
+      <div className="text-center">
+        <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
+        <p className="mt-3 text-slate-600">{body}</p>
+      </div>
+    </Shell>
+  );
+}
+
+export default async function ClaimPage({ searchParams }: { searchParams: { token?: string } }) {
+  const token = searchParams?.token;
+  const secret = process.env['NEXTAUTH_SECRET'] || '';
+  const payload = token ? verifyClaimToken(token, secret) : null;
+
+  if (!token || !payload || !payload.homeId) {
+    return <Notice title="This link is invalid" body="The claim link is invalid or has expired. Please use the most recent email we sent, or reply to it and we’ll help." />;
+  }
+
+  const session = await getServerSession(authOptions);
+
+  // Not signed in → preserve the existing register/redeem path verbatim (new operators
+  // register + redeem here; returning operators get the register page's "already have an
+  // account?" prompt and can sign in, then re-open this link to claim).
+  if (!session?.user?.email) {
+    redirect(`/auth/register?role=OPERATOR&claimToken=${encodeURIComponent(token)}`);
+  }
+
+  if (session.user.email.toLowerCase() !== payload.operatorEmail.toLowerCase()) {
+    return (
+      <Notice
+        title="This link is for a different account"
+        body={`This claim link is addressed to ${payload.operatorEmail}, but you’re signed in as ${session.user.email}. Sign out and open the link again, or forward it to that inbox.`}
+      />
+    );
+  }
+
+  const home = await prisma.assistedLivingHome.findUnique({
+    where: { id: payload.homeId },
+    select: { id: true, name: true, operator: { select: { user: { select: { email: true } } } } },
+  });
+  if (!home) {
+    return <Notice title="Listing not found" body="We couldn’t find that listing — it may have been removed." />;
+  }
+
+  // Only claimable while still owned by the directory sentinel (unclaimed).
+  const ownerEmail = (home.operator?.user?.email || '').toLowerCase();
+  if (ownerEmail !== DIRECTORY_UNCLAIMED_EMAIL) {
+    return (
+      <Notice
+        title="Already claimed"
+        body={`${home.name} has already been claimed. If that was you, you’ll find it in your operator dashboard.`}
+      />
+    );
+  }
+
+  return (
+    <Shell>
+      <ClaimConfirm token={token} homeName={home.name} />
+    </Shell>
+  );
+}


### PR DESCRIPTION
## Multi-home claim from one collapsed email (OL-095)

Completes the "claim all their listings from one email" goal. Resolves the gap found while hardening the sender (#624): the single-use `seededHomeId` guard let an operator claim only the **first** of their N listings.

### Approach (lowest-risk — reuses existing mechanisms)
The re-arm endpoint (`POST /api/operator/claim`) and the onboarding claim UI (with the image-rights ack + ownership transfer) already exist and already support claiming home-after-home via `seededHomeId` re-arm. This PR just adds a smooth, token-authorized entry point so the email links drive that loop:

- **`/claim?token=…` (NEW public page)** — the new target of the claim-nudge links. Verifies the signed token, then:
  - invalid/expired → friendly notice
  - **not signed in** → falls through to today's `/auth/register?claimToken=…` flow (unchanged for first-timers)
  - signed in as a **different** user → notice (use the link from the addressed inbox)
  - signed in as the **addressed operator** → confirm → re-arm `seededHomeId` via the existing `/api/operator/claim` → onboarding step 2 claims it (ack + transfer). Only offered while the home is still **owned by the directory sentinel** (sentinel-owned safety check, so a leaked token can't grab a claimed home).
- **`ClaimConfirm.tsx` (NEW client)** — explicit "Claim {home}" button (no claim-on-load side effect).
- **`send-claim-nudges.ts`** — claim links now point at `/claim?token=…`.

### Why it's safe
- **No change to the transfer endpoint** (`/api/operator/homes/[id]/claim`) or its e2e — the existing claim path is untouched.
- Each link is authorized by its own HMAC token (`homeId` + `operatorEmail`); the page additionally requires the home to be unclaimed.

### Flow for a shared-inbox operator (e.g. `marketing@csig.com`, 6 homes)
Click link 1 → register/redeem → claim home 1. Click link 2 (now signed in) → `/claim` → confirm → claim home 2. …through all 6, each from the one email.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_