### PR TITLE
feat(leads): tour→claim nudge (urgent) + email backup for claimed operators

### DIFF
--- a/src/app/api/family/tours/request/route.ts
+++ b/src/app/api/family/tours/request/route.ts
@@ -16,6 +16,8 @@ import { z } from "zod";
 import { smsService } from "@/lib/sms/sms-service";
 import { sendTourConfirmationEmail } from "@/lib/notifications/tour-notifications";
 import { captureError } from '@/lib/sentry';
+import { notifyUnclaimedHomeInquiry, isUnclaimedHome } from "@/lib/claim-engine/inquiry-claim-notification";
+import { sendNewLeadOperatorEmail } from "@/lib/email";
 
 const tourRequestSchema = z.object({
   homeId: z.string(),
@@ -454,6 +456,29 @@ export async function POST(request: NextRequest) {
         tourRequest.home.name
       ).catch(() => {});
     }
+
+    // Email backup of the operator tour alert — CLAIMED homes only (never the
+    // directory sentinel). SMS can be missing/undeliverable; email is reliable.
+    const operatorEmail = tourRequest.operator?.user?.email;
+    if (operatorEmail && !isUnclaimedHome(operatorEmail)) {
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com';
+      sendNewLeadOperatorEmail({
+        facilityName: tourRequest.home.name,
+        toEmail: operatorEmail,
+        operatorFirstName: tourRequest.operator?.user?.firstName,
+        leadType: 'tour',
+        ctaUrl: `${appUrl.replace(/\/$/, '')}/operator/tours`,
+      }).catch(() => {});
+    }
+
+    // Tour→claim "pull" engine: a tour is the HOTTEST lead — nudge an UNCLAIMED
+    // facility to claim with urgent copy ("confirm the visit"). Self-filters to
+    // unclaimed homes with a known outreach email; non-blocking, generic (no PHI).
+    notifyUnclaimedHomeInquiry({
+      homeId: tourRequest.homeId,
+      inquiryId: tourRequest.id,
+      trigger: 'tour',
+    }).catch(() => {});
 
     // === STEP 10: Prepare Response ===
     console.log('🟢 [TOUR API] Step 10: Sending Response');

--- a/src/app/api/inquiries/route.ts
+++ b/src/app/api/inquiries/route.ts
@@ -9,7 +9,8 @@ import { authOptions } from '@/lib/auth';
 import { afterInquiryCreated } from '@/lib/hooks/inquiry-hooks';
 import { smsService } from '@/lib/sms/sms-service';
 import { createInquirySchema } from '@/lib/inquiries/schema';
-import { notifyUnclaimedHomeInquiry } from '@/lib/claim-engine/inquiry-claim-notification';
+import { notifyUnclaimedHomeInquiry, isUnclaimedHome } from '@/lib/claim-engine/inquiry-claim-notification';
+import { sendNewLeadOperatorEmail } from '@/lib/email';
 
 /**
  * POST /api/inquiries - Create a new inquiry
@@ -92,7 +93,7 @@ export async function POST(request: NextRequest) {
               select: {
                 id: true,
                 companyName: true,
-                user: { select: { firstName: true, phone: true } },
+                user: { select: { firstName: true, phone: true, email: true } },
               },
             },
           },
@@ -116,6 +117,21 @@ export async function POST(request: NextRequest) {
         inquiry.careRecipientName || 'your loved one',
         inquiry.home.name
       ).catch(() => {});
+    }
+
+    // Email backup of the operator alert — CLAIMED homes only (never the directory
+    // sentinel). SMS can be missing/wrong/undeliverable; email is the reliable
+    // channel. Generic copy only — no PHI.
+    const operatorEmail = inquiry.home?.operator?.user?.email;
+    if (operatorEmail && !isUnclaimedHome(operatorEmail)) {
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com';
+      sendNewLeadOperatorEmail({
+        facilityName: inquiry.home.name,
+        toEmail: operatorEmail,
+        operatorFirstName: inquiry.home.operator?.user?.firstName,
+        leadType: 'inquiry',
+        ctaUrl: `${appUrl.replace(/\/$/, '')}/operator/inquiries`,
+      }).catch(() => {});
     }
 
     // Inquiry→claim "pull" engine (OL-083): if the home is UNCLAIMED, best-effort

--- a/src/lib/claim-engine/inquiry-claim-notification.ts
+++ b/src/lib/claim-engine/inquiry-claim-notification.ts
@@ -65,8 +65,10 @@ function buildClaimUrl(homeId: string, operatorEmail: string, secret: string): s
 export async function notifyUnclaimedHomeInquiry(params: {
   homeId: string;
   inquiryId: string;
+  /** What triggered the nudge. A tour is the hottest lead → more urgent copy. */
+  trigger?: 'inquiry' | 'tour';
 }): Promise<void> {
-  const { homeId, inquiryId } = params;
+  const { homeId, inquiryId, trigger = 'inquiry' } = params;
   try {
     const home = await prisma.assistedLivingHome.findUnique({
       where: { id: homeId },
@@ -112,10 +114,15 @@ export async function notifyUnclaimedHomeInquiry(params: {
       toEmail: outreachEmail,
       claimUrl,
       waitingCount,
+      trigger,
     });
 
     if (outreachPhone) {
-      await smsService.sendInquiryClaimNudge(outreachPhone, home.name, claimUrl);
+      if (trigger === 'tour') {
+        await smsService.sendTourClaimNudge(outreachPhone, home.name, claimUrl);
+      } else {
+        await smsService.sendInquiryClaimNudge(outreachPhone, home.name, claimUrl);
+      }
     }
 
     await prisma.assistedLivingHome.update({

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -193,29 +193,40 @@ export async function sendInquiryClaimNudgeEmail(args: {
   toEmail: string;
   claimUrl: string;
   waitingCount?: number;
+  /** A tour request is the hottest lead — use more urgent copy than an inquiry. */
+  trigger?: 'inquiry' | 'tour';
 }): Promise<boolean> {
   const facilityName = args.facilityName?.trim() || 'your community';
+  const isTour = args.trigger === 'tour';
   const count = args.waitingCount && args.waitingCount > 1 ? args.waitingCount : 1;
-  const leadPhrase =
-    count > 1 ? `${count} families are trying to reach` : `A family is trying to reach`;
+  const leadPhrase = isTour
+    ? `A family wants to tour`
+    : count > 1
+    ? `${count} families are trying to reach`
+    : `A family is trying to reach`;
   try {
     if (!process.env.RESEND_API_KEY) {
       console.error('[Resend] RESEND_API_KEY not configured — skipping inquiry claim nudge');
       return false;
     }
     const safeFacility = escapeHtml(facilityName);
-    const subject = `${leadPhrase} ${facilityName} on CareLinkAI`;
+    const subject = isTour
+      ? `A family wants to tour ${facilityName} — claim to confirm the visit`
+      : `${leadPhrase} ${facilityName} on CareLinkAI`;
+    const actionLine = isTour
+      ? 'Claim your free listing in about 2 minutes to confirm the visit and respond securely:'
+      : 'Claim your free listing in about 2 minutes to view and respond securely:';
     const text =
-      `${leadPhrase} ${facilityName} on CareLinkAI.\n\n` +
-      `Claim your free listing in about 2 minutes to view and respond securely:\n${args.claimUrl}\n\n` +
-      `Inquiry details are kept private until you claim. There is no cost to claim or respond.`;
+      (isTour ? `A family wants to tour ${facilityName} on CareLinkAI.\n\n` : `${leadPhrase} ${facilityName} on CareLinkAI.\n\n`) +
+      `${actionLine}\n${args.claimUrl}\n\n` +
+      `Details are kept private until you claim. There is no cost to claim or respond.`;
     const html = `
 <!DOCTYPE html>
 <html><body style="font-family:Arial,sans-serif;color:#1f2937;line-height:1.5">
-  <p>${escapeHtml(leadPhrase)} <strong>${safeFacility}</strong> on CareLinkAI.</p>
-  <p>Claim your free listing in about 2 minutes to view and respond securely:</p>
-  <p><a href="${escapeHtml(args.claimUrl)}" style="display:inline-block;background:#0d9488;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600">Claim ${safeFacility}</a></p>
-  <p style="color:#6b7280;font-size:13px">Inquiry details are kept private until you claim. There is no cost to claim or respond.</p>
+  <p>${isTour ? `A family wants to <strong>tour</strong> ` : `${escapeHtml(leadPhrase)} `}<strong>${safeFacility}</strong> on CareLinkAI.</p>
+  <p>${escapeHtml(actionLine)}</p>
+  <p><a href="${escapeHtml(args.claimUrl)}" style="display:inline-block;background:#0d9488;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600">${isTour ? 'Claim &amp; confirm the tour' : `Claim ${safeFacility}`}</a></p>
+  <p style="color:#6b7280;font-size:13px">Details are kept private until you claim. There is no cost to claim or respond.</p>
 </body></html>`;
 
     const { data, error } = await resend.emails.send({
@@ -241,6 +252,60 @@ export async function sendInquiryClaimNudgeEmail(args: {
     captureError(error instanceof Error ? error : new Error(String(error)), {
       tags: { feature: 'inquiry-claim-notification' },
       extra: { facilityName },
+    });
+    return false;
+  }
+}
+
+/**
+ * Email backup of the operator SMS lead alert, for CLAIMED homes. SMS can be
+ * missing/wrong/undeliverable, so a new inquiry or tour request also emails the
+ * operator. HIPAA: generic only — names the facility + lead type, never the
+ * family's name or any care/health detail. The CTA is the operator dashboard.
+ */
+export async function sendNewLeadOperatorEmail(args: {
+  facilityName: string;
+  toEmail: string;
+  operatorFirstName?: string;
+  leadType: 'inquiry' | 'tour';
+  ctaUrl: string;
+}): Promise<boolean> {
+  try {
+    if (!process.env.RESEND_API_KEY) return false;
+    const facility = escapeHtml(args.facilityName?.trim() || 'your community');
+    const hi = args.operatorFirstName ? `Hi ${escapeHtml(args.operatorFirstName)}, ` : '';
+    const lead = args.leadType === 'tour' ? 'tour request' : 'inquiry';
+    const subject = args.leadType === 'tour'
+      ? `New tour request for ${args.facilityName} on CareLinkAI`
+      : `New inquiry for ${args.facilityName} on CareLinkAI`;
+    const text =
+      `${args.operatorFirstName ? `Hi ${args.operatorFirstName}, ` : ''}you have a new ${lead} for ${args.facilityName} on CareLinkAI.\n\n` +
+      `Log in to view the details and respond:\n${args.ctaUrl}\n\n` +
+      `Details are kept private and secure on CareLinkAI.`;
+    const html = `
+<!DOCTYPE html>
+<html><body style="font-family:Arial,sans-serif;color:#1f2937;line-height:1.5">
+  <p>${hi}you have a new ${lead} for <strong>${facility}</strong> on CareLinkAI.</p>
+  <p><a href="${escapeHtml(args.ctaUrl)}" style="display:inline-block;background:#0d9488;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600">View &amp; respond</a></p>
+  <p style="color:#6b7280;font-size:13px">Details are kept private and secure on CareLinkAI.</p>
+</body></html>`;
+
+    const { error } = await resend.emails.send({
+      from: `${APP_NAME} <${FROM_EMAIL}>`,
+      to: [args.toEmail],
+      subject,
+      text,
+      html,
+    });
+    if (error) {
+      captureError(error instanceof Error ? error : new Error(String((error as { message?: string })?.message ?? error)),
+        { tags: { feature: 'operator-lead-alert' }, extra: { facilityName: args.facilityName, leadType: args.leadType } });
+      return false;
+    }
+    return true;
+  } catch (error) {
+    captureError(error instanceof Error ? error : new Error(String(error)), {
+      tags: { feature: 'operator-lead-alert' }, extra: { facilityName: args.facilityName },
     });
     return false;
   }

--- a/src/lib/sms/sms-service.ts
+++ b/src/lib/sms/sms-service.ts
@@ -122,6 +122,16 @@ export class SMSService {
     return this.sendSMS(to, msg);
   }
 
+  // ── Operator (UNCLAIMED listing): TOUR→claim nudge — hottest lead, urgent copy ──
+  async sendTourClaimNudge(
+    to: string,
+    facilityName: string,
+    claimUrl: string
+  ): Promise<boolean> {
+    const msg = `A family wants to TOUR ${facilityName} on CareLinkAI. Claim your free listing (~2 min) to confirm the visit: ${claimUrl}`;
+    return this.sendSMS(to, msg);
+  }
+
   // Legacy — kept for backward compatibility
   async sendFollowUpSMS(to: string, contactName: string, inquiryId: string): Promise<boolean> {
     const msg = `Hi ${contactName}, this is CareLinkAI following up on your senior care inquiry. We're here to help! Reply YES to speak with an advisor or visit carelinkai.com. Ref: ${inquiryId.slice(0, 8)}`;


### PR DESCRIPTION
Build-order items **(a)** and **(b)**.

### (a) Tour → claim nudge (more urgent than an inquiry)
A tour request on an **unclaimed** home now fires the claim-nudge engine — previously it did **nothing** (sentinel operator has no phone, no email path). Copy reflects that a tour is the hottest lead:
- **Email:** subject *"A family wants to tour <facility> — claim to confirm the visit"*, CTA *"Claim & confirm the tour"*.
- **SMS:** new `sendTourClaimNudge` — *"A family wants to TOUR <facility>… claim to confirm the visit"*.
- The engine gained `trigger: 'inquiry' | 'tour'` (default `inquiry`); **inquiry copy unchanged**. Same 24h throttle, HIPAA-safe generic copy, self-filters to unclaimed homes with a known outreach email.

### (b) Email backup for claimed operators (alongside SMS)
New inquiries **and** tour requests now also **email** the operator on **claimed** homes (`sendNewLeadOperatorEmail`), as a backup to the existing SMS — SMS can be missing/wrong/undeliverable. Guarded to real operators (never the directory sentinel), generic copy (no PHI), links to `/operator/inquiries` or `/operator/tours`.

### Notes
- No schema change. `tsc`: 0 errors; reviews + inquiries-payload tests pass.
- Next in your order: **(2)** family-side fallback on unclaimed inquiry/tour, then **(3)** the per-facility multi-touch claim drip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_