### PR TITLE
feat(search): map view plots all matching homes, not just current page (2)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -552,6 +552,10 @@ export async function GET(request: NextRequest) {
       MAX_PAGE_SIZE
     );
     const offset = (page - 1) * limit;
+    // Map view: return ALL matching homes (lightweight markers), unpaginated, so the map
+    // plots the full result set instead of just the current page. Capped for safety.
+    const markersOnly = searchParams.get('markers') === '1';
+    const MARKERS_MAX = 1000;
 
     // New Phase-1 query params
     const radius = searchParams.get('radius')
@@ -680,8 +684,8 @@ export async function GET(request: NextRequest) {
               take: 1
             }
           },
-          skip: offset,
-          take: limit
+          skip: markersOnly ? 0 : offset,
+          take: markersOnly ? MARKERS_MAX : limit
         }),
         prisma.assistedLivingHome.count({
           where: whereClause
@@ -691,6 +695,36 @@ export async function GET(request: NextRequest) {
       console.error('DB query failed, falling back to mocks:', dbErr);
       homes = [];
       totalCount = 0;
+    }
+
+    // Map view: return lightweight markers for ALL matching homes (no pagination, no AI
+    // scoring / favorites / image work) so the map can plot the full result set.
+    if (markersOnly) {
+      const markers = homes.map((home: any) => {
+        const dbCoords = home.address?.latitude && home.address?.longitude
+          ? { lat: home.address.latitude, lng: home.address.longitude }
+          : null;
+        const coordinates = dbCoords
+          || (home.address ? getApproximateCoordinates(home.address.city, home.address.state) : null);
+        return {
+          id: home.id,
+          name: home.name,
+          careLevel: home.careLevel,
+          priceRange: {
+            min: home.priceMin ? Number(home.priceMin) : null,
+            max: home.priceMax ? Number(home.priceMax) : null,
+            formattedMin: home.priceMin ? formatCurrency(Number(home.priceMin)) : null,
+          },
+          coordinates,
+          address: home.address ? {
+            street: home.address.street,
+            city: home.address.city,
+            state: home.address.state,
+            coordinates,
+          } : null,
+        };
+      });
+      return NextResponse.json({ markers, total: totalCount });
     }
 
     // --- favourites ----

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -140,6 +140,36 @@ function SearchPageContent() {
   
   // State for search results
   const [searchResponse, setSearchResponse] = useState<SearchResponse | null>(null);
+
+  // Map view plots ALL matching homes (not just the current page) — fetched as lightweight
+  // markers from /api/search?markers=1 with the same filters. Grid/list stay paginated.
+  const [mapMarkers, setMapMarkers] = useState<any[] | null>(null);
+  useEffect(() => {
+    if (viewType !== "map") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const qp = new URLSearchParams();
+        if (filters.query) qp.set("q", String(filters.query));
+        if (filters.location) qp.set("location", String(filters.location));
+        (filters.careLevels ?? []).forEach((l) => qp.append("careLevel", l));
+        if (filters.priceMin) qp.set("priceMin", String(filters.priceMin));
+        if (filters.priceMax) qp.set("priceMax", String(filters.priceMax));
+        if (filters.gender) qp.set("gender", String(filters.gender));
+        if (filters.availability) qp.set("availability", "true");
+        if (filters.verified) qp.set("verified", "true");
+        if (filters.radius) qp.set("radius", String(filters.radius));
+        qp.set("markers", "1");
+        const res = await fetch(`/api/search?${qp.toString()}`, { cache: "no-store" });
+        if (!res.ok) return;
+        const j = await res.json();
+        if (!cancelled) setMapMarkers(Array.isArray(j?.markers) ? j.markers : []);
+      } catch {
+        if (!cancelled) setMapMarkers(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [viewType, filters, searchResponse]);
   
   // State for loading status
   const [isLoading, setIsLoading] = useState(false);
@@ -1119,11 +1149,11 @@ function SearchPageContent() {
               </div>
             )}
             
-            {/* Map view */}
-            {!isLoading && viewType === "map" && searchResults.length > 0 && (
+            {/* Map view — plots ALL matching homes (markers), not just the current page */}
+            {!isLoading && viewType === "map" && (mapMarkers ?? searchResults).length > 0 && (
               <div className="h-[calc(100vh-12rem)] w-full">
                 <SimpleMap
-                  homes={searchResults as any}
+                  homes={(mapMarkers ?? searchResults) as any}
                   onToggleFavorite={handleToggleFavorite}
                   favorites={Array.from(favoriteIds)}
                 />


### PR DESCRIPTION
## 2 — Map view plots ALL matching homes (not just the current page)

Map mode only rendered the current page (10 of 144). Now it shows the full result set.

- **`/api/search?markers=1`** (NEW mode) — reuses the **exact same `whereClause` filters + coordinate logic**, but skips pagination and the heavy AI-scoring/favorites/image work, returning all matching homes' lightweight marker data (`id, name, coordinates, careLevel, priceRange`). Capped at 1000 for safety.
- **Search page** — when Map view is active, fetches markers with the current filters and passes the **full set** to `SimpleMap`; grid/list stay paginated.

Since all 144 homes now have correct coords (from the B run), the map shows every matching facility in its real NE-Ohio location.

`tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_