### PR TITLE
feat(homes): warmer, honest empty states for amenities & pricing (enrich 3)

### DIFF
--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -54,6 +54,22 @@ const SimpleMap = dynamic(
   { ssr: false }
 );
 
+// Readable care-level phrase for GENERAL (clearly non-facility-specific) empty-state copy.
+const CARE_LEVEL_WORDS: Record<string, string> = {
+  ASSISTED: "assisted living",
+  MEMORY_CARE: "memory care",
+  INDEPENDENT: "independent living",
+  SKILLED_NURSING: "skilled nursing",
+};
+function careLevelPhrase(levels: unknown): string {
+  const arr = Array.isArray(levels) ? (levels as string[]) : [];
+  const mapped = arr.map((l) => CARE_LEVEL_WORDS[l]).filter(Boolean);
+  if (mapped.length === 0) return "senior care";
+  if (mapped.length === 1) return mapped[0];
+  if (mapped.length === 2) return `${mapped[0]} and ${mapped[1]}`;
+  return `${mapped.slice(0, -1).join(", ")}, and ${mapped[mapped.length - 1]}`;
+}
+
 // Mock data for a single home
 const MOCK_HOME = {
   id: "home_1",
@@ -981,7 +997,21 @@ export default function HomeDetailPage() {
                       )}
                     </div>
                   ) : (
-                    <div className="rounded-lg border border-neutral-200 bg-white p-6 text-neutral-500">No amenities listed.</div>
+                    <div className="rounded-lg border border-neutral-200 bg-white p-6">
+                      <p className="text-neutral-600">
+                        Specific amenities haven&apos;t been added to this listing yet. Communities offering{" "}
+                        {careLevelPhrase(realHome.careLevel)} typically provide assistance with daily living,
+                        meals, housekeeping, and social activities — though offerings vary by community.
+                      </p>
+                      {realHome.unclaimed && (
+                        <a
+                          href="/auth/register?role=OPERATOR"
+                          className="mt-3 inline-flex items-center rounded-md border border-primary-600 px-3 py-1.5 text-sm font-semibold text-primary-700 hover:bg-primary-50"
+                        >
+                          Claim this listing to add verified amenities
+                        </a>
+                      )}
+                    </div>
                   )}
                 </div>
 
@@ -1016,7 +1046,23 @@ export default function HomeDetailPage() {
                         </div>
                       </>
                     ) : (
-                      <p className="text-neutral-600">Contact the facility directly for current pricing.</p>
+                      <div>
+                        <p className="font-medium text-neutral-700">Pricing isn&apos;t published for this listing yet.</p>
+                        <p className="mt-1 text-sm text-neutral-600">
+                          Monthly costs depend on care level, room type, and the services each resident needs.
+                          {realHome.unclaimed
+                            ? " Operators can add current pricing by claiming this free listing."
+                            : " Contact the community for a current quote."}
+                        </p>
+                        {realHome.unclaimed && (
+                          <a
+                            href="/auth/register?role=OPERATOR"
+                            className="mt-3 inline-flex items-center rounded-md border border-primary-600 px-3 py-1.5 text-sm font-semibold text-primary-700 hover:bg-primary-50"
+                          >
+                            Claim this listing to add pricing
+                          </a>
+                        )}
+                      </div>
                     )}
                     {/* Financing CTA */}
                     <div className="mt-4 rounded-lg bg-amber-50 border border-amber-200 p-4 flex items-start gap-3">


### PR DESCRIPTION
**Enrichment item #3.** Replaces two bare empty states on `/homes/[id]` with warmer, **honest** copy + a claim CTA on unclaimed listings.

### Amenities (was: "No amenities listed.")
> Specific amenities haven't been added to this listing yet. Communities offering **{care level}** typically provide assistance with daily living, meals, housekeeping, and social activities — though offerings vary by community.

Clearly labeled as **general/typical** ("typically", "vary by community") — never asserted as this facility's specific amenities. Unclaimed → **"Claim this listing to add verified amenities"**.

### Pricing (was: "Contact the facility directly for current pricing.")
> Pricing isn't published for this listing yet. Monthly costs depend on care level, room type, and the services each resident needs.

**No invented price numbers.** Unclaimed → "Operators can add current pricing by claiming this free listing" + CTA; claimed → "Contact the community for a current quote." Existing tour + financing CTAs untouched.

### Honest-by-design
- General info is explicitly framed as typical/varies, not facility-specific.
- Reuses the existing `realHome.unclaimed` flag + `/auth/register?role=OPERATOR` claim link.
- Small top-level `careLevelPhrase()` helper.

`tsc --noEmit`: 0 errors. UI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_