### PR TITLE
feat(directory): Google rating trust badge (enrich 4)

### DIFF
--- a/prisma/migrations/20260626000002_home_google_rating/migration.sql
+++ b/prisma/migrations/20260626000002_home_google_rating/migration.sql
@@ -1,0 +1,7 @@
+-- Google Places aggregate rating for the "See reviews on Google" trust badge.
+-- Additive + idempotent. Stores rating + review count + place id ONLY — never
+-- review text (Google Maps Platform ToS). Populated by backfill-google-ratings.ts.
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "googleRating" DOUBLE PRECISION;
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "googleRatingCount" INTEGER;
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "googlePlaceId" TEXT;
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "googleRatingUpdatedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -526,6 +526,13 @@ model AssistedLivingHome {
   autoPopulatedVersion    Int?             @default(0)
   preFilledFields         Json?
   aiPopulationConfidence  String?
+  // Google Places aggregate rating for a "See reviews on Google" trust badge.
+  // Rating + review count + place id ONLY — NO review text is stored (Maps ToS).
+  // Populated by scripts/backfill-google-ratings.ts; badge hidden when null.
+  googleRating            Float?
+  googleRatingCount       Int?
+  googlePlaceId           String?
+  googleRatingUpdatedAt   DateTime?
   // Public listing contact + marketing fields populated by the enrich pipeline
   // (OL-080). Distinct from outreachEmail/outreachPhone below, which are the
   // unclaimed-listing nudge channel, not public display.

