### PR TITLE
feat(public): anonymous public browse for /search + /homes/[id] (A)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -123,7 +123,16 @@ function getApproximateCoordinates(city: string | null, state: string | null): {
       };
     }
   }
-  
+
+  // Final fallback: the directory is Greater-Cleveland-only, so an unlisted OH city (or a
+  // home with no state) defaults to a Cleveland-metro point — NOT the state centroid /
+  // central Ohio — so any future coord-less home stays local instead of drifting away.
+  // (All current homes have real geocoded coords; this only guards future gaps.)
+  if (!state || state.toLowerCase() === 'oh' || state.toLowerCase() === 'ohio') {
+    const offset = () => (Math.random() - 0.5) * 0.1; // ~5km jitter within the metro
+    return { lat: 41.4993 + offset(), lng: -81.6944 + offset() }; // downtown Cleveland
+  }
+
   return null;
 }
 

--- a/src/app/background-checks/layout.tsx
+++ b/src/app/background-checks/layout.tsx
@@ -1,0 +1,16 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+
+/**
+ * Server-side auth gate for /background-checks. The page itself only checks auth
+ * client-side (useSession + router.push); this adds a server-side redirect so an
+ * anonymous request never renders the page at all (defense-in-depth).
+ */
+export default async function BackgroundChecksLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    redirect('/auth/login?callbackUrl=/background-checks');
+  }
+  return <>{children}</>;
+}

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -38,7 +38,7 @@ import {
 } from "react-icons/fi";
 import { Camera, MessageSquare } from "lucide-react";
 
-import DashboardLayout from "@/components/layout/DashboardLayout";
+import BrowseShell from "@/components/layout/BrowseShell";
 import TourRequestModal from "@/components/tours/TourRequestModal";
 // Import our new components
 import PhotoGallery from "@/components/homes/PhotoGallery";
@@ -704,26 +704,26 @@ export default function HomeDetailPage() {
 
     if (loadError) {
       return (
-        <DashboardLayout title="Home Details">
+        <BrowseShell title="Home Details">
           <div className="p-4 md:p-6">
             <div className="rounded-lg border border-error-200 bg-error-50 p-6">
               <h2 className="text-lg font-semibold text-error-700 mb-2">Could not load listing</h2>
               <p className="text-error-700">{loadError}</p>
             </div>
           </div>
-        </DashboardLayout>
+        </BrowseShell>
       );
     }
 
     if (!realHome) {
       return (
-        <DashboardLayout title="Home Details">
+        <BrowseShell title="Home Details">
           <div className="p-4 md:p-6">
             <div className="rounded-lg border border-neutral-200 bg-white p-6">
               <p className="text-neutral-600">No data found.</p>
             </div>
           </div>
-        </DashboardLayout>
+        </BrowseShell>
       );
     }
 
@@ -733,7 +733,7 @@ export default function HomeDetailPage() {
     const photos = (realHome.photos || []).map((p: any) => ({ id: p.id, url: p.url, caption: p.caption || '' }));
 
     return (
-      <DashboardLayout title={`Home Details - ${realHome.name}`}>
+      <BrowseShell title={`Home Details - ${realHome.name}`}>
         <div className="min-h-screen bg-neutral-50 pb-28">
           {/* Sticky top nav */}
           <div className="sticky top-0 z-20 bg-white shadow-sm">
@@ -1292,12 +1292,12 @@ export default function HomeDetailPage() {
             </div>
           </div>
         </div>
-      </DashboardLayout>
+      </BrowseShell>
     );
   }
   
   return (
-    <DashboardLayout title={`Home Details - ${home.name}`}>
+    <BrowseShell title={`Home Details - ${home.name}`}>
     <div className="min-h-screen bg-neutral-50 pb-28">
       {/* Back button */}
       <div className="sticky top-0 z-20 bg-white shadow-sm">
@@ -2290,6 +2290,6 @@ export default function HomeDetailPage() {
         }}
       />
     </div>
-    </DashboardLayout>
+    </BrowseShell>
   );
 }

