### PR TITLE
feat(directory): honest facts-only description generator for unclaimed listings (enrich 2)

### DIFF
--- a/scripts/enrich-unclaimed-descriptions.ts
+++ b/scripts/enrich-unclaimed-descriptions.ts
@@ -1,0 +1,153 @@
+/**
+ * enrich-unclaimed-descriptions.ts
+ *
+ * Generate HONEST, facts-only descriptions for UNCLAIMED directory listings using
+ * src/lib/profile-generator/unclaimed-description-generator.ts (known facts +
+ * general care-level/area context only — never invents amenities/pricing/etc).
+ *
+ * Provenance: writes the description and tags `preFilledFields.description =
+ * 'AI_PUBLIC_DATA'` so it's identifiable and cleanly overwritten when an operator
+ * claims the listing.
+ *
+ * SAFETY:
+ *   - Only ACTIVE listings owned by the directory sentinel (truly unclaimed).
+ *   - DEFAULT targets SPARSE homes only (description < 50 words OR already tagged
+ *     AI_PUBLIC_DATA) so a good website-extracted description is never clobbered.
+ *     Pass --all to (re)generate for every unclaimed home.
+ *   - --sample N: generate + PRINT N, NO writes (founder voice-check gate).
+ *   - --force: actually write. Without --sample or --force it's a dry count.
+ *
+ * Usage (Render shell — DATABASE_URL + ANTHROPIC_API_KEY):
+ *   npx tsx scripts/enrich-unclaimed-descriptions.ts --sample 3        # preview 3, no writes
+ *   npx tsx scripts/enrich-unclaimed-descriptions.ts --force           # write all sparse
+ *   npx tsx scripts/enrich-unclaimed-descriptions.ts --all --force     # write every unclaimed
+ *   npx tsx scripts/enrich-unclaimed-descriptions.ts --limit 20 --force
+ */
+
+import { PrismaClient } from '@prisma/client';
+import {
+  generateUnclaimedDescription,
+  countyForCity,
+  type UnclaimedFacts,
+} from '../src/lib/profile-generator/unclaimed-description-generator';
+
+const prisma = new PrismaClient();
+
+const DIRECTORY_UNCLAIMED_EMAIL = 'directory-unclaimed@carelinkai.system';
+const SPARSE_WORD_THRESHOLD = 50;
+
+// Sonnet 4.6 pricing (approx, USD per token) for a cost estimate.
+const COST_IN = 3 / 1_000_000;
+const COST_OUT = 15 / 1_000_000;
+
+function wordCount(s: string | null | undefined): number {
+  return s ? s.trim().split(/\s+/).filter(Boolean).length : 0;
+}
+
+async function main() {
+  const argv = process.argv;
+  const force = argv.includes('--force');
+  const all = argv.includes('--all');
+  const sampleArg = argv.indexOf('--sample');
+  const sampleN = sampleArg !== -1 ? parseInt(argv[sampleArg + 1] || '3', 10) : 0;
+  const limArg = argv.indexOf('--limit');
+  const limit = limArg !== -1 ? parseInt(argv[limArg + 1] || '0', 10) : 0;
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('⛔ ANTHROPIC_API_KEY is not set. Run on Render where the key exists.');
+    process.exit(1);
+  }
+
+  const seedUser = await prisma.user.findUnique({ where: { email: DIRECTORY_UNCLAIMED_EMAIL } });
+  const seedOperator = seedUser ? await prisma.operator.findUnique({ where: { userId: seedUser.id } }) : null;
+  if (!seedOperator) {
+    console.error('⛔ directory sentinel operator not found.');
+    process.exit(1);
+  }
+
+  const homes = await prisma.assistedLivingHome.findMany({
+    where: { operatorId: seedOperator.id, status: 'ACTIVE' },
+    select: {
+      id: true, name: true, description: true, careLevel: true, capacity: true,
+      preFilledFields: true,
+      address: { select: { city: true, state: true } },
+    },
+    orderBy: { name: 'asc' },
+  });
+
+  // Target filter: sparse-by-default (short OR previously AI_PUBLIC_DATA), unless --all.
+  const isTarget = (h: (typeof homes)[number]) => {
+    if (all) return true;
+    const prov = (h.preFilledFields as Record<string, unknown> | null)?.description;
+    return wordCount(h.description) < SPARSE_WORD_THRESHOLD || prov === 'AI_PUBLIC_DATA';
+  };
+  let targets = homes.filter(isTarget);
+  if (limit > 0) targets = targets.slice(0, limit);
+
+  const mode = sampleN > 0 ? `SAMPLE ${sampleN} (no writes)` : force ? 'LIVE (--force)' : 'DRY COUNT';
+  console.log(`\n=== Unclaimed description enrichment — ${mode} ===`);
+  console.log(`Unclaimed ACTIVE homes: ${homes.length} | targets (${all ? 'all' : 'sparse'}): ${targets.length}\n`);
+
+  if (sampleN === 0 && !force) {
+    console.log('DRY COUNT only. Re-run with --sample 3 to preview, or --force to write.');
+    return;
+  }
+
+  const toProcess = sampleN > 0 ? targets.slice(0, sampleN) : targets;
+  let written = 0, tokIn = 0, tokOut = 0;
+
+  for (const h of toProcess) {
+    const county = countyForCity(h.address?.city, h.address?.state);
+    const facts: UnclaimedFacts = {
+      name: h.name,
+      city: h.address?.city ?? null,
+      state: h.address?.state ?? null,
+      county,
+      careLevel: Array.isArray(h.careLevel) ? (h.careLevel as string[]) : [],
+      capacity: h.capacity ?? null,
+    };
+
+    let gen;
+    try {
+      gen = await generateUnclaimedDescription(facts);
+    } catch (e: any) {
+      console.log(`  ✗ ${h.name}: generation failed — ${String(e?.message ?? e)}`);
+      continue;
+    }
+    tokIn += gen.tokensIn;
+    tokOut += gen.tokensOut;
+
+    if (sampleN > 0) {
+      console.log(`──────── ${h.name} ────────`);
+      console.log(`facts: ${facts.city ?? '?'}${county ? `, ${county} County` : ''} | ${facts.careLevel.join('+') || '—'} | cap ${facts.capacity ?? '?'}`);
+      console.log(`[${gen.wordCount} words]\n${gen.description}\n`);
+      continue;
+    }
+
+    // LIVE write: description + provenance tag (merge, preserve other keys).
+    const prevPff = (h.preFilledFields && typeof h.preFilledFields === 'object'
+      ? h.preFilledFields : {}) as Record<string, unknown>;
+    await prisma.assistedLivingHome.update({
+      where: { id: h.id },
+      data: {
+        description: gen.description,
+        preFilledFields: { ...prevPff, description: 'AI_PUBLIC_DATA' },
+      },
+    });
+    written++;
+    if (written % 10 === 0) console.log(`  …${written} written`);
+  }
+
+  const cost = tokIn * COST_IN + tokOut * COST_OUT;
+  console.log('\n─────────────────────────────────────────────');
+  if (sampleN > 0) {
+    console.log(`Sample of ${toProcess.length} generated (NO writes). Approve the voice, then run --force.`);
+  } else {
+    console.log(`Written: ${written}/${toProcess.length}`);
+  }
+  console.log(`Tokens: in ${tokIn}, out ${tokOut} | est. cost $${cost.toFixed(3)}`);
+}
+
+main()
+  .catch((e) => { console.error('ERROR:', e); process.exit(1); })
+  .finally(async () => { await prisma.$disconnect(); });