--- a/scripts/backfill-google-ratings.ts
+++ b/scripts/backfill-google-ratings.ts
@@ -1,0 +1,138 @@
+/**
+ * backfill-google-ratings.ts
+ *
+ * Populate the Google Places aggregate rating fields used by the "See reviews on
+ * Google" trust badge: googleRating, googleRatingCount, googlePlaceId,
+ * googleRatingUpdatedAt. ONE Places (New) Text Search per home; writes only on a
+ * confident name/city match (so a wrong nearby business never lands a rating).
+ *
+ * Stores rating + count + place id ONLY. NEVER stores Google review TEXT (Maps
+ * Platform ToS). Idempotent / refreshable: re-running updates the numbers.
+ *
+ * Dry-run by default. Cost ≈ ~$5 for ~144 homes (Places "Enterprise" SKU), inside
+ * Google's $200/mo Maps free credit.
+ *
+ * Usage (Render shell — DATABASE_URL + GOOGLE_PLACES_API_KEY):
+ *   npx tsx scripts/backfill-google-ratings.ts             # DRY RUN
+ *   npx tsx scripts/backfill-google-ratings.ts --force      # write
+ *   npx tsx scripts/backfill-google-ratings.ts --limit 10 --force
+ *   npx tsx scripts/backfill-google-ratings.ts --all-active --force  # every ACTIVE home
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { nameMatchScore } from '../src/lib/place-lookup';
+
+const prisma = new PrismaClient();
+
+const DIRECTORY_UNCLAIMED_EMAIL = 'directory-unclaimed@carelinkai.system';
+const PLACES_SEARCH_URL = 'https://places.googleapis.com/v1/places:searchText';
+const REQUEST_TIMEOUT_MS = 10_000;
+
+type Hit = { placeId: string | null; name: string | null; rating: number | null; count: number | null; matchScore: number; cityMatch: boolean };
+
+async function lookup(name: string, city: string | null, state: string | null, apiKey: string): Promise<Hit | null> {
+  const textQuery = `${name} assisted living ${[city, state].filter(Boolean).join(' ')}`.trim();
+  let res: Response;
+  try {
+    res = await fetch(PLACES_SEARCH_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Goog-Api-Key': apiKey,
+        'X-Goog-FieldMask': 'places.id,places.displayName,places.formattedAddress,places.rating,places.userRatingCount',
+      },
+      body: JSON.stringify({ textQuery, maxResultCount: 5, regionCode: 'US' }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (e: any) {
+    console.log(`   ⚠ network error for "${name}": ${String(e?.message ?? e)}`);
+    return null;
+  }
+  if (!res.ok) { console.log(`   ⚠ HTTP ${res.status} for "${name}"`); return null; }
+  const data = (await res.json()) as { places?: Array<{ id?: string; displayName?: { text?: string }; formattedAddress?: string; rating?: number; userRatingCount?: number }> };
+  const places = Array.isArray(data.places) ? data.places : [];
+  if (places.length === 0) return null;
+
+  let best: Hit | null = null;
+  for (const p of places) {
+    const matchedName = p.displayName?.text ?? null;
+    const addr = p.formattedAddress ?? '';
+    const score = matchedName ? nameMatchScore(name, matchedName) : 0;
+    const cityMatch = !!city && addr.toLowerCase().includes(city.toLowerCase());
+    if (!best || score > best.matchScore) {
+      best = { placeId: p.id ?? null, name: matchedName, rating: p.rating ?? null, count: p.userRatingCount ?? null, matchScore: score, cityMatch };
+    }
+  }
+  return best;
+}
+
+async function main() {
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) { console.error('⛔ GOOGLE_PLACES_API_KEY not set. Run on Render.'); process.exit(1); }
+  const force = process.argv.includes('--force');
+  const allActive = process.argv.includes('--all-active');
+  const limArg = process.argv.indexOf('--limit');
+  const limit = limArg !== -1 ? parseInt(process.argv[limArg + 1] || '0', 10) : 0;
+
+  let operatorFilter = {};
+  if (!allActive) {
+    const seedUser = await prisma.user.findUnique({ where: { email: DIRECTORY_UNCLAIMED_EMAIL } });
+    const seedOperator = seedUser ? await prisma.operator.findUnique({ where: { userId: seedUser.id } }) : null;
+    if (!seedOperator) { console.error('⛔ directory sentinel operator not found. Use --all-active.'); process.exit(1); }
+    operatorFilter = { operatorId: seedOperator.id };
+  }
+
+  const homes = await prisma.assistedLivingHome.findMany({
+    where: { status: 'ACTIVE', ...operatorFilter },
+    select: { id: true, name: true, address: { select: { city: true, state: true } } },
+    orderBy: { name: 'asc' },
+    ...(limit > 0 ? { take: limit } : {}),
+  });
+
+  console.log(`\n=== Backfill Google ratings — ${force ? 'LIVE (--force)' : 'DRY RUN'} ===`);
+  console.log(`Scanning ${homes.length} ACTIVE ${allActive ? '' : 'directory '}home(s)…\n`);
+
+  const confident = (h: Hit) => h.matchScore >= 0.6 || (h.matchScore >= 0.34 && h.cityMatch);
+  let written = 0, rated = 0, weak = 0, none = 0, cleared = 0;
+
+  for (const h of homes) {
+    const hit = await lookup(h.name, h.address?.city ?? null, h.address?.state ?? null, apiKey);
+    if (!hit) { none++; console.log(`  ✗ ${h.name} — no candidate`); continue; }
+    if (!confident(hit)) { weak++; console.log(`  ~ ${h.name} — weak match ("${hit.name}", ${hit.matchScore.toFixed(2)}) — skip`); continue; }
+
+    if (hit.rating != null && hit.count != null && hit.count > 0 && hit.placeId) {
+      rated++;
+      console.log(`  ★ ${h.name} — ${hit.rating}★ (${hit.count}) [${hit.placeId}]`);
+      if (force) {
+        await prisma.assistedLivingHome.update({
+          where: { id: h.id },
+          data: {
+            googleRating: hit.rating,
+            googleRatingCount: hit.count,
+            googlePlaceId: hit.placeId,
+            googleRatingUpdatedAt: new Date(),
+          },
+        });
+        written++;
+      }
+    } else {
+      // Matched but Google has no rating → clear any stale value so we never show a wrong number.
+      console.log(`  ○ ${h.name} — matched "${hit.name}" but no rating`);
+      if (force) {
+        await prisma.assistedLivingHome.update({
+          where: { id: h.id },
+          data: { googleRating: null, googleRatingCount: null, googleRatingUpdatedAt: new Date(), googlePlaceId: hit.placeId ?? undefined },
+        });
+        cleared++;
+      }
+    }
+  }
+
+  console.log('\n─────────────────────────────────────────────');
+  console.log(`Rated matches: ${rated} | weak: ${weak} | no candidate: ${none}`);
+  console.log(force ? `Written: ${written} ratings, ${cleared} cleared` : 'DRY RUN — re-run with --force to write.');
+}
+
+main()
+  .catch((e) => { console.error('ERROR:', e); process.exit(1); })
+  .finally(async () => { await prisma.$disconnect(); });

--- a/src/app/api/homes/[id]/route.ts
+++ b/src/app/api/homes/[id]/route.ts
@@ -253,6 +253,10 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
       reviewCount: ratings.length,
       isFavorited,
       unclaimed,
+      // Google aggregate rating (trust badge) — rating + count + place id only, no review text.
+      googleRating: home.googleRating ?? null,
+      googleRatingCount: home.googleRatingCount ?? null,
+      googlePlaceId: home.googlePlaceId ?? null,
       pendingInquiryCount,
     };
 

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -486,6 +486,9 @@ export function generateMockHomes(count: number = 12) {
       aiMatchWeights: undefined,
       isFavorited: false,
       isUnclaimed: false,
+      googleRating: null,
+      googleRatingCount: null,
+      googlePlaceId: null,
     };
   });
 }
@@ -821,6 +824,10 @@ export async function GET(request: NextRequest) {
         // — surfaced in results so the seeded directory shows, badged so families
         // know no operator manages it yet.
         isUnclaimed: unclaimed,
+        // Google aggregate rating (trust badge) — rating + count + place id only.
+        googleRating: home.googleRating ?? null,
+        googleRatingCount: home.googleRatingCount ?? null,
+        googlePlaceId: home.googlePlaceId ?? null,
         aiMatchScore,
         aiMatchFactors,
         aiMatchWeights,

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -43,6 +43,7 @@ import TourRequestModal from "@/components/tours/TourRequestModal";
 // Import our new components
 import PhotoGallery from "@/components/homes/PhotoGallery";
 import { placeholderImageFor } from "@/lib/placeholder-images";
+import GoogleRatingBadge from "@/components/homes/GoogleRatingBadge";
 import PricingCalculator from "@/components/homes/PricingCalculator";
 import type { PricingEstimate } from "@/components/homes/PricingCalculator";
 import { getCloudinaryAvatar, isCloudinaryUrl } from "@/lib/cloudinaryUrl";
@@ -833,6 +834,15 @@ export default function HomeDetailPage() {
                         <FiMapPin className="mr-1 h-4 w-4 text-neutral-500" />
                         <span className="text-sm text-neutral-600">{addrText}</span>
                       </div>
+                      {realHome.googleRating != null && (
+                        <div className="mt-1.5">
+                          <GoogleRatingBadge
+                            rating={realHome.googleRating}
+                            count={realHome.googleRatingCount}
+                            placeId={realHome.googlePlaceId}
+                          />
+                        </div>
+                      )}
                       {realHome.phone && (
                         <div className="mt-1 flex items-center">
                           <FiPhone className="mr-1 h-4 w-4 text-neutral-500" />

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/lib/searchService";
 import { MOCK_HOMES } from "@/lib/mock/homes";
 import { formatCurrency } from "@/lib/utils";
+import GoogleRatingBadge from "@/components/homes/GoogleRatingBadge";
 import {
   getFavorites,
   toggleFavorite,
@@ -1088,6 +1089,11 @@ function SearchPageContent() {
                           <p className="mb-1 text-sm text-neutral-600">
                             {home.address?.city}, {home.address?.state}
                           </p>
+                          {home.googleRating != null && (
+                            <p className="mb-1">
+                              <GoogleRatingBadge rating={home.googleRating} count={home.googleRatingCount} compact />
+                            </p>
+                          )}
                           {!home.isUnclaimed && home.tagline && (
                             <p className="mb-2 line-clamp-1 text-xs italic text-neutral-500">{home.tagline}</p>
                           )}
@@ -1247,10 +1253,15 @@ function SearchPageContent() {
                             <div>
                               <h3 className="text-lg font-medium text-neutral-800">{home.name}</h3>
                               <p className="text-sm text-neutral-600">
-                                {home.address ? 
-                                  `${home.address.street}, ${home.address.city}, ${home.address.state} ${home.address.zipCode}` : 
+                                {home.address ?
+                                  `${home.address.street}, ${home.address.city}, ${home.address.state} ${home.address.zipCode}` :
                                   "Address not available"}
                               </p>
+                              {home.googleRating != null && (
+                                <p className="mt-1">
+                                  <GoogleRatingBadge rating={home.googleRating} count={home.googleRatingCount} compact />
+                                </p>
+                              )}
                             </div>
                           </div>
 

--- a/src/components/homes/GoogleRatingBadge.tsx
+++ b/src/components/homes/GoogleRatingBadge.tsx
@@ -1,0 +1,60 @@
+import { FiStar, FiExternalLink } from 'react-icons/fi';
+
+interface GoogleRatingBadgeProps {
+  rating: number | null | undefined;
+  count: number | null | undefined;
+  placeId?: string | null;
+  /** Compact = card variant (attribution only, no link — keeps traffic on-site). */
+  compact?: boolean;
+  className?: string;
+}
+
+/**
+ * Google aggregate-rating trust badge. Rating + review count + attribution only —
+ * NEVER review text (Maps Platform ToS). Hidden entirely when there's no rating
+ * (never seeded/faked). Secondary to the inquiry/tour CTA: the card variant is
+ * non-interactive (no off-site link); the full variant adds a "See reviews on
+ * Google" link, opened in a new tab.
+ */
+export default function GoogleRatingBadge({ rating, count, placeId, compact = false, className = '' }: GoogleRatingBadgeProps) {
+  if (rating == null || !count || count <= 0) return null;
+
+  const stars = (
+    <span className="inline-flex items-center font-semibold text-neutral-800">
+      <FiStar className="mr-0.5 h-3.5 w-3.5 fill-amber-400 text-amber-400" />
+      {rating.toFixed(1)}
+    </span>
+  );
+
+  if (compact) {
+    return (
+      <span className={`inline-flex items-center gap-1 text-xs text-neutral-600 ${className}`}>
+        {stars}
+        <span className="text-neutral-500">({count})</span>
+        <span className="text-neutral-400">· Google</span>
+      </span>
+    );
+  }
+
+  const reviewsUrl = placeId
+    ? `https://search.google.com/local/reviews?placeid=${encodeURIComponent(placeId)}`
+    : null;
+
+  return (
+    <span className={`inline-flex items-center gap-1.5 text-sm text-neutral-600 ${className}`}>
+      {stars}
+      <span className="text-neutral-500">{count} Google {count === 1 ? 'review' : 'reviews'}</span>
+      {reviewsUrl && (
+        <a
+          href={reviewsUrl}
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+          className="inline-flex items-center text-primary-600 hover:text-primary-700 hover:underline"
+        >
+          See reviews on Google
+          <FiExternalLink className="ml-0.5 h-3.5 w-3.5" />
+        </a>
+      )}
+    </span>
+  );
+}

