### PR TITLE
feat(reviews): first-party reviews on listing detail page (enrich 5b)

### DIFF
--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -44,6 +44,7 @@ import TourRequestModal from "@/components/tours/TourRequestModal";
 import PhotoGallery from "@/components/homes/PhotoGallery";
 import { placeholderImageFor } from "@/lib/placeholder-images";
 import GoogleRatingBadge from "@/components/homes/GoogleRatingBadge";
+import HomeReviews from "@/components/homes/HomeReviews";
 import PricingCalculator from "@/components/homes/PricingCalculator";
 import type { PricingEstimate } from "@/components/homes/PricingCalculator";
 import { getCloudinaryAvatar, isCloudinaryUrl } from "@/lib/cloudinaryUrl";
@@ -1100,6 +1101,11 @@ export default function HomeDetailPage() {
                       </button>
                     </div>
                   </div>
+                </div>
+
+                {/* Reviews (first-party, real data) */}
+                <div ref={reviewsRef} className="mb-8 scroll-mt-20">
+                  <HomeReviews homeId={realHome.id} homeName={realHome.name} />
                 </div>
 
                 {/* Location */}

--- a/src/components/homes/HomeReviews.tsx
+++ b/src/components/homes/HomeReviews.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
+import { FiStar } from 'react-icons/fi';
+
+interface ReviewItem {
+  id: string;
+  rating: number;
+  title: string | null;
+  content: string | null;
+  isVerified: boolean;
+  operatorResponse: string | null;
+  operatorRespondedAt: string | null;
+  createdAt: string;
+}
+
+interface HomeReviewsProps {
+  homeId: string;
+  homeName: string;
+}
+
+function Stars({ rating, className = '' }: { rating: number; className?: string }) {
+  return (
+    <span className={`inline-flex items-center text-amber-500 ${className}`} aria-label={`${rating} out of 5 stars`}>
+      {[1, 2, 3, 4, 5].map((s) => (
+        <FiStar key={s} className={`h-4 w-4 ${s <= Math.round(rating) ? 'fill-current' : 'text-neutral-300'}`} />
+      ))}
+    </span>
+  );
+}
+
+/**
+ * First-party reviews on the listing detail page. Reads real reviews from
+ * /api/reviews/homes, shows a friendly empty state, and lets a logged-in family
+ * who has engaged the home (inquiry/tour/booking) leave one. Operator replies are
+ * shown inline. No third-party review text is ever displayed here.
+ */
+export default function HomeReviews({ homeId, homeName }: HomeReviewsProps) {
+  const { data: session } = useSession();
+  const [reviews, setReviews] = useState<ReviewItem[]>([]);
+  const [stats, setStats] = useState<{ averageRating: number; totalReviews: number }>({ averageRating: 0, totalReviews: 0 });
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+
+  // form state
+  const [rating, setRating] = useState(0);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/reviews/homes?homeId=${encodeURIComponent(homeId)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setReviews(Array.isArray(data.reviews) ? data.reviews : []);
+        if (data.stats) setStats(data.stats);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [homeId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const submit = async () => {
+    setError(null);
+    if (rating < 1) {
+      setError('Please choose a star rating.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/reviews/homes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ homeId, rating, title: title || undefined, content: content || undefined }),
+      });
+      if (res.ok) {
+        setDone(true);
+        setShowForm(false);
+        setRating(0);
+        setTitle('');
+        setContent('');
+        await load();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || 'Could not submit your review.');
+      }
+    } catch {
+      setError('Could not submit your review. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-neutral-800">Reviews</h2>
+        {stats.totalReviews > 0 && (
+          <div className="flex items-center gap-1.5">
+            <Stars rating={stats.averageRating} />
+            <span className="font-semibold text-neutral-800">{stats.averageRating.toFixed(1)}</span>
+            <span className="text-sm text-neutral-500">({stats.totalReviews})</span>
+          </div>
+        )}
+      </div>
+
+      {/* List / empty state */}
+      {loading ? (
+        <p className="text-sm text-neutral-500">Loading reviews…</p>
+      ) : reviews.length === 0 ? (
+        <div className="rounded-lg border border-neutral-200 bg-white p-6 text-center">
+          <p className="font-medium text-neutral-700">No reviews yet — be the first.</p>
+          <p className="mt-1 text-sm text-neutral-500">
+            Have you connected with {homeName} through CareLinkAI? Share your experience to help other families.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {reviews.map((r) => (
+            <div key={r.id} className="rounded-lg border border-neutral-200 bg-white p-5">
+              <div className="mb-2 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Stars rating={r.rating} />
+                  {r.isVerified && (
+                    <span className="rounded-full bg-success-50 px-2 py-0.5 text-xs font-medium text-success-700">Verified family</span>
+                  )}
+                </div>
+                <span className="text-xs text-neutral-400">{new Date(r.createdAt).toLocaleDateString()}</span>
+              </div>
+              {r.title && <p className="font-medium text-neutral-800">{r.title}</p>}
+              {r.content && <p className="mt-1 text-neutral-700">{r.content}</p>}
+              <p className="mt-2 text-xs text-neutral-400">— CareLinkAI member</p>
+
+              {r.operatorResponse && (
+                <div className="mt-3 rounded-md border-l-2 border-primary-300 bg-primary-50 p-3">
+                  <p className="text-xs font-semibold text-primary-800">Response from {homeName}</p>
+                  <p className="mt-0.5 text-sm text-neutral-700">{r.operatorResponse}</p>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Submit */}
+      <div className="mt-5">
+        {done ? (
+          <p className="rounded-md bg-success-50 px-4 py-3 text-sm text-success-700">
+            Thanks for sharing your experience — your review is now live.
+          </p>
+        ) : !session?.user ? (
+          <a href="/auth/login" className="text-sm font-medium text-primary-600 hover:text-primary-700">
+            Log in to write a review →
+          </a>
+        ) : !showForm ? (
+          <button
+            type="button"
+            onClick={() => setShowForm(true)}
+            className="rounded-md border border-primary-600 px-4 py-2 text-sm font-semibold text-primary-700 hover:bg-primary-50"
+          >
+            Write a review
+          </button>
+        ) : (
+          <div className="rounded-lg border border-neutral-200 bg-white p-5">
+            <p className="mb-2 text-sm font-medium text-neutral-700">Your rating</p>
+            <div className="mb-3 flex gap-1">
+              {[1, 2, 3, 4, 5].map((s) => (
+                <button key={s} type="button" onClick={() => setRating(s)} aria-label={`${s} star${s > 1 ? 's' : ''}`}>
+                  <FiStar className={`h-7 w-7 ${s <= rating ? 'fill-amber-400 text-amber-400' : 'text-neutral-300 hover:text-amber-300'}`} />
+                </button>
+              ))}
+            </div>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Title (optional)"
+              className="mb-2 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm"
+              maxLength={120}
+            />
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder={`What was your experience with ${homeName}?`}
+              rows={4}
+              className="mb-3 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm"
+              maxLength={2000}
+            />
+            {error && <p className="mb-2 text-sm text-error-600">{error}</p>}
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={submit}
+                disabled={submitting}
+                className="rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-50"
+              >
+                {submitting ? 'Submitting…' : 'Submit review'}
+              </button>
+              <button type="button" onClick={() => setShowForm(false)} className="text-sm text-neutral-500 hover:text-neutral-700">
+                Cancel
+              </button>
+            </div>
+            <p className="mt-2 text-xs text-neutral-400">
+              You can review a community after you&apos;ve inquired, requested a tour, or booked it through CareLinkAI.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**Enrichment item #5, PR 2 of 3 (family-facing UI).**

The detail page's reviews section was **mock data** that only rendered on the legacy mock-home path — the real listing had no review list. This adds a real one.

### `HomeReviews` component (on the real listing)
- Reads `/api/reviews/homes` — aggregate (★ + count), the review list.
- **Empty state:** "No reviews yet — be the first." with a warm sub-line.
- **Submit:** logged-in families pick a star rating + optional title/content → `POST`. The form explains reviews are earned (inquiry/tour/booking) and surfaces the API's eligibility message on 403. Anonymous → "Log in to write a review".
- **Operator replies** render inline ("Response from <home>").
- **Privacy-safe identity:** "CareLinkAI member" + a "Verified family" badge when the review is tied to a booking. No reviewer PII exposed.
- No third-party review text anywhere.

### Sequencing
Best merged **after 5a (#650)** — full eligibility (inquiry/tour) and operator replies depend on it. Degrades gracefully against the current API until 5a deploys (operator replies simply don't show; submit falls back to the old booking gate).

`tsc --noEmit`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_