### PR TITLE
feat(search): distinct, deterministic placeholders for photo-less homes (1)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -51,13 +51,13 @@ const MAX_PAGE_SIZE = 50;
  * NOTE: keep the list static so the assignment is deterministic across requests.
  */
 const PLACEHOLDER_IMAGES: string[] = [
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506192/carelinkai/placeholders/placeholder-1.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506195/carelinkai/placeholders/placeholder-2.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507649/carelinkai/placeholders/placeholder-1.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507654/carelinkai/placeholders/placeholder-2.jpg',
   'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506198/carelinkai/placeholders/placeholder-3.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506202/carelinkai/placeholders/placeholder-4.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506206/carelinkai/placeholders/placeholder-5.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506210/carelinkai/placeholders/placeholder-6.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506240/carelinkai/placeholders/placeholder-7.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507657/carelinkai/placeholders/placeholder-4.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507662/carelinkai/placeholders/placeholder-5.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507667/carelinkai/placeholders/placeholder-6.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507672/carelinkai/placeholders/placeholder-7.jpg',
   'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506214/carelinkai/placeholders/placeholder-8.jpg',
   'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506217/carelinkai/placeholders/placeholder-9.jpg',
   'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506222/carelinkai/placeholders/placeholder-10.jpg',

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -39,23 +39,52 @@ const DEFAULT_PAGE_SIZE = 10;
 const MAX_PAGE_SIZE = 50;
 
 /**
- * Curated exterior / home photos sourced from Unsplash (free to use)
- * NOTE: keep the list small and static so mocks are deterministic.
+ * Distinct senior-living placeholder photos (Pexels, free for commercial use,
+ * no attribution required) used only for homes that have NO real photo.
+ *
+ * Replaces the previous `home-1..12` set, which were 11 byte-identical copies of
+ * a single kitchen image — so every photo-less listing rendered the same picture
+ * (a "wall of identical homes"). This set mixes residential exteriors, gardens,
+ * and warm common areas so the grid looks varied. A home is assigned one of these
+ * deterministically by `placeholderImageFor(home.id)` (stable per home).
+ *
+ * NOTE: keep the list static so the assignment is deterministic across requests.
  */
-const HOME_IMAGES: string[] = [
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830428/carelinkai/homes/home-1.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830435/carelinkai/homes/home-2.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830437/carelinkai/homes/home-3.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830439/carelinkai/homes/home-4.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830441/carelinkai/homes/home-5.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830443/carelinkai/homes/home-6.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830445/carelinkai/homes/home-7.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830447/carelinkai/homes/home-8.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830449/carelinkai/homes/home-9.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830430/carelinkai/homes/home-10.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830431/carelinkai/homes/home-11.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1765830433/carelinkai/homes/home-12.jpg',
+const PLACEHOLDER_IMAGES: string[] = [
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506192/carelinkai/placeholders/placeholder-1.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506195/carelinkai/placeholders/placeholder-2.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506198/carelinkai/placeholders/placeholder-3.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506202/carelinkai/placeholders/placeholder-4.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506206/carelinkai/placeholders/placeholder-5.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506210/carelinkai/placeholders/placeholder-6.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506240/carelinkai/placeholders/placeholder-7.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506214/carelinkai/placeholders/placeholder-8.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506217/carelinkai/placeholders/placeholder-9.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506222/carelinkai/placeholders/placeholder-10.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506227/carelinkai/placeholders/placeholder-11.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506246/carelinkai/placeholders/placeholder-12.jpg',
 ];
+
+/**
+ * Stable 32-bit string hash (djb2). Lets us pick a placeholder image from a
+ * home's id so the SAME home always gets the SAME image — regardless of which
+ * result page / sort position it lands on.
+ */
+function hashStringToInt(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0; // hash * 33 + c
+  }
+  return Math.abs(hash);
+}
+
+/**
+ * Deterministic placeholder image for a home with no real photo.
+ * Stable per `id`, so the grid stays varied but each home is consistent.
+ */
+function placeholderImageFor(id: string): string {
+  return PLACEHOLDER_IMAGES[hashStringToInt(id) % PLACEHOLDER_IMAGES.length];
+}
 
 /**
  * City coordinates lookup for homes without geo data
@@ -496,8 +525,8 @@ export function generateMockHomes(count: number = 12) {
       availability: 5 + (i % 4),
       gender: 'ALL',
       amenities: amenitiesSamples[i % amenitiesSamples.length],
-      // Use seeded Picsum photos so each mock home gets a stable image
-      imageUrl: HOME_IMAGES[i % HOME_IMAGES.length],
+      // Deterministic placeholder so each mock home gets a stable image
+      imageUrl: placeholderImageFor(`mock-home-${i}`),
       operator: null,
       aiMatchScore: 60 + (i * 3) % 35, // 60-95
       aiMatchFactors: undefined,
@@ -786,9 +815,10 @@ export async function GET(request: NextRequest) {
         aiMatchScore = calculateMatchScore(home, searchCriteria);
       }
 
-      // 2. Image handling – prefer primary DB photo, else deterministic Unsplash fallback
+      // 2. Image handling – prefer primary DB photo, else a deterministic
+      // placeholder keyed off the home's id (stable per home, varied across the grid).
       const primary = sanitizeImageUrl(home.photos?.[0]?.url ?? null);
-      const fallback = HOME_IMAGES[i % HOME_IMAGES.length];
+      const fallback = placeholderImageFor(home.id);
       const imageUrl = primary ?? fallback;
 
       // 3. Build response object - use fallback coordinates if address lacks lat/lng


### PR DESCRIPTION
## Issue #1 — "wall of identical homes"

73 of 144 listings had `primaryPhoto=null` and all rendered the **same** image. Root cause confirmed via Cloudinary: the 12 `home-1..12` placeholder assets were **11 byte-identical copies** of one kitchen photo (all 97,608 bytes except `home-2`). So deterministic assignment alone wasn't enough — the *image set itself* had to be replaced.

### What changed
1. **12 distinct senior-living placeholders** uploaded to `carelinkai/placeholders/` — Pexels, free for commercial use, **no attribution required**. Mix of residential exteriors, gardens, and warm common areas (all normalized to 1200×800). Founder visually vetted the set; the 6 originally auto-sourced exteriors/gardens were swapped for hand-picked ones (no people):

   | # | Type | Image |
   |---|------|------|
   | [1](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507649/carelinkai/placeholders/placeholder-1.jpg) | exterior | Cream building + manicured garden ✅ vetted |
   | [2](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507654/carelinkai/placeholders/placeholder-2.jpg) | exterior | Red-brick building + blossoming tree ✅ vetted |
   | [3](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506198/carelinkai/placeholders/placeholder-3.jpg) | exterior | Exterior of a modern apartment building |
   | [4](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507657/carelinkai/placeholders/placeholder-4.jpg) | exterior | Modern residential complex w/ greenery ✅ vetted |
   | [5](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507662/carelinkai/placeholders/placeholder-5.jpg) | exterior | Classic balconied residential building ✅ vetted |
   | [6](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507667/carelinkai/placeholders/placeholder-6.jpg) | garden | Courtyard with fountain + hedges ✅ vetted |
   | [7](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507672/carelinkai/placeholders/placeholder-7.jpg) | garden | Garden with iron bench + stone wall ✅ vetted |
   | [8](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506214/carelinkai/placeholders/placeholder-8.jpg) | interior | Living room interior design |
   | [9](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506217/carelinkai/placeholders/placeholder-9.jpg) | interior | Cozy living room with sofa |
   | [10](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506222/carelinkai/placeholders/placeholder-10.jpg) | interior | Cozy living room |
   | [11](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506227/carelinkai/placeholders/placeholder-11.jpg) | interior | Cozy living room with sofa |
   | [12](https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506246/carelinkai/placeholders/placeholder-12.jpg) | interior | Cozy living room with fireplace |

2. **Deterministic assignment** via `placeholderImageFor(home.id)` (djb2 hash → `% 12`). Each home keeps the **same** image across pages and sorts, but the grid is varied. Replaces the old `HOME_IMAGES[i % len]`, which keyed off **page position** (so a home's image changed as it moved between pages).

3. **Real photos untouched** — `home.photos[0]` is still preferred; placeholders only fill in for homes with none. After the recent Google Places enrichment (418 real photos across ~75 homes), placeholders now affect a much smaller residual (~18+ photo-less homes).

### Test/build
- `tsc --noEmit`: **0 errors**.
- No DB or schema changes; markers endpoint (#637) unaffected.
- Old `home-*` assets left in place → fully reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)