--- a/src/lib/searchService.ts
+++ b/src/lib/searchService.ts
@@ -109,6 +109,10 @@ export interface SearchResultItem {
   isFavorited?: boolean;
   /** True when the listing is still directory-owned (no operator has claimed it) */
   isUnclaimed?: boolean;
+  /** Google aggregate rating (trust badge). Rating + count + place id only — no review text. */
+  googleRating?: number | null;
+  googleRatingCount?: number | null;
+  googlePlaceId?: string | null;
 }
 
 /**


### PR DESCRIPTION
**Enrichment item #4**, greenlit by the #644 coverage check (~90% of directory homes have a Google rating, avg 4.24★, median 43 reviews).

**Rating + review count + place id ONLY — never review text** (Google Maps Platform ToS).

### Schema (additive, idempotent migration `20260626000002`)
`googleRating Float?`, `googleRatingCount Int?`, `googlePlaceId String?`, `googleRatingUpdatedAt DateTime?` on `AssistedLivingHome`.

### Capture — `scripts/backfill-google-ratings.ts`
One Places Text Search per ACTIVE directory home; writes **only on a confident name/city match**; clears any stale value when Google has no rating. Dry-run default, `--force` to write, `--limit`/`--all-active`. ~$5/144 inside the Maps free credit. Refreshable.

### Badge — `GoogleRatingBadge`
- **Hidden when no rating** (never seeded/faked).
- **Card variant**: attribution-only (`★ 4.2 (57) · Google`) — no off-site link, keeps traffic on-site.
- **Detail variant**: adds a "See reviews on Google" link (built from `placeId`, `rel="nofollow"`, new tab).
- **Secondary** to the inquiry/tour CTA everywhere.
- Surfaced via `/api/search` (grid + list cards) and `/api/homes/[id]` (detail header).

### Rollout
The badge stays hidden until the capture script runs. After merge → Render auto-deploys (runs the migration) → run on Render:
```
npx tsx scripts/backfill-google-ratings.ts --limit 10        # dry-run preview
npx tsx scripts/backfill-google-ratings.ts --force           # write (~$5)
```

`tsc --noEmit`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_