### PR TITLE
feat(family): honest fallback when inquiring/touring an unclaimed home (lead item 2)

### DIFF
--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -1345,8 +1345,24 @@ export default function HomeDetailPage() {
                           <div className="rounded-full bg-success-100 p-4"><FiCheck className="h-8 w-8 text-success-600" /></div>
                         </div>
                         <h3 className="mb-2 text-lg font-semibold text-neutral-800">Request Submitted!</h3>
-                        <p className="mb-4 text-sm text-neutral-600">We've received your inquiry for {realHome.name}. A representative will contact you within 24 hours.</p>
-                        <button onClick={() => setBookingStep(0)} className="text-sm text-primary-600 hover:underline">Submit another inquiry</button>
+                        {realHome.unclaimed ? (
+                          <>
+                            <p className="mb-3 text-sm text-neutral-600">
+                              We&apos;ve sent your inquiry to {realHome.name} and let them know a family is waiting. Some communities haven&apos;t set up their CareLinkAI page yet, so a direct reply can take a little longer — we&apos;ll route their response to you as soon as it comes in.
+                            </p>
+                            <a
+                              href={`/search?location=${encodeURIComponent(realHome.address?.city || '')}${realHome.careLevel?.[0] ? `&careLevel=${encodeURIComponent(realHome.careLevel[0])}` : ''}`}
+                              className="inline-flex items-center rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+                            >
+                              Browse similar communities ready to respond
+                            </a>
+                          </>
+                        ) : (
+                          <p className="mb-4 text-sm text-neutral-600">We&apos;ve received your inquiry for {realHome.name}. A representative will contact you within 24 hours.</p>
+                        )}
+                        <div className="mt-3">
+                          <button onClick={() => setBookingStep(0)} className="text-sm text-primary-600 hover:underline">Submit another inquiry</button>
+                        </div>
                       </div>
                     )}
                   </div>
@@ -2348,6 +2364,7 @@ export default function HomeDetailPage() {
         onClose={() => setShowTourModal(false)}
         homeId={realHome?.id || String(id)}
         homeName={realHome?.name || home.name}
+        homeUnclaimed={Boolean(realHome?.unclaimed)}
         onSuccess={() => {
           console.log("Tour request submitted successfully!");
         }}

--- a/src/components/tours/TourRequestModal.tsx
+++ b/src/components/tours/TourRequestModal.tsx
@@ -23,6 +23,8 @@ interface TourRequestModalProps {
   onClose: () => void;
   homeId: string;
   homeName: string;
+  /** True when the home is an unclaimed directory listing — softens the confirmation copy. */
+  homeUnclaimed?: boolean;
   onSuccess?: () => void;
 }
 
@@ -40,6 +42,7 @@ export default function TourRequestModal({
   onClose,
   homeId,
   homeName,
+  homeUnclaimed = false,
   onSuccess,
 }: TourRequestModalProps) {
   const [currentStep, setCurrentStep] = useState<Step>("date-range");
@@ -482,13 +485,32 @@ export default function TourRequestModal({
                       <h3 className="mt-4 text-lg font-medium text-neutral-900">
                         Tour Request Submitted!
                       </h3>
-                      <p className="mt-2 text-sm text-neutral-600">
-                        Your tour request has been sent to {homeName}. They will confirm your
-                        appointment shortly.
-                      </p>
-                      <p className="mt-4 text-xs text-neutral-500">
-                        You'll receive an email confirmation once the tour is confirmed.
-                      </p>
+                      {homeUnclaimed ? (
+                        <>
+                          <p className="mt-2 text-sm text-neutral-600">
+                            Your tour request has been sent to {homeName} and we&apos;ve let them know a
+                            family wants to visit. Some communities haven&apos;t set up their CareLinkAI
+                            page yet, so confirmation can take a little longer — we&apos;ll email you the
+                            moment they respond.
+                          </p>
+                          <a
+                            href="/search"
+                            className="mt-4 inline-flex items-center rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+                          >
+                            Browse similar communities ready to respond
+                          </a>
+                        </>
+                      ) : (
+                        <>
+                          <p className="mt-2 text-sm text-neutral-600">
+                            Your tour request has been sent to {homeName}. They will confirm your
+                            appointment shortly.
+                          </p>
+                          <p className="mt-4 text-xs text-neutral-500">
+                            You&apos;ll receive an email confirmation once the tour is confirmed.
+                          </p>
+                        </>
+                      )}
                     </div>
                   )}
 


### PR DESCRIPTION
**Build-order item 2** — protects family trust + adds a conversion path when the contacted home is unclaimed.

### Problem
On an **unclaimed** listing, the inquiry/tour success screens promised "a representative will contact you within 24 hours" / "they will confirm shortly" — but there may be **no operator** to respond, which erodes family trust.

### Fix (UI-only — uses the existing `realHome.unclaimed` flag; no route changes)
- **Inquiry success** (listing detail): for unclaimed homes →
  > We've sent your inquiry to <home> and let them know a family is waiting. Some communities haven't set up their CareLinkAI page yet, so a direct reply can take a little longer — we'll route their response to you as soon as it comes in.

  \+ a **"Browse similar communities ready to respond"** button (`/search?location=<city>&careLevel=<level>`).
- **Tour modal**: same softened confirmation + browse-similar link, gated by a new `homeUnclaimed` prop passed from the detail page.
- **Claimed-home copy is unchanged.**

Honest by design — no false "24h response" promise when there's no operator yet. `tsc`: 0 errors.

### Sequencing
Independent of PR #655 (a/b) — no overlapping files. Next: **item 3** — the per-facility multi-touch claim drip (bigger; schema + cron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_