### PR TITLE
feat(homes): representative placeholder hero on listing detail (enrich 1)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -33,58 +33,11 @@ import { formatCurrency } from '@/lib/utils';
 import { calculateAIMatchScore, calculateAIMatchBreakdown } from '@/lib/ai-matching';
 import { isUnclaimedHome } from '@/lib/claim-engine/inquiry-claim-notification';
 import { prisma } from '@/lib/prisma';
+import { placeholderImageFor } from '@/lib/placeholder-images';
 
 // Constants
 const DEFAULT_PAGE_SIZE = 10;
 const MAX_PAGE_SIZE = 50;
-
-/**
- * Distinct senior-living placeholder photos (Pexels, free for commercial use,
- * no attribution required) used only for homes that have NO real photo.
- *
- * Replaces the previous `home-1..12` set, which were 11 byte-identical copies of
- * a single kitchen image — so every photo-less listing rendered the same picture
- * (a "wall of identical homes"). This set mixes residential exteriors, gardens,
- * and warm common areas so the grid looks varied. A home is assigned one of these
- * deterministically by `placeholderImageFor(home.id)` (stable per home).
- *
- * NOTE: keep the list static so the assignment is deterministic across requests.
- */
-const PLACEHOLDER_IMAGES: string[] = [
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507649/carelinkai/placeholders/placeholder-1.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507654/carelinkai/placeholders/placeholder-2.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506198/carelinkai/placeholders/placeholder-3.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507657/carelinkai/placeholders/placeholder-4.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507662/carelinkai/placeholders/placeholder-5.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507667/carelinkai/placeholders/placeholder-6.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507672/carelinkai/placeholders/placeholder-7.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506214/carelinkai/placeholders/placeholder-8.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506217/carelinkai/placeholders/placeholder-9.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506222/carelinkai/placeholders/placeholder-10.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506227/carelinkai/placeholders/placeholder-11.jpg',
-  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506246/carelinkai/placeholders/placeholder-12.jpg',
-];
-
-/**
- * Stable 32-bit string hash (djb2). Lets us pick a placeholder image from a
- * home's id so the SAME home always gets the SAME image — regardless of which
- * result page / sort position it lands on.
- */
-function hashStringToInt(str: string): number {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0; // hash * 33 + c
-  }
-  return Math.abs(hash);
-}
-
-/**
- * Deterministic placeholder image for a home with no real photo.
- * Stable per `id`, so the grid stays varied but each home is consistent.
- */
-function placeholderImageFor(id: string): string {
-  return PLACEHOLDER_IMAGES[hashStringToInt(id) % PLACEHOLDER_IMAGES.length];
-}
 
 /**
  * City coordinates lookup for homes without geo data

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -42,6 +42,7 @@ import BrowseShell from "@/components/layout/BrowseShell";
 import TourRequestModal from "@/components/tours/TourRequestModal";
 // Import our new components
 import PhotoGallery from "@/components/homes/PhotoGallery";
+import { placeholderImageFor } from "@/lib/placeholder-images";
 import PricingCalculator from "@/components/homes/PricingCalculator";
 import type { PricingEstimate } from "@/components/homes/PricingCalculator";
 import { getCloudinaryAvatar, isCloudinaryUrl } from "@/lib/cloudinaryUrl";
@@ -764,7 +765,7 @@ export default function HomeDetailPage() {
 
           {/* Photos */}
           <div className="container mx-auto px-4 pt-6">
-            <PhotoGallery photos={photos} />
+            <PhotoGallery photos={photos} placeholderImageUrl={placeholderImageFor(realHome.id)} />
           </div>
 
           {/* Main content */}
