### PR TITLE
fix(sentry): stop app-wide Stripe.js load + filter known client noise

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,20 +6,11 @@ import React, {
   useState,
   useEffect,
   useReducer,
-  useMemo,
 } from "react";
 import { SessionProvider } from "next-auth/react";
-import { Elements } from "@stripe/react-stripe-js";
-import { loadStripe } from "@stripe/stripe-js";
-import type { StripeElementsOptions } from "@stripe/stripe-js";
 import { io, Socket } from "socket.io-client";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "react-hot-toast";
-
-// Initialize Stripe
-const publishableKey =
-  process.env["NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY"];
-const stripePromise = publishableKey ? loadStripe(publishableKey) : null;
 
 // Socket.io Context
 type SocketContextType = {
@@ -352,20 +343,6 @@ function AppProvider({ children }: { children: React.ReactNode }) {
 
 // Main Providers component that wraps the app
 export function Providers({ children }: { children: React.ReactNode }) {
-  // Stripe payment options with HIPAA compliance considerations
-  const stripeOptions = useMemo<StripeElementsOptions>(
-    () => ({
-      locale: "en",
-      // HIPAA compliance: Ensure proper data handling
-      appearance: {
-        theme: "stripe",
-        variables: {
-          colorPrimary: "#0099e6",
-        },
-      },
-    }),
-    []
-  );
 
   const e2eEnvBypass = process.env['NODE_ENV'] !== 'production' && process.env['NEXT_PUBLIC_E2E_AUTH_BYPASS'] === '1';
   const e2eCookieBypass = typeof window !== 'undefined' && document.cookie.includes('e2e-bypass=1');
@@ -398,15 +375,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
         <UserProvider>
           <AppProvider>
-            <SocketProvider>
-              {stripePromise ? (
-                <Elements stripe={stripePromise} options={stripeOptions}>
-                  {children}
-                </Elements>
-              ) : (
-                children
-              )}
-            </SocketProvider>
+            {/* Stripe <Elements> is mounted per-route by the components that need it
+                (DepositModal, BackgroundCheckOrderPanel, /background-checks), so we no
+                longer load Stripe.js app-wide — it was initializing on /auth/login and
+                throwing "Failed to load Stripe.js" when a client blocked js.stripe.com. */}
+            <SocketProvider>{children}</SocketProvider>
           </AppProvider>
         </UserProvider>
       </ThemeProvider>

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -35,6 +35,16 @@ if (SENTRY_DSN) {
     // HIPAA: never send PII/PHI to Sentry by default
     sendDefaultPii: false,
 
+    // Drop known third-party browser noise (browser extensions / email link-scanners /
+    // client adblockers) so it doesn't burn Sentry quota. None of these are app errors.
+    ignoreErrors: [
+      // MS Outlook "SafeLink" / extension false positive on link pre-fetch
+      'Object Not Found Matching Id',
+      'Non-Error promise rejection captured with value: Object Not Found Matching Id',
+      // Client adblocker/network blocking js.stripe.com
+      'Failed to load Stripe.js',
+    ],
+
     // Integrations
     integrations: [
       // Session Replay — mask all inputs (form fields are primary PHI risk in replays)
@@ -53,6 +63,14 @@ if (SENTRY_DSN) {
     beforeSend(event) {
       // Filter noisy ResizeObserver errors
       if (event.exception?.values?.[0]?.value?.includes('ResizeObserver')) {
+        return null;
+      }
+      // Belt-and-suspenders for the known third-party noise above: these often arrive as
+      // a promise-rejection `message` rather than an exception value, which ignoreErrors
+      // can miss. Drop them so they don't burn quota.
+      const noise = ['Object Not Found Matching Id', 'Failed to load Stripe.js'];
+      const haystack = `${event.message ?? ''} ${event.exception?.values?.[0]?.value ?? ''}`;
+      if (noise.some((n) => haystack.includes(n))) {
         return null;
       }
       // Scrub PHI/PII from captured events


### PR DESCRIPTION
## Two low-priority Sentry cleanups (client-side noise on /auth/login)

Both are noise, not real bugs.

### 1. Stop loading Stripe.js on non-payment pages
`src/app/providers.tsx` wrapped **every page** in `<Elements>` with a module-level `loadStripe()`, so Stripe.js initialized on `/auth/login` (and everywhere) and threw **"Failed to load Stripe.js"** whenever a client adblocker/network blocked `js.stripe.com`.

The three components that actually use Stripe — `DepositModal`, `BackgroundCheckOrderPanel`, and `/background-checks` — **already mount their own `<Elements>`** with their own `loadStripe`. So the app-wide wrapper was redundant. Removed it (and the now-unused `loadStripe`/`Elements`/`useMemo` imports + `stripeOptions`). Stripe.js now loads **only** on the routes that need it.

### 2. Filter known third-party noise in the Sentry client config
`src/instrumentation-client.ts` (next to the existing `scrubPhi`/ResizeObserver `beforeSend`):
- Added **`ignoreErrors`** for `"Object Not Found Matching Id"` / `"Non-Error promise rejection captured with value: …"` (MS Outlook SafeLink / browser-extension false positive) and `"Failed to load Stripe.js"`.
- Added a belt-and-suspenders **`beforeSend`** check — these often arrive as a promise-rejection *message* rather than an exception value, which `ignoreErrors` can miss. Dropped so they don't burn Sentry quota.

`tsc --noEmit` + `eslint` clean on both files. No behavior change for payment flows (each self-wraps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_