--- a/src/lib/profile-generator/unclaimed-description-generator.ts
+++ b/src/lib/profile-generator/unclaimed-description-generator.ts
@@ -1,0 +1,147 @@
+/**
+ * Honest, facts-only description generator for UNCLAIMED directory listings.
+ *
+ * Distinct from `generateHomeProfile` (operator marketing copy, which permits
+ * inventive/aspirational phrasing). This generator is HARD-CONSTRAINED: it may
+ * use ONLY verified public facts about the specific community (name, city,
+ * county, care level, capacity) plus GENERAL context about what the care level
+ * typically provides and general local geography. It must NEVER fabricate
+ * facility-specific amenities, pricing, staff, awards, features, or reviews.
+ *
+ * Output: 90–140 words, warm + factual + SEO (city, county, care type), ending
+ * with a "reflects public licensing records … operator can claim …" line + a
+ * tour/inquiry CTA. Written so it can be cleanly overwritten when an operator
+ * claims the listing (tag the description field as AI_PUBLIC_DATA provenance).
+ */
+
+import { getAnthropicClient } from '@/lib/ai/claude';
+
+export interface UnclaimedFacts {
+  name: string;
+  city: string | null;
+  state: string | null;
+  /** Derived (city→county) — may be null when unknown; then it's simply omitted. */
+  county: string | null;
+  /** Raw CareLevel[] enum values, e.g. ['ASSISTED','MEMORY_CARE']. */
+  careLevel: string[];
+  /** Licensed capacity (bed count) if known. */
+  capacity: number | null;
+}
+
+export interface GeneratedUnclaimedDescription {
+  description: string;
+  wordCount: number;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/** Greater-Cleveland city → county. Best-effort; unknown cities omit county (never guess). */
+const CITY_COUNTY: Record<string, string> = {
+  // Cuyahoga
+  'cleveland': 'Cuyahoga', 'lakewood': 'Cuyahoga', 'parma': 'Cuyahoga', 'parma heights': 'Cuyahoga',
+  'westlake': 'Cuyahoga', 'rocky river': 'Cuyahoga', 'bay village': 'Cuyahoga', 'fairview park': 'Cuyahoga',
+  'north olmsted': 'Cuyahoga', 'brook park': 'Cuyahoga', 'middleburg heights': 'Cuyahoga', 'strongsville': 'Cuyahoga',
+  'brecksville': 'Cuyahoga', 'broadview heights': 'Cuyahoga', 'independence': 'Cuyahoga', 'solon': 'Cuyahoga',
+  'beachwood': 'Cuyahoga', 'shaker heights': 'Cuyahoga', 'cleveland heights': 'Cuyahoga', 'university heights': 'Cuyahoga',
+  'south euclid': 'Cuyahoga', 'lyndhurst': 'Cuyahoga', 'mayfield heights': 'Cuyahoga', 'highland heights': 'Cuyahoga',
+  'gates mills': 'Cuyahoga', 'pepper pike': 'Cuyahoga', 'orange': 'Cuyahoga', 'bedford': 'Cuyahoga',
+  'bedford heights': 'Cuyahoga', 'maple heights': 'Cuyahoga', 'garfield heights': 'Cuyahoga', 'north royalton': 'Cuyahoga',
+  'berea': 'Cuyahoga', 'olmsted falls': 'Cuyahoga', 'euclid': 'Cuyahoga', 'richmond heights': 'Cuyahoga',
+  'chagrin falls': 'Cuyahoga',
+  // Summit
+  'akron': 'Summit', 'cuyahoga falls': 'Summit', 'stow': 'Summit', 'hudson': 'Summit', 'twinsburg': 'Summit',
+  'macedonia': 'Summit', 'tallmadge': 'Summit', 'munroe falls': 'Summit', 'fairlawn': 'Summit', 'copley': 'Summit',
+  'green': 'Summit', 'barberton': 'Summit', 'northfield': 'Summit', 'sagamore hills': 'Summit',
+  // Medina
+  'medina': 'Medina', 'wadsworth': 'Medina', 'brunswick': 'Medina', 'hinckley': 'Medina', 'seville': 'Medina',
+  // Lorain
+  'lorain': 'Lorain', 'elyria': 'Lorain', 'avon': 'Lorain', 'avon lake': 'Lorain', 'north ridgeville': 'Lorain',
+  'amherst': 'Lorain', 'oberlin': 'Lorain', 'sheffield lake': 'Lorain', 'sheffield village': 'Lorain',
+  // Lake
+  'mentor': 'Lake', 'willoughby': 'Lake', 'willoughby hills': 'Lake', 'eastlake': 'Lake', 'wickliffe': 'Lake',
+  'painesville': 'Lake', 'mentor-on-the-lake': 'Lake', 'kirtland': 'Lake', 'concord': 'Lake',
+  // Geauga
+  'chardon': 'Geauga', 'chesterland': 'Geauga', 'burton': 'Geauga', 'middlefield': 'Geauga', 'newbury': 'Geauga',
+  'bainbridge': 'Geauga',
+  // Portage
+  'kent': 'Portage', 'ravenna': 'Portage', 'streetsboro': 'Portage', 'aurora': 'Portage', 'brimfield': 'Portage',
+};
+
+/** Look up a Greater-Cleveland county for a city, or null when not confidently known. */
+export function countyForCity(city: string | null | undefined, state: string | null | undefined): string | null {
+  if (!city) return null;
+  if (state && !['oh', 'ohio'].includes(state.toLowerCase())) return null;
+  return CITY_COUNTY[city.trim().toLowerCase()] ?? null;
+}
+
+const CARE_LABELS: Record<string, string> = {
+  ASSISTED: 'assisted living',
+  MEMORY_CARE: 'memory care',
+  INDEPENDENT: 'independent living',
+  SKILLED_NURSING: 'skilled nursing',
+};
+
+function readableCareLevels(levels: string[]): string {
+  const mapped = levels.map((l) => CARE_LABELS[l]).filter(Boolean);
+  if (mapped.length === 0) return 'senior care';
+  if (mapped.length === 1) return mapped[0];
+  if (mapped.length === 2) return `${mapped[0]} and ${mapped[1]}`;
+  return `${mapped.slice(0, -1).join(', ')}, and ${mapped[mapped.length - 1]}`;
+}
+
+const SYSTEM_PROMPT = `You write short, HONEST directory descriptions for senior-living communities in Greater Cleveland, Ohio.
+You are given ONLY verified public facts about one specific community, plus your own general knowledge of care types and local geography.
+
+ABSOLUTE RULES — violate none:
+1. Use ONLY the facts provided. NEVER invent or imply facility-SPECIFIC amenities, pricing, staff, programs, awards, features, room types, dining, or reviews for THIS community. If a detail is not in the facts, do not mention it.
+2. You MAY add GENERAL, clearly non-specific context: what the stated care level(s) TYPICALLY provide, and general facts about the named city/county/area (e.g., proximity to highways or hospitals). Frame these as general context, never as specific claims about this community.
+3. Never state a number (capacity, price, year, ratio) you were not given.
+4. Tone: warm, factual, plain. No marketing superlatives (no "luxurious", "premier", "best", "state-of-the-art"). No markdown, no headings, third person.
+5. Length: 90–140 words.
+6. Naturally include the city, the county (if provided), and the care type — for local SEO.
+7. END with: one sentence stating the listing reflects public licensing records and that the operator can claim it to add photos, current pricing, and verified details — immediately followed by a short tour/inquiry call to action.`;
+
+function buildUserPrompt(f: UnclaimedFacts): string {
+  const careText = readableCareLevels(f.careLevel);
+  const lines = [
+    `Name: ${f.name}`,
+    `City: ${f.city ?? 'unknown'}`,
+    f.county ? `County: ${f.county} County` : `County: (unknown — do not state a county)`,
+    `State: ${f.state ?? 'OH'}`,
+    `Care level(s): ${careText}`,
+    f.capacity && f.capacity > 0
+      ? `Licensed capacity: ${f.capacity} residents (Ohio Department of Health)`
+      : `Licensed capacity: (unknown — do not state a number)`,
+  ];
+  return `Write the description for this community using ONLY these facts plus general care-level/area context:
+
+${lines.join('\n')}
+
+Remember: 90–140 words; include city${f.county ? ', county' : ''}, and care type; never invent specific amenities/pricing/staff/awards; end with the public-records + claim line and a tour/inquiry CTA.`;
+}
+
+/**
+ * Generate one honest, facts-only description. Throws if ANTHROPIC_API_KEY is unset
+ * (callers should ensure it's present — this is a Render/server-side script tool).
+ */
+export async function generateUnclaimedDescription(facts: UnclaimedFacts): Promise<GeneratedUnclaimedDescription> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY is required to generate descriptions');
+  }
+  const client = getAnthropicClient();
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 400,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: buildUserPrompt(facts) }],
+  });
+
+  const block = response.content[0];
+  const description = block && block.type === 'text' ? block.text.trim() : '';
+  return {
+    description,
+    wordCount: description ? description.split(/\s+/).length : 0,
+    tokensIn: response.usage.input_tokens,
+    tokensOut: response.usage.output_tokens,
+  };
+}