--- a/src/app/messages/layout.tsx
+++ b/src/app/messages/layout.tsx
@@ -1,0 +1,17 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+
+/**
+ * Server-side auth gate for /messages. The page only checks auth client-side
+ * (via DashboardLayout's useSession); this adds a server-side redirect so an
+ * anonymous request never renders the page (defense-in-depth — messages can
+ * contain PHI).
+ */
+export default async function MessagesLayout({ children }: { children: React.ReactNode }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    redirect('/auth/login?callbackUrl=/messages');
+  }
+  return <>{children}</>;
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useRef, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import toast from "react-hot-toast";
 import Link from "next/link";
 import { 
   FiSearch, 
@@ -37,7 +39,7 @@ import {
   getFavorites,
   toggleFavorite,
 } from "@/lib/favoritesService";
-import DashboardLayout from "@/components/layout/DashboardLayout";
+import BrowseShell from "@/components/layout/BrowseShell";
 import SearchFilters from "@/components/search/SearchFilters";
 import HomeCompareModal from "@/components/family/HomeCompareModal";
 import dynamic from "next/dynamic";
@@ -84,6 +86,8 @@ function SearchPageContent() {
   // Search params and router for query handling
   const searchParams = useSearchParams();
   const router = useRouter();
+  // Auth status — anonymous families can browse + inquire; saving prompts signup.
+  const { status: authStatus } = useSession();
   // Runtime mock toggle fetched from API
   const [showMock, setShowMock] = useState(false);
   useEffect(() => {
@@ -163,8 +167,9 @@ function SearchPageContent() {
   // ---- Favorites -----------------------------------------------------------------
   const [favoriteIds, setFavoriteIds] = useState<Set<string>>(new Set());
 
-  // Fetch favorites once (or when session changes in future)
+  // Fetch favorites once — only for signed-in families (the API 401s for anon).
   useEffect(() => {
+    if (authStatus !== "authenticated") return;
     async function fetchFavorites() {
       try {
         const favs = await getFavorites();
@@ -174,14 +179,35 @@ function SearchPageContent() {
       }
     }
     fetchFavorites();
-  }, []);
+  }, [authStatus]);
 
   const handleToggleFavorite = async (homeId: string, e?: React.MouseEvent) => {
     if (e) {
       e.preventDefault(); // prevent link navigation
       e.stopPropagation(); // prevent bubbling
     }
-    
+
+    // Anonymous visitors can browse freely, but saving requires an account —
+    // trigger signup here (not a login wall on browsing).
+    if (authStatus !== "authenticated") {
+      toast(
+        (t) => (
+          <span>
+            Create a free account to save homes.{" "}
+            <a
+              href="/auth/register"
+              className="font-semibold text-teal-700 underline"
+              onClick={() => toast.dismiss(t.id)}
+            >
+              Sign up
+            </a>
+          </span>
+        ),
+        { duration: 6000 },
+      );
+      return;
+    }
+
     // optimistic UI
     setFavoriteIds((prev) => {
       const newSet = new Set(prev);
@@ -587,7 +613,7 @@ function SearchPageContent() {
   };
   
   return (
-    <DashboardLayout title="Search Homes" showSearch={false}>
+    <BrowseShell title="Search Homes" showSearch={false}>
       <div className="p-4 md:p-6">
         {/* Natural language search bar */}
         <div className="relative mb-6">
@@ -1597,7 +1623,7 @@ function SearchPageContent() {
           </div>
         </div>
       )}
-    </DashboardLayout>
+    </BrowseShell>
   );
 }
 

--- a/src/components/layout/BrowseShell.tsx
+++ b/src/components/layout/BrowseShell.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import DashboardLayout from './DashboardLayout';
+import PublicShell from './PublicShell';
+
+/**
+ * Session-aware shell for the publicly-browsable pages (/search, /homes/[id]).
+ *  - authenticated  → the full member DashboardLayout (members keep their nav)
+ *  - anonymous/loading → the minimal PublicShell (no auth redirect — logged-out
+ *    families can browse + inquire; signup is triggered only at inquiry/save)
+ *
+ * This replaces wrapping these pages directly in DashboardLayout, which redirected
+ * anonymous visitors to /auth/login (a login wall on what should be public).
+ */
+export default function BrowseShell({
+  title,
+  showSearch,
+  children,
+}: {
+  title?: string;
+  showSearch?: boolean;
+  children: React.ReactNode;
+}) {
+  const { status } = useSession();
+  if (status === 'authenticated') {
+    return (
+      <DashboardLayout title={title ?? ''} showSearch={showSearch}>
+        {children}
+      </DashboardLayout>
+    );
+  }
+  return <PublicShell>{children}</PublicShell>;
+}

--- a/src/components/layout/PublicShell.tsx
+++ b/src/components/layout/PublicShell.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+
+/**
+ * Minimal public chrome for ANONYMOUS (logged-out) visitors browsing the directory
+ * (/search, /homes/[id]). No member sidebar, no useSession redirect — logged-out families
+ * can search, browse, view listings, and submit an inquiry; signup is only triggered at
+ * inquiry/save, never as a wall. Authenticated users get the full DashboardLayout instead
+ * (see BrowseShell).
+ */
+export default function PublicShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-neutral-50">
+      <header className="border-b border-neutral-200 bg-white">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
+          <Link href="/" className="text-lg font-bold text-teal-700">
+            CareLinkAI
+          </Link>
+          <nav className="flex items-center gap-3">
+            <Link href="/auth/login" className="text-sm font-medium text-neutral-700 hover:text-teal-700">
+              Log in
+            </Link>
+            <Link
+              href="/auth/register"
+              className="rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-700"
+            >
+              Sign up
+            </Link>
+          </nav>
+        </div>
+      </header>
+
+      <main className="flex-1">{children}</main>
+
+      <footer className="border-t border-neutral-200 bg-white">
+        <div className="mx-auto max-w-7xl px-4 py-6 text-center text-xs text-neutral-500">
+          CareLinkAI · Greater Cleveland senior-care directory ·{' '}
+          <Link href="/privacy" className="underline hover:text-neutral-700">Privacy</Link> ·{' '}
+          <Link href="/terms" className="underline hover:text-neutral-700">Terms</Link>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -133,7 +133,7 @@ export default function middleware(req: NextRequest) {
         }
 
         // Always-public paths (must match the authorized callback list above)
-        const publicPaths = ['/', '/help', '/search', '/privacy', '/terms', '/learn'];
+        const publicPaths = ['/', '/help', '/search', '/homes', '/privacy', '/terms', '/learn'];
         const mockPublicPrefixes = ['/marketplace'];
 
         if (publicPaths.some(p => pathname === p || pathname.startsWith(p + '/')) || (showMocks && mockPublicPrefixes.some(p => pathname === p || pathname.startsWith(p + '/')))) {
@@ -171,7 +171,7 @@ export default function middleware(req: NextRequest) {
             }
 
             // Always-public paths — no auth required regardless of mock mode
-            const alwaysPublic = ['/', '/help', '/search', '/privacy', '/terms', '/learn'];
+            const alwaysPublic = ['/', '/help', '/search', '/homes', '/privacy', '/terms', '/learn'];
             if (alwaysPublic.some(p => pathname === p || pathname.startsWith(p + '/'))) {
               return true;
             }


### PR DESCRIPTION
## A — Anonymous public browse for /search + /homes/[id]

Logged-out families were **redirected to `/auth/login`** when hitting `/search` or `/homes/[id]` (the member `DashboardLayout` redirects client-side; `/homes/[id]` was also edge-blocked) — a login wall on what should be public.

> **A#1 first:** production does **not** leak sessions — an anonymous/incognito visitor gets no session (`mockSession` is null in prod; mocks are ADMIN-only). What surfaced this was a browser's sticky `demo.family` cookie, not a leak.

### What this changes
- **`PublicShell`** (NEW) — minimal anon chrome (logo + Log in / Sign up + footer). No member nav, no auth redirect.
- **`BrowseShell`** (NEW) — session-aware: **authenticated → `DashboardLayout`** (members keep their nav), **anonymous/loading → `PublicShell`**. `/search` and `/homes/[id]` now wrap in `BrowseShell`.
- **middleware** — `/homes` added to the public-path lists so anon can reach listing detail.
- **`/search`** — anon browses/searches freely; favorites API isn't called for anon (no 401 noise); **clicking Save prompts a signup toast** (signup only at save, never a browse wall). Inquiry already allows anonymous submission (`/api/inquiries` → `familyId: null`), and `/api/homes/[id]` returns listings to anon (session is optional there).
- **A#3** — server-side auth-gate **layouts** for `/background-checks` and `/messages` (were client-side-only; messages can carry PHI).
- **B fallback** (folded in per request) — `getApproximateCoordinates` now defaults an unlisted-OH / no-state home to a **Cleveland-metro point** instead of central Ohio. (All 144 current homes already have real geocoded coords from the B run.)

### Guardrail honored
Anon public shell keeps **search, browse, listing-detail, and the inquiry CTA fully usable** — signup/account only at inquiry or save. Not a login wall.

### A#4 (your side)
Rotate the `demo.*` prod passwords when convenient (low urgency — no auto-login / no data exposure confirmed).

`tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_