### PR TITLE
feat(reviews): operator reply UI + claim incentive (enrich 5c)

### DIFF
--- a/src/app/api/homes/[id]/route.ts
+++ b/src/app/api/homes/[id]/route.ts
@@ -181,6 +181,16 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
       }
     }
 
+    // Is the viewer the operator who owns this (claimed) home? Lets them reply to reviews.
+    let viewerIsOwner = false;
+    if (session?.user?.email) {
+      const viewerUser = await prisma.user.findUnique({
+        where: { email: session.user.email as string },
+        select: { operator: { select: { id: true } } },
+      });
+      viewerIsOwner = Boolean(viewerUser?.operator && viewerUser.operator.id === home.operatorId);
+    }
+
     // Compute rating
     const ratings = home.reviews?.map((r) => r.rating) ?? [];
     const averageRating = ratings.length > 0
@@ -252,6 +262,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
       rating: averageRating,
       reviewCount: ratings.length,
       isFavorited,
+      viewerIsOwner,
       unclaimed,
       // Google aggregate rating (trust badge) — rating + count + place id only, no review text.
       googleRating: home.googleRating ?? null,

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -810,8 +810,8 @@ export default function HomeDetailPage() {
                     <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
                       <p className="text-sm text-neutral-700">
                         {photos.length === 0
-                          ? 'Are you the operator of this community? Claim your free listing to add your photos, manage it, and respond to families.'
-                          : 'Are you the operator of this community? Claim your free listing to manage it and respond to families.'}
+                          ? 'Are you the operator of this community? Claim your free listing to add your photos, showcase & respond to reviews, manage it, and respond to families.'
+                          : 'Are you the operator of this community? Claim your free listing to showcase & respond to reviews, manage it, and respond to families.'}
                       </p>
                       <a
                         href="/auth/register?role=OPERATOR"
@@ -1105,7 +1105,7 @@ export default function HomeDetailPage() {
 
                 {/* Reviews (first-party, real data) */}
                 <div ref={reviewsRef} className="mb-8 scroll-mt-20">
-                  <HomeReviews homeId={realHome.id} homeName={realHome.name} />
+                  <HomeReviews homeId={realHome.id} homeName={realHome.name} canRespond={Boolean(realHome.viewerIsOwner)} />
                 </div>
 
                 {/* Location */}

--- a/src/components/homes/HomeReviews.tsx
+++ b/src/components/homes/HomeReviews.tsx
@@ -18,6 +18,8 @@ interface ReviewItem {
 interface HomeReviewsProps {
   homeId: string;
   homeName: string;
+  /** True when the viewer is the operator who owns this claimed home (can reply). */
+  canRespond?: boolean;
 }
 
 function Stars({ rating, className = '' }: { rating: number; className?: string }) {
@@ -36,8 +38,30 @@ function Stars({ rating, className = '' }: { rating: number; className?: string 
  * who has engaged the home (inquiry/tour/booking) leave one. Operator replies are
  * shown inline. No third-party review text is ever displayed here.
  */
-export default function HomeReviews({ homeId, homeName }: HomeReviewsProps) {
+export default function HomeReviews({ homeId, homeName, canRespond = false }: HomeReviewsProps) {
   const { data: session } = useSession();
+  const [respondingTo, setRespondingTo] = useState<string | null>(null);
+  const [responseText, setResponseText] = useState('');
+  const [savingResponse, setSavingResponse] = useState(false);
+
+  const saveResponse = async (reviewId: string) => {
+    if (!responseText.trim()) return;
+    setSavingResponse(true);
+    try {
+      const res = await fetch(`/api/reviews/homes/${reviewId}/response`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ response: responseText.trim() }),
+      });
+      if (res.ok) {
+        setRespondingTo(null);
+        setResponseText('');
+        await load();
+      }
+    } finally {
+      setSavingResponse(false);
+    }
+  };
   const [reviews, setReviews] = useState<ReviewItem[]>([]);
   const [stats, setStats] = useState<{ averageRating: number; totalReviews: number }>({ averageRating: 0, totalReviews: 0 });
   const [loading, setLoading] = useState(true);
@@ -145,6 +169,42 @@ export default function HomeReviews({ homeId, homeName }: HomeReviewsProps) {
                   <p className="text-xs font-semibold text-primary-800">Response from {homeName}</p>
                   <p className="mt-0.5 text-sm text-neutral-700">{r.operatorResponse}</p>
                 </div>
+              )}
+
+              {canRespond && !r.operatorResponse && (
+                respondingTo === r.id ? (
+                  <div className="mt-3">
+                    <textarea
+                      value={responseText}
+                      onChange={(e) => setResponseText(e.target.value)}
+                      placeholder="Write a public response to this review…"
+                      rows={3}
+                      maxLength={2000}
+                      className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm"
+                    />
+                    <div className="mt-2 flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => saveResponse(r.id)}
+                        disabled={savingResponse}
+                        className="rounded-md bg-primary-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-50"
+                      >
+                        {savingResponse ? 'Posting…' : 'Post response'}
+                      </button>
+                      <button type="button" onClick={() => setRespondingTo(null)} className="text-sm text-neutral-500 hover:text-neutral-700">
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => { setRespondingTo(r.id); setResponseText(''); }}
+                    className="mt-3 text-sm font-medium text-primary-600 hover:text-primary-700"
+                  >
+                    Respond as the operator
+                  </button>
+                )
               )}
             </div>
           ))}


### PR DESCRIPTION
**Enrichment item #5, PR 3 of 3 — completes first-party reviews.**

- **`/api/homes/[id]`** now returns `viewerIsOwner` (the logged-in operator owns this claimed home), so reply controls are offered only to the right person.
- **`HomeReviews` `canRespond` mode** — the owning operator sees **"Respond as the operator"** under each un-answered review → inline form → `POST /api/reviews/homes/[id]/response` (the 5a endpoint). The reply then renders inline as "Response from <home>".
- **Claim incentive** — the unclaimed-listing claim pitch now advertises **"showcase & respond to reviews"**.

### #5 complete
- 5a (#650): backend — earned eligibility (inquiry/tour/booking) + operator-response endpoint + migration.
- 5b (#651): family UI — real reviews, "be the first" empty state, submit form.
- 5c (this): operator reply UI + claim incentive.

`tsc --noEmit`: 0 errors. `home.reviews.api.test.ts`: 20/20. No third-party review text anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_