### PR DESCRIPTION
**Enrichment item #2.** A NEW generator — **not** `generateHomeProfile` (that one permits inventive marketing copy, which you explicitly ruled out).

### Hard constraints (honest-by-design)
- Uses **only known facts**: name, city, county (derived), care level(s), capacity.
- May add **general** care-level context ("communities at this level typically provide…") and general local geography (highways/hospitals) — clearly non-specific.
- **Never** invents facility-specific amenities, pricing, staff, awards, features, or reviews. Never states a number it wasn't given.
- 90–140 words, warm + factual, no marketing superlatives, SEO (city/county/care type), closing with the public-records + "operator can claim…" line + tour/inquiry CTA — modeled on your East Park bar.

### Files
- `src/lib/profile-generator/unclaimed-description-generator.ts` — generator + a Greater-Cleveland **city→county** map (omits county when a city isn't known; never guesses).
- `scripts/enrich-unclaimed-descriptions.ts` — Render script:
  - `--sample 3` → **preview only, no writes** (your voice-check gate)
  - `--force` → writes the description + tags `preFilledFields.description='AI_PUBLIC_DATA'` so it's identifiable and **cleanly overwritten on claim**
  - Defaults to **sparse** homes (<50 words) so a good website-extracted description is never clobbered; `--all` overrides.

### Gate
No full run happens until you approve the voice. After this merges, run:
```
npx tsx scripts/enrich-unclaimed-descriptions.ts --sample 3
```
and paste the 3 outputs — that's deliverable **(b)**.

`tsc --noEmit`: 0 errors. Generator only; no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_