### PR TITLE
fix(search): stop Unclaimed and % Match badges overlapping on cards

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1038,12 +1038,24 @@ function SearchPageContent() {
                             </div>
                           )}
                           
-                          {/* AI Match Score */}
-                          <div className="absolute left-2 top-2 rounded-full bg-gradient-to-r from-primary-500 to-primary-600 px-2 py-1 text-xs font-medium text-white shadow-md">
-                            <div className="flex items-center">
-                              <FiAward className="mr-1" />
-                              {home.aiMatchScore}% Match
-                            </div>
+                          {/* Top-left badges, stacked so they never overlap. The "% Match" badge
+                              renders ONLY with real personalization (aiMatchFactors present); anon /
+                              no-preference sessions would otherwise show a meaningless constant 50%,
+                              so they get a clean single "Unclaimed" badge instead. */}
+                          <div className="absolute left-2 top-2 flex flex-col items-start gap-1">
+                            {home.aiMatchFactors && (
+                              <div className="rounded-full bg-gradient-to-r from-primary-500 to-primary-600 px-2 py-1 text-xs font-medium text-white shadow-md">
+                                <div className="flex items-center">
+                                  <FiAward className="mr-1" />
+                                  {home.aiMatchScore}% Match
+                                </div>
+                              </div>
+                            )}
+                            {home.isUnclaimed && (
+                              <div className="rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 shadow-md border border-amber-200">
+                                Unclaimed
+                              </div>
+                            )}
                           </div>
                           {/* Why this match - top factors (grid card) */}
                           {home.aiMatchFactors && (
@@ -1067,13 +1079,6 @@ function SearchPageContent() {
                           ) : (
                             <div className="absolute right-2 top-2 rounded-full bg-neutral-500 px-2 py-1 text-xs font-medium text-white shadow-md">
                               Waitlist
-                            </div>
-                          )}
-
-                          {/* Unclaimed (directory) badge */}
-                          {home.isUnclaimed && (
-                            <div className="absolute left-2 top-2 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 shadow-md border border-amber-200">
-                              Unclaimed
                             </div>
                           )}
                         </div>
@@ -1191,12 +1196,24 @@ function SearchPageContent() {
                             </div>
                           )}
                           
-                          {/* AI Match Score */}
-                          <div className="absolute left-2 top-2 rounded-full bg-gradient-to-r from-primary-500 to-primary-600 px-2 py-1 text-xs font-medium text-white shadow-md">
-                            <div className="flex items-center">
-                              <FiAward className="mr-1" />
-                              {home.aiMatchScore}% Match
-                            </div>
+                          {/* Top-left badges, stacked so they never overlap. The "% Match" badge
+                              renders ONLY with real personalization (aiMatchFactors present); anon /
+                              no-preference sessions would otherwise show a meaningless constant 50%,
+                              so they get a clean single "Unclaimed" badge instead. */}
+                          <div className="absolute left-2 top-2 flex flex-col items-start gap-1">
+                            {home.aiMatchFactors && (
+                              <div className="rounded-full bg-gradient-to-r from-primary-500 to-primary-600 px-2 py-1 text-xs font-medium text-white shadow-md">
+                                <div className="flex items-center">
+                                  <FiAward className="mr-1" />
+                                  {home.aiMatchScore}% Match
+                                </div>
+                              </div>
+                            )}
+                            {home.isUnclaimed && (
+                              <div className="rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 shadow-md border border-amber-200">
+                                Unclaimed
+                              </div>
+                            )}
                           </div>
                           {/* Why this match - top factors (list card) */}
                           {home.aiMatchFactors && (
@@ -1220,13 +1237,6 @@ function SearchPageContent() {
                           ) : (
                             <div className="absolute right-2 top-2 rounded-full bg-neutral-500 px-2 py-1 text-xs font-medium text-white shadow-md">
                               Waitlist
-                            </div>
-                          )}
-
-                          {/* Unclaimed (directory) badge */}
-                          {home.isUnclaimed && (
-                            <div className="absolute left-2 top-2 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 shadow-md border border-amber-200">
-                              Unclaimed
                             </div>
                           )}
                         </div>


### PR DESCRIPTION
## Bug
On `/search` cards, the amber **Unclaimed** badge and the purple **X% Match** badge were both `absolute left-2 top-2`, so they rendered on top of each other on every directory card — only "…ch" (from "Match") peeked out. Top-right is already taken by the "X Available" badge.

## Fix (founder's preferred approach + robustness)
1. **Only render "% Match" with real personalization** (`home.aiMatchFactors` present). Anonymous / no-preference sessions were showing a constant, meaningless **50% Match** — that's both noise and the source of the overlap. They now get a clean single **Unclaimed** badge.
2. **Wrap both top-left badges in one `flex flex-col gap-1` container** so that, in the rare case a *personalized* session views an *unclaimed* home, the two badges stack vertically instead of overlapping.

Applied to both the **grid** and **list** card layouts (identical badge blocks).

## Notes
- `aiMatchFactors` is the same signal already gating the "Why this match" factor chips and the "Explain" button, so the match badge now appears exactly when those do — consistent.
- `tsc --noEmit`: **0 errors**. CSS/JSX only, no data or API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_