@@ -1334,7 +1335,7 @@ export default function HomeDetailPage() {
       
       {/* Photo gallery */}
       <div className="container mx-auto px-4 pt-6">
-        <PhotoGallery photos={home.photos} />
+        <PhotoGallery photos={home.photos} placeholderImageUrl={placeholderImageFor(home.id)} />
       </div>
       
       {/* Main content */}

--- a/src/components/homes/PhotoGallery.tsx
+++ b/src/components/homes/PhotoGallery.tsx
@@ -11,6 +11,7 @@ import {
   FiGrid
 } from 'react-icons/fi';
 import HomeImagePlaceholder from './HomeImagePlaceholder';
+import { PLACEHOLDER_CAPTION } from '@/lib/placeholder-images';
 
 export interface Photo {
   id: string;
@@ -21,11 +22,18 @@ export interface Photo {
 interface PhotoGalleryProps {
   photos: Photo[];
   initialIndex?: number;
+  /**
+   * When there are no real photos, show this representative stand-in image
+   * (deterministic per home) with an honest caption, instead of the blank
+   * "Photos coming soon" box. Real photos always take precedence.
+   */
+  placeholderImageUrl?: string;
 }
 
-const PhotoGallery: React.FC<PhotoGalleryProps> = ({ 
-  photos, 
-  initialIndex = 0 
+const PhotoGallery: React.FC<PhotoGalleryProps> = ({
+  photos,
+  initialIndex = 0,
+  placeholderImageUrl,
 }) => {
   const [activeIndex, setActiveIndex] = useState(initialIndex);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -147,8 +155,26 @@ const PhotoGallery: React.FC<PhotoGalleryProps> = ({
     setIsLoading(false);
   };
 
-  // If no photos, show a clean branded placeholder (not a broken image).
+  // If no real photos: prefer a representative stand-in image (deterministic per
+  // home) with an honest caption; fall back to the branded box if none supplied.
   if (!photos.length) {
+    if (placeholderImageUrl) {
+      return (
+        <div className="relative h-64 w-full overflow-hidden rounded-lg bg-neutral-100 md:h-96">
+          <Image
+            src={placeholderImageUrl}
+            alt="Representative senior-living photo (no operator photo yet)"
+            fill
+            sizes="(max-width: 768px) 100vw, 50vw"
+            className="object-cover"
+            priority
+          />
+          <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-3">
+            <p className="text-xs text-white/90">{PLACEHOLDER_CAPTION}</p>
+          </div>
+        </div>
+      );
+    }
     return <HomeImagePlaceholder className="h-64 w-full rounded-lg md:h-96" />;
   }
 

--- a/src/lib/placeholder-images.ts
+++ b/src/lib/placeholder-images.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared senior-living placeholder photos + deterministic per-home picker.
+ *
+ * Used for any home that has NO real photo (Places/operator photos always win).
+ * The 12 images (Pexels, free for commercial use, no attribution) mix residential
+ * exteriors, gardens, and warm common areas so a grid of photo-less homes looks
+ * varied instead of repeating one image. A home is assigned one deterministically
+ * by `placeholderImageFor(home.id)`, so the SAME home always gets the SAME image —
+ * on the search grid AND the listing detail hero.
+ *
+ * Keep the list static so the assignment stays deterministic across requests.
+ */
+export const PLACEHOLDER_IMAGES: string[] = [
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507649/carelinkai/placeholders/placeholder-1.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507654/carelinkai/placeholders/placeholder-2.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506198/carelinkai/placeholders/placeholder-3.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507657/carelinkai/placeholders/placeholder-4.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507662/carelinkai/placeholders/placeholder-5.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507667/carelinkai/placeholders/placeholder-6.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782507672/carelinkai/placeholders/placeholder-7.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506214/carelinkai/placeholders/placeholder-8.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506217/carelinkai/placeholders/placeholder-9.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506222/carelinkai/placeholders/placeholder-10.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506227/carelinkai/placeholders/placeholder-11.jpg',
+  'https://res.cloudinary.com/dygtsnu8z/image/upload/v1782506246/carelinkai/placeholders/placeholder-12.jpg',
+];
+
+/** Caption shown over a placeholder hero so it's never mistaken for a real facility photo. */
+export const PLACEHOLDER_CAPTION = 'Representative photo — pending operator upload.';
+
+/**
+ * Stable 32-bit string hash (djb2). Picks a placeholder from a home's id so the
+ * SAME home always maps to the SAME image, regardless of page/sort position.
+ */
+export function hashStringToInt(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0; // hash * 33 + c
+  }
+  return Math.abs(hash);
+}
+
+/**
+ * Deterministic placeholder image for a home with no real photo. Stable per `id`.
+ * Falls back to the first image for an empty/missing id rather than throwing.
+ */
+export function placeholderImageFor(id: string | null | undefined): string {
+  const key = id && id.length > 0 ? id : 'carelinkai-home';
+  return PLACEHOLDER_IMAGES[hashStringToInt(key) % PLACEHOLDER_IMAGES.length];
+}


### PR DESCRIPTION
**Enrichment item #1 of the unclaimed-listing batch.**

Photo-less `/homes/[id]` pages showed a blank "Photos coming soon" box for the hero. Now they show the **same deterministic per-home placeholder** used on the search grid, with an honest caption overlay:

> Representative photo — pending operator upload.

Real Places/operator photos always take precedence (that path is unchanged — placeholders only fill in when `photos.length === 0`).

### Changes
- **`src/lib/placeholder-images.ts` (NEW)** — single source of truth: `PLACEHOLDER_IMAGES` (the 12 founder-vetted Pexels images from #638), `hashStringToInt`, `placeholderImageFor(id)`, and `PLACEHOLDER_CAPTION`. Previously these lived inline in the search route.
- **`api/search/route.ts`** — now imports from the shared lib (removed the local copies; grid behavior identical).
- **`PhotoGallery`** — optional `placeholderImageUrl`: with no real photos + a url, renders it as the hero with the caption; else falls back to the existing branded `HomeImagePlaceholder` box.
- **`/homes/[id]`** — passes `placeholderImageFor(home.id)` at both gallery call sites.

### Honest-by-design
- Caption makes clear it's representative, not the actual building.
- Deterministic per `home.id` → matches the card image for the same home (consistent grid → detail).
- No fabricated facility detail; real photos override.

`tsc --noEmit`: **0 errors**. No DB/schema/API-shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_