### PR TITLE
chore(context): log VA email gap-fill (#640) + CAN-SPAM re-verify

### DIFF
--- a/context/CARELINKAI_TECH_OPEN_LOOPS.md
+++ b/context/CARELINKAI_TECH_OPEN_LOOPS.md
@@ -1,5 +1,5 @@
 # CareLinkAI — Tech Open Loops
-_Last updated: 2026-06-26 — /search polish shipped (OL-098): distinct deterministic placeholders (#638) + full-result map (#637); 418 real photos enriched. Prior: OL-097 public browse/map coords/price markers. Founder TODO: rotate demo.* passwords; incognito-verify anon /search._
+_Last updated: 2026-06-26 — VA email gap-fill (#640): 5 phone-verified operator emails → MEDIUM tier (OL-092), CAN-SPAM re-verified. Prior: /search polish (OL-098, #637/#638). Founder TODO: rotate demo.* passwords; incognito-verify anon /search; measure claim funnel before next medium send._
 
 ## Format
 Each loop: what it is, why it matters, what done looks like.
@@ -274,6 +274,7 @@ Each loop: what it is, why it matters, what done looks like.
   - ✅ **CAN-SPAM** (#624) — `EmailSuppression` model + migration `20260626000001_email_suppression`; one-click unsubscribe route `/api/outreach/unsubscribe` (signed token, `List-Unsubscribe` + RFC 8058 headers); sender skips suppressed addresses every run. Email footer carries the unsubscribe link + company physical address + clear sender identity.
   - ✅ **Multi-home claim** (#625, OL-095) — new `/claim?token=` landing lets one operator claim ALL their listings from the collapsed email.
 - ✅ `COMPANY_POSTAL_ADDRESS` set in Render; sender hardened (#624 collapse + CAN-SPAM) and multi-home claim shipped (#625) before the send.
+- **Gap-fill (2026-06-26, #640):** 5 VA-sourced (Anita), phone-verified operator emails backfilled via `scripts/backfill-va-operator-emails.ts` (founder ran `--force`: 5 applied) — Arden Courts Parma (`ncosta@arden-courts.com`, replaced dead promedica.org), Village of the Falls (`hcorwin@sprengerhealthcare.com`, replaced bounced hjohnson@), The Residence of Chardon (`cagardner@sonidaliving.com`), Danbury Woods (`mcollage@danburyseniorliving.com`, kept-dup), O'Neill Lakewood (`administrator.lw@oneillhc.com`, upgraded from Dir.sales@). All tagged `preFilledFields.outreachEmail='MEDIUM'` + status ACTIVE → queued for the **next** `--tier medium` send (24h per-address throttle protects re-sends). Excluded CALL-ONLY: Arden Courts Bath (HR inbox), Concordia at Sumner (no email). CAN-SPAM re-verified end-to-end (unsubscribe→`EmailSuppression` upsert + postal hard-gate) — no code change needed.
 - **What's next:**
   1. **Measure (~3–5 business days):** `npx tsx scripts/report-claim-funnel.ts` (#619) — now covers all ~59 (pilot + scale wave). Opens/clicks live in the Resend dashboard.
   2. **Watch for bounces:** a few generic `info@` inboxes may hard-bounce; Resend auto-suppresses them. (Optional follow-up: sync Resend bounces into our `EmailSuppression` table so our own re-runs also skip them.)

--- a/context/DEV_SESSION_SUMMARIES.md
+++ b/context/DEV_SESSION_SUMMARIES.md
@@ -2,6 +2,22 @@
 
 ---
 
+### 2026-06-26 (later) — VA-sourced operator-email gap-fill + CAN-SPAM re-verify (#640)
+
+- **Objective:** Backfill 5 VA-sourced (Anita), phone-verified operator emails into the claim-nudge channel and re-confirm the medium-wave is CAN-SPAM-ready.
+- **Work completed:**
+  - **#640** — new guarded script `scripts/backfill-va-operator-emails.ts`. For Arden Courts (Parma), Village of the Falls, The Residence of Chardon, Danbury Woods (kept dup), and O'Neill Lakewood: set the verified admin `outreachEmail`, tag `preFilledFields.outreachEmail='MEDIUM'` (send-eligibility, matching the `load-directory-outreach-contacts.ts` confidence convention), flip `status → ACTIVE`. Sentinel-owner guard, name sanity warning, dry-run default, idempotent.
+  - **Founder ran on Render** (dry-run → `--force`): **Applied: 5, Skipped: 0**. Two (Arden Parma, Village of the Falls) had their dead/bounced addresses already `BOUNCED-CLEARED` → installed fresh + re-armed to MEDIUM; Chardon + Danbury fresh; O'Neill Lakewood upgraded `Dir.sales@ → administrator.lw@` (already MEDIUM). All 5 were already ACTIVE (status flip was a no-op).
+  - **Excluded (CALL-ONLY, per founder):** Arden Courts Bath (HR-only inbox), Concordia at Sumner (no email).
+  - **CAN-SPAM re-verified (no code change):** claim-invite email + sender already fully compliant — per-recipient signed unsubscribe token (`/api/outreach/unsubscribe` upserts `EmailSuppression`), `COMPANY_POSTAL_ADDRESS` hard-gate (sender exits if unset), suppression skip, `List-Unsubscribe`/RFC 8058 headers (shipped #624, OL-092).
+- **Files changed:** `scripts/backfill-va-operator-emails.ts` (NEW). Plus this docs wrap.
+- **Tests/build status:** #640 green CI, squash-merged. Script excluded from project `tsc` (tsconfig `exclude`), but mirrors the proven batch-loader pattern; runtime-verified by the founder's Render run.
+- **Deployment impact:** Render auto-deployed the script; prod DB mutated by the Render `--force` run (5 homes: outreachEmail + preFilledFields + status). No emails sent — these sit dormant at MEDIUM tier.
+- **New risks/blockers:** none. The 5 join the next `--tier medium` send (parked pending pilot go/no-go per founder).
+- **Recommended next step:** measure the already-sent pilot+wave via `report-claim-funnel.ts`; when firing the next medium run, the 24h per-address throttle naturally protects re-sends.
+
+---
+
 ### 2026-06-26 — Family /search fixes: distinct placeholders + full-result map (#637, #638)
 
 - **Objective:** Two family-facing `/search` improvements on getcarelinkai.com — (1) photo-less homes all rendered the SAME generic kitchen ("wall of identical homes"); (2) Map view only plotted the current page (10 of 144) instead of the full match set.


### PR DESCRIPTION
Docs-only. Logs the VA-sourced operator-email gap-fill (#640) and the CAN-SPAM re-verification.

- **DEV_SESSION_SUMMARIES.md** — new "2026-06-26 (later)" entry: the 5 backfilled emails (founder ran `--force`, 5 applied), the CALL-ONLY exclusions, and the CAN-SPAM end-to-end confirmation.
- **CARELINKAI_TECH_OPEN_LOOPS.md** — OL-092 updated with the gap-fill bullet (5 homes → MEDIUM/ACTIVE, queued for the next `--tier medium` send); header refreshed.

**CAN-SPAM finding:** already complete (shipped #624) — per-recipient signed unsubscribe token (`/api/outreach/unsubscribe` upserts `EmailSuppression`), `COMPANY_POSTAL_ADDRESS` hard-gate in the sender, suppression skip, `List-Unsubscribe`/RFC 8058 headers. No code change required.

No app/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_