### PR TITLE
feat(reviews): first-party review backend — earned eligibility + operator response (enrich 5a)

### DIFF
--- a/__tests__/home.reviews.api.test.ts
+++ b/__tests__/home.reviews.api.test.ts
@@ -60,6 +60,12 @@ jest.mock('@/lib/prisma', () => {
       },
       booking: {
         findFirst: jest.fn(),
+      },
+      inquiry: {
+        findFirst: jest.fn(),
+      },
+      tourRequest: {
+        findFirst: jest.fn(),
       }
     }
   };
@@ -320,45 +326,77 @@ describe('Home Reviews API', () => {
       expect(await response.json()).toEqual({ error: "You have already reviewed this home" });
     });
     
-    test('returns 403 when user has no booking with the home', async () => {
+    test('returns 403 when user has not engaged the home (no inquiry/tour/booking)', async () => {
       (getServerSession as jest.Mock).mockResolvedValueOnce({
         user: mockUser,
       });
-      
+
       (prisma.assistedLivingHome.findUnique as jest.Mock).mockResolvedValueOnce(mockHome);
       (prisma.family.findUnique as jest.Mock).mockResolvedValueOnce(mockFamily);
       (prisma.operator.findUnique as jest.Mock).mockResolvedValueOnce(null);
       (prisma.homeReview.findFirst as jest.Mock).mockResolvedValueOnce(null);
       (prisma.booking.findFirst as jest.Mock).mockResolvedValueOnce(null);
-      
+      (prisma.inquiry.findFirst as jest.Mock).mockResolvedValueOnce(null);
+      (prisma.tourRequest.findFirst as jest.Mock).mockResolvedValueOnce(null);
+
       const request = createMockRequest({}, 'POST');
       request.json = jest.fn().mockResolvedValueOnce(validReviewData);
-      
+
       const response = await POST(request);
-      
+
       expect(response.status).toBe(403);
-      expect(await response.json()).toEqual({ error: "You do not have permission to review this home" });
+      expect(await response.json()).toEqual({
+        error: "You can review a community after you've inquired, requested a tour, or booked it through CareLinkAI.",
+      });
     });
-    
-    test('successfully creates a review', async () => {
+
+    test('allows a review from an inquiry (unverified) even without a booking', async () => {
       (getServerSession as jest.Mock).mockResolvedValueOnce({
         user: mockUser,
       });
-      
+
+      (prisma.assistedLivingHome.findUnique as jest.Mock).mockResolvedValueOnce(mockHome);
+      (prisma.family.findUnique as jest.Mock).mockResolvedValueOnce(mockFamily);
+      (prisma.operator.findUnique as jest.Mock).mockResolvedValueOnce(null);
+      (prisma.homeReview.findFirst as jest.Mock).mockResolvedValueOnce(null);
+      (prisma.booking.findFirst as jest.Mock).mockResolvedValueOnce(null);
+      (prisma.inquiry.findFirst as jest.Mock).mockResolvedValueOnce({ id: 'inquiry-1' });
+      (prisma.tourRequest.findFirst as jest.Mock).mockResolvedValueOnce(null);
+      (prisma.homeReview.create as jest.Mock).mockResolvedValueOnce(mockReview);
+
+      const request = createMockRequest({}, 'POST');
+      request.json = jest.fn().mockResolvedValueOnce(validReviewData);
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      // An inquiry/tour reviewer is genuine but NOT a verified stay.
+      expect(prisma.homeReview.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ isVerified: false }),
+      });
+    });
+
+    test('successfully creates a review (booking → verified)', async () => {
+      (getServerSession as jest.Mock).mockResolvedValueOnce({
+        user: mockUser,
+      });
+
       (prisma.assistedLivingHome.findUnique as jest.Mock).mockResolvedValueOnce(mockHome);
       (prisma.family.findUnique as jest.Mock).mockResolvedValueOnce(mockFamily);
       (prisma.operator.findUnique as jest.Mock).mockResolvedValueOnce(null);
       (prisma.homeReview.findFirst as jest.Mock).mockResolvedValueOnce(null);
       (prisma.booking.findFirst as jest.Mock).mockResolvedValueOnce(mockBooking);
+      (prisma.inquiry.findFirst as jest.Mock).mockResolvedValueOnce(null);
+      (prisma.tourRequest.findFirst as jest.Mock).mockResolvedValueOnce(null);
       (prisma.homeReview.create as jest.Mock).mockResolvedValueOnce(mockReview);
-      
+
       const request = createMockRequest({}, 'POST');
       request.json = jest.fn().mockResolvedValueOnce(validReviewData);
-      
+
       const response = await POST(request);
-      
+
       expect(response.status).toBe(200);
-      
+
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.review).toEqual(expect.objectContaining({
@@ -366,14 +404,14 @@ describe('Home Reviews API', () => {
         homeId: mockReview.homeId,
         rating: mockReview.rating,
       }));
-      
-      // Verify create was called with correct data
+
+      // Verify create was called with correct data (a booking → isVerified true)
       expect(prisma.homeReview.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           homeId: mockHomeId,
           reviewerId: mockUser.id,
           rating: validReviewData.rating,
-          isVerified: false,
+          isVerified: true,
         }),
       });
     });

--- a/prisma/migrations/20260627000001_home_review_operator_response/migration.sql
+++ b/prisma/migrations/20260627000001_home_review_operator_response/migration.sql
@@ -1,0 +1,4 @@
+-- First-party reviews: operator public reply to a HomeReview (available after claim).
+-- Additive + idempotent.
+ALTER TABLE "HomeReview" ADD COLUMN IF NOT EXISTS "operatorResponse" TEXT;
+ALTER TABLE "HomeReview" ADD COLUMN IF NOT EXISTS "operatorRespondedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1199,6 +1199,10 @@ model HomeReview {
   content    String?
   isPublic   Boolean            @default(true)
   isVerified Boolean            @default(false)
+  // Operator's public reply to a review — available once the operator has claimed
+  // the listing. A claim incentive ("showcase & respond to reviews").
+  operatorResponse    String?
+  operatorRespondedAt DateTime?
   createdAt  DateTime           @default(now())
   updatedAt  DateTime           @updatedAt
   home       AssistedLivingHome @relation(fields: [homeId], references: [id], onDelete: Cascade)

--- a/src/app/api/reviews/homes/[id]/response/route.ts
+++ b/src/app/api/reviews/homes/[id]/response/route.ts
@@ -1,0 +1,100 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+const responseSchema = z.object({
+  response: z.string().trim().min(1, 'Response cannot be empty').max(2000),
+});
+
+/**
+ * POST /api/reviews/homes/[id]/response
+ *
+ * Operator public reply to a review on their OWN (claimed) home. The session
+ * user must be the operator that owns the reviewed home. Idempotent upsert of
+ * the reply text; stamps operatorRespondedAt.
+ */
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const parsed = responseSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid input', details: parsed.error.format() },
+        { status: 400 },
+      );
+    }
+
+    const review = await prisma.homeReview.findUnique({
+      where: { id: params.id },
+      select: { id: true, home: { select: { operatorId: true } } },
+    });
+    if (!review) {
+      return NextResponse.json({ error: 'Review not found' }, { status: 404 });
+    }
+
+    // Only the operator who owns the (claimed) home may respond.
+    const operator = await prisma.operator.findUnique({
+      where: { userId: session.user.id },
+      select: { id: true },
+    });
+    if (!operator || operator.id !== review.home.operatorId) {
+      return NextResponse.json(
+        { error: 'Only the operator who owns this listing can respond to its reviews.' },
+        { status: 403 },
+      );
+    }
+
+    const updated = await prisma.homeReview.update({
+      where: { id: params.id },
+      data: { operatorResponse: parsed.data.response, operatorRespondedAt: new Date() },
+      select: { id: true, operatorResponse: true, operatorRespondedAt: true },
+    });
+
+    return NextResponse.json({ success: true, review: updated });
+  } catch (error) {
+    console.error('Error saving operator review response:', error);
+    return NextResponse.json({ error: 'Failed to save response' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/reviews/homes/[id]/response — operator removes their reply.
+ */
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const review = await prisma.homeReview.findUnique({
+      where: { id: params.id },
+      select: { id: true, home: { select: { operatorId: true } } },
+    });
+    if (!review) {
+      return NextResponse.json({ error: 'Review not found' }, { status: 404 });
+    }
+    const operator = await prisma.operator.findUnique({
+      where: { userId: session.user.id },
+      select: { id: true },
+    });
+    if (!operator || operator.id !== review.home.operatorId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    await prisma.homeReview.update({
+      where: { id: params.id },
+      data: { operatorResponse: null, operatorRespondedAt: null },
+    });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting operator review response:', error);
+    return NextResponse.json({ error: 'Failed to delete response' }, { status: 500 });
+  }
+}

--- a/src/app/api/reviews/homes/route.ts
+++ b/src/app/api/reviews/homes/route.ts
@@ -76,6 +76,8 @@ export async function GET(request: NextRequest) {
           title: true,
           content: true,
           isVerified: true,
+          operatorResponse: true,
+          operatorRespondedAt: true,
           createdAt: true,
           updatedAt: true
         }
@@ -206,22 +208,24 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Verify permission: user's family must have a booking for this home
-    const hasBooking = await prisma.booking.findFirst({
-      where: {
-        familyId: family.id,
-        homeId
-      }
-    });
+    // Eligibility: the family must have engaged this home via CareLinkAI — an
+    // inquiry, a tour request, or a booking. Reviews are first-party and earned,
+    // not anonymous drive-by ratings.
+    const [hasBooking, hasInquiry, hasTour] = await Promise.all([
+      prisma.booking.findFirst({ where: { familyId: family.id, homeId }, select: { id: true } }),
+      prisma.inquiry.findFirst({ where: { familyId: family.id, homeId }, select: { id: true } }),
+      prisma.tourRequest.findFirst({ where: { familyId: family.id, homeId }, select: { id: true } }),
+    ]);
 
-    if (!hasBooking) {
+    if (!hasBooking && !hasInquiry && !hasTour) {
       return NextResponse.json(
-        { error: "You do not have permission to review this home" },
+        { error: "You can review a community after you've inquired, requested a tour, or booked it through CareLinkAI." },
         { status: 403 }
       );
     }
 
-    // Create the review
+    // Create the review. A booking implies an actual placement → mark verified;
+    // inquiry/tour reviewers are genuine CareLinkAI users but not a verified stay.
     const review = await prisma.homeReview.create({
       data: {
         homeId,
@@ -230,7 +234,7 @@ export async function POST(request: NextRequest) {
         title,
         content,
         isPublic,
-        isVerified: false // Default to unverified
+        isVerified: Boolean(hasBooking)
       }
     });
 


### PR DESCRIPTION
**Enrichment item #5, PR 1 of 3 (backend foundation).** First-party reviews stored on our platform (not third-party). Builds on the existing `HomeReview` model + `/api/reviews/homes` GET/POST.

### Changes
- **Schema** (migration `20260627000001`, additive/idempotent): `HomeReview.operatorResponse` + `operatorRespondedAt` so a **claimed** operator can publicly reply.
- **Eligibility broadened** — `POST /api/reviews/homes` previously required a `Booking`; now accepts **engaged via CareLinkAI = inquiry OR tour request OR booking**. (Most directory families inquire/tour, not "book.") A booking marks the review `isVerified` (actual placement); inquiry/tour reviewers are genuine but not a verified stay. Reviews stay *earned*, not anonymous drive-bys.
- **GET** now returns `operatorResponse` + `operatorRespondedAt`.
- **NEW** `POST`/`DELETE /api/reviews/homes/[id]/response` — operator reply, restricted to the operator that owns the home.

### Next (separate PRs)
- **5b** — detail-page reviews UI: real reviews + "No reviews yet — be the first" empty state + submit form for eligible families + render operator responses.
- **5c** — operator response UI on `/operator/reviews` + "showcase & respond to reviews" claim-pitch incentive.

`tsc --noEmit`: 0 errors. No review text scraped from third parties anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_