### PR TITLE
chore(copy): swap out-of-state demo examples for Greater Cleveland

### DIFF
--- a/src/app/discharge-planner/search/_components/SearchInterface.tsx
+++ b/src/app/discharge-planner/search/_components/SearchInterface.tsx
@@ -28,10 +28,10 @@ interface SearchResponse {
 }
 
 const EXAMPLE_QUERIES = [
-  "I need a memory care facility in Boston for a 78-year-old with moderate Alzheimer's, budget around $6,000/month",
-  "Looking for assisted living in Miami with physical therapy, 24/7 nursing, accepts Medicaid",
-  "Need a home in San Francisco for a veteran with PTSD, private room, pet-friendly, under $5,000/month",
-  "Seeking skilled nursing facility in Chicago for post-stroke patient, needs speech therapy, Medicare coverage"
+  "I need a memory care facility in Beachwood for a 78-year-old with moderate Alzheimer's, budget around $6,000/month",
+  "Looking for assisted living in Lakewood with physical therapy, 24/7 nursing, accepts Medicaid",
+  "Need a home in Parma for a veteran with PTSD, private room, pet-friendly, under $5,000/month",
+  "Seeking skilled nursing facility in Westlake for post-stroke patient, needs speech therapy, Medicare coverage"
 ];
 
 export default function SearchInterface() {
@@ -93,7 +93,7 @@ export default function SearchInterface() {
               id="search-query"
               value={query}
               onChange={(e) => setQuery(e?.target?.value || '')}
-              placeholder="E.g., I need a memory care facility in Boston for a 78-year-old with moderate Alzheimer's, budget around $6,000/month..."
+              placeholder="E.g., I need a memory care facility in Beachwood for a 78-year-old with moderate Alzheimer's, budget around $6,000/month..."
               rows={4}
               className="w-full px-4 py-3 border border-neutral-300 rounded-xl focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none text-base"
               disabled={isSearching}

--- a/src/app/operator/homes/[id]/edit/page.tsx
+++ b/src/app/operator/homes/[id]/edit/page.tsx
@@ -649,7 +649,7 @@ export default function EditHomePage() {
                     className="w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
                     value={form.city}
                     onChange={(e) => handleInputChange('city', e.target.value)}
-                    placeholder="Seattle"
+                    placeholder="Cleveland"
                   />
                 </div>
 

--- a/src/app/operator/homes/new/page.tsx
+++ b/src/app/operator/homes/new/page.tsx
@@ -368,7 +368,7 @@ export default function NewHomePage() {
                     }`}
                     value={form.city}
                     onChange={(e) => handleInputChange('city', e.target.value)}
-                    placeholder="Seattle"
+                    placeholder="Cleveland"
                   />
                   {errors.city && (
                     <p className="mt-1 text-sm text-error-600">{errors.city}</p>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -596,7 +596,7 @@ function SearchPageContent() {
               <FiSearch className="text-neutral-400" />
               <input
                 type="text"
-                placeholder="Try 'Memory care near San Francisco' or 'Assisted living under $5000'"
+                placeholder="Try 'Memory care near Beachwood' or 'Assisted living with a garden under $5,000 in Lakewood'"
                 value={naturalQuery}
                 onChange={(e) => handleNaturalQueryChange(e.target.value)}
                 className="w-full border-none py-3 pl-2 text-sm focus:outline-none focus:ring-0"
@@ -1376,7 +1376,7 @@ function SearchPageContent() {
                   <FiMessageCircle className="mr-1 inline" /> Search Tips
                 </h3>
                 <p className="text-xs text-neutral-600">
-                  Try natural language searches like "memory care near San Francisco" or "assisted living with garden under $5000". 
+                  Try natural language searches like "memory care near Beachwood" or "assisted living with a garden under $5,000 in Lakewood".
                   Our AI will understand your needs and find the best matches.
                 </p>
               </div>

--- a/src/app/settings/profile/page.tsx
+++ b/src/app/settings/profile/page.tsx
@@ -1611,7 +1611,7 @@ export default function ProfileSettings() {
                 type="text"
                 name="coverageAreaCities"
                 id="coverageAreaCities"
-                placeholder="Seattle, Bellevue, Redmond"
+                placeholder="Cleveland, Lakewood, Beachwood"
                 value={(formData.coverageArea?.cities || []).join(", ")}
                 onChange={(e) => {
                   const cities = e.target.value.split(",").map(c => c.trim()).filter(c => c);


### PR DESCRIPTION
## Swap out-of-state demo examples for Greater Cleveland (cosmetic)

The directory is Cleveland-metro only, but several UI examples/placeholders still showed out-of-state demo cities. Swept the frontend and swapped them all to NE Ohio:

| File | Before | After |
|---|---|---|
| `/search` placeholder + Search Tips | "memory care near San Francisco" / "under $5000" | **"memory care near Beachwood"** / **"assisted living with a garden under $5,000 in Lakewood"** |
| discharge-planner `EXAMPLE_QUERIES` + textarea placeholder | Boston / Miami / San Francisco / Chicago | **Beachwood / Lakewood / Parma / Westlake** |
| operator home **create** city placeholder | "Seattle" | **"Cleveland"** |
| operator home **edit** city placeholder | "Seattle" | **"Cleveland"** |
| settings/profile coverage-area placeholder | "Seattle, Bellevue, Redmond" | **"Cleveland, Lakewood, Beachwood"** |

Final grep confirms no out-of-state example/placeholder strings remain in rendered UI. Cosmetic only — no logic change. `tsc` + `eslint` clean. (Dead `src/app/search/page_clean.tsx` left as-is — unreferenced, not an App Router route.)

Low-risk; rides the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_