### PR TITLE
feat(claim-drip): per-facility email-only multi-touch claim drip (lead item 3)

### DIFF
--- a/prisma/migrations/20260627000002_home_claim_drip/migration.sql
+++ b/prisma/migrations/20260627000002_home_claim_drip/migration.sql
@@ -1,0 +1,7 @@
+-- Per-facility claim drip (email-only). Additive + idempotent.
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "claimDripStartedAt" TIMESTAMP(3);
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "claimDripStep" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "claimDripNextAt" TIMESTAMP(3);
+ALTER TABLE "AssistedLivingHome" ADD COLUMN IF NOT EXISTS "claimDripStoppedReason" TEXT;
+-- Cron scans for due drips: index the scheduling columns.
+CREATE INDEX IF NOT EXISTS "AssistedLivingHome_claimDripNextAt_idx" ON "AssistedLivingHome" ("claimDripNextAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -550,6 +550,13 @@ model AssistedLivingHome {
   outreachEmail           String?
   outreachPhone           String?
   claimNudgeLastSentAt    DateTime?
+  // Per-facility claim drip (email-only): one active sequence per home, started on
+  // the first lead, advanced by the claim-drip cron. step = touches sent (0-4);
+  // stoppedReason = claimed | unsubscribed | bounce | exhausted | no_email.
+  claimDripStartedAt      DateTime?
+  claimDripStep           Int       @default(0)
+  claimDripNextAt         DateTime?
+  claimDripStoppedReason  String?
   address                Address?
   operator               Operator         @relation(fields: [operatorId], references: [id], onDelete: Cascade)
   bookings               Booking[]
@@ -573,6 +580,7 @@ model AssistedLivingHome {
   @@index([status])
   @@index([priceMin, priceMax])
   @@index([careLevel])
+  @@index([claimDripNextAt])
   @@index([lastProfileGenerated])
   @@index([isFeatured])
 }

--- a/render.yaml
+++ b/render.yaml
@@ -32,3 +32,18 @@ services:
 #       value: production
 #     - key: CRON_SECRET
 #       sync: false  # Pull from environment variables
+#
+# Per-facility claim drip — advance due touches once daily (email-only).
+# - type: cron
+#   name: claim-drip
+#   runtime: node
+#   region: oregon
+#   plan: starter
+#   schedule: "0 14 * * *"  # 14:00 UTC daily (~9-10am ET)
+#   buildCommand: npm install
+#   startCommand: |
+#     curl -sS -H "Authorization: Bearer $CRON_SECRET" \
+#       https://getcarelinkai.com/api/cron/claim-drip
+#   envVars:
+#     - key: CRON_SECRET
+#       sync: false

--- a/scripts/report-claim-drip.ts
+++ b/scripts/report-claim-drip.ts
@@ -1,0 +1,63 @@
+/**
+ * report-claim-drip.ts  (READ-ONLY)
+ *
+ * Claim-drip funnel + inquiry→claim attribution by touch. For every home that has
+ * started a drip, reports active step distribution, stop reasons, and — the key
+ * metric — how many got CLAIMED after N touches (claimed = no longer owned by the
+ * directory sentinel). Run anytime to see which touch is converting.
+ *
+ * Usage (Render shell): npx tsx scripts/report-claim-drip.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const DIRECTORY_UNCLAIMED_EMAIL = 'directory-unclaimed@carelinkai.system';
+
+async function main() {
+  const homes = await prisma.assistedLivingHome.findMany({
+    where: { claimDripStartedAt: { not: null } },
+    select: {
+      id: true, name: true, claimDripStep: true, claimDripStartedAt: true,
+      claimDripNextAt: true, claimDripStoppedReason: true,
+      operator: { select: { user: { select: { email: true } } } },
+    },
+    orderBy: { claimDripStartedAt: 'asc' },
+  });
+
+  const isClaimed = (e?: string | null) => (e ?? '').toLowerCase() !== DIRECTORY_UNCLAIMED_EMAIL;
+
+  const started = homes.length;
+  const claimedHomes = homes.filter((h) => isClaimed(h.operator?.user?.email));
+  const activeHomes = homes.filter((h) => !isClaimed(h.operator?.user?.email) && !h.claimDripStoppedReason);
+
+  // Claims attributed by the number of touches that had been sent.
+  const claimsByTouch: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0 };
+  for (const h of claimedHomes) {
+    const t = Math.min(4, Math.max(1, h.claimDripStep || 1));
+    claimsByTouch[t] = (claimsByTouch[t] ?? 0) + 1;
+  }
+
+  const stepDist: Record<number, number> = {};
+  for (const h of activeHomes) stepDist[h.claimDripStep] = (stepDist[h.claimDripStep] ?? 0) + 1;
+
+  const stopReasons: Record<string, number> = {};
+  for (const h of homes) {
+    if (h.claimDripStoppedReason && !isClaimed(h.operator?.user?.email)) {
+      stopReasons[h.claimDripStoppedReason] = (stopReasons[h.claimDripStoppedReason] ?? 0) + 1;
+    }
+  }
+
+  console.log('\n=== Claim-drip funnel (READ-ONLY) ===');
+  console.log(`Drips started:        ${started}`);
+  console.log(`Currently active:     ${activeHomes.length}  (by touches sent: ${JSON.stringify(stepDist)})`);
+  console.log(`Claimed:              ${claimedHomes.length}  (${started ? ((claimedHomes.length / started) * 100).toFixed(0) : '0'}% of started)`);
+  console.log(`  └─ claims by touch: 1:${claimsByTouch[1]}  2:${claimsByTouch[2]}  3:${claimsByTouch[3]}  4:${claimsByTouch[4]}`);
+  console.log(`Stopped (not claimed): ${JSON.stringify(stopReasons)}`);
+  console.log('\nNote: a claim is attributed to the touch count sent before it. The cron also');
+  console.log('marks stoppedReason=claimed on its next run; this report detects claims live.');
+}
+
+main()
+  .catch((e) => { console.error('ERROR:', e); process.exit(1); })
+  .finally(async () => { await prisma.$disconnect(); });

--- a/src/app/api/cron/claim-drip/route.ts
+++ b/src/app/api/cron/claim-drip/route.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /api/cron/claim-drip
+ *
+ * Advances every due per-facility claim drip by one touch (email-only). Intended
+ * to run daily. Secure with CRON_SECRET:
+ *   Authorization: Bearer <CRON_SECRET>
+ *
+ * Idempotent: only homes whose claimDripNextAt is due and that aren't stopped are
+ * touched, and each run advances a home by at most one touch.
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { advanceClaimDrips } from '@/lib/claim-engine/claim-drip';
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const result = await advanceClaimDrips();
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: error instanceof Error ? error.message : 'Failed to advance claim drips' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/claim-engine/claim-drip.ts
+++ b/src/lib/claim-engine/claim-drip.ts
@@ -1,0 +1,206 @@
+/**
+ * Per-facility CLAIM DRIP (email-only). ONE active sequence per unclaimed home,
+ * started on the first lead and advanced by the claim-drip cron.
+ *
+ * Cadence (days from start): touch 1 = 0, 2 = 3, 3 = 7, 4 = 14, then EXHAUSTED.
+ * Copy escalates per touch and always surfaces the live "N families waiting"
+ * count (computed from NEW inquiries). EMAIL ONLY — no SMS in the cold pre-claim
+ * path (TCPA / A2P risk). CAN-SPAM is handled in sendClaimDripEmail (unsubscribe
+ * + postal + List-Unsubscribe headers); this module refuses to send without a
+ * configured COMPANY_POSTAL_ADDRESS.
+ *
+ * Hard stops (claimDripStoppedReason): claimed | unsubscribe | bounce | no_email
+ * | exhausted. Subsequent leads on an already-started drip do NOT start a new one
+ * — the waiting count simply grows and the next scheduled touch reflects it.
+ *
+ * Instrumentation: claimDripStep records touches sent; when the cron detects a
+ * claim it freezes the step + sets stoppedReason='claimed', so a claim can be
+ * attributed to "claimed after N touches".
+ */
+
+import { prisma } from '@/lib/prisma';
+import { signClaimToken, DEFAULT_CLAIM_TOKEN_TTL_HOURS } from '@/lib/claim-token';
+import { signUnsubscribeToken } from '@/lib/unsubscribe-token';
+import { sendClaimDripEmail } from '@/lib/email';
+import { captureError } from '@/lib/sentry';
+
+/** Sentinel operator that owns unclaimed/directory listings. Inlined to keep this
+ *  module free of a cycle with inquiry-claim-notification (which imports the drip). */
+const DIRECTORY_UNCLAIMED_EMAIL = 'directory-unclaimed@carelinkai.system';
+function isUnclaimedHome(operatorUserEmail: string | null | undefined): boolean {
+  return (operatorUserEmail ?? '').toLowerCase() === DIRECTORY_UNCLAIMED_EMAIL;
+}
+
+/** Day offsets from drip start for touch 1..4. Length = max touches. */
+export const DRIP_OFFSETS_DAYS = [0, 3, 7, 14];
+export const MAX_DRIP_TOUCHES = DRIP_OFFSETS_DAYS.length;
+const DAY_MS = 86_400_000;
+
+function appUrl(): string {
+  return (process.env['NEXT_PUBLIC_APP_URL'] || process.env['NEXTAUTH_URL'] || 'https://getcarelinkai.com').replace(/\/$/, '');
+}
+function postalAddress(): string | null {
+  const v = (process.env['COMPANY_POSTAL_ADDRESS'] || '').trim();
+  // Guard against an obvious placeholder being left in the env.
+  return v && !/«|set .*before/i.test(v) ? v : null;
+}
+function buildClaimUrl(homeId: string, operatorEmail: string, secret: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const token = signClaimToken(
+    { operatorEmail: operatorEmail.toLowerCase(), homeId, clevelandFounder: true, iat: now, exp: now + DEFAULT_CLAIM_TOKEN_TTL_HOURS * 3600 },
+    secret,
+  );
+  return `${appUrl()}/auth/register?role=OPERATOR&claimToken=${encodeURIComponent(token)}`;
+}
+function unsubscribeUrl(email: string, secret: string): string {
+  return `${appUrl()}/api/outreach/unsubscribe?token=${encodeURIComponent(signUnsubscribeToken(email, secret))}`;
+}
+async function waitingCount(homeId: string): Promise<number> {
+  return prisma.inquiry.count({ where: { homeId, status: 'NEW' } });
+}
+/** Returns the suppression reason ('unsubscribe'|'bounce'|'manual') if suppressed, else null. */
+async function suppressionReason(email: string): Promise<string | null> {
+  const s = await prisma.emailSuppression.findUnique({ where: { email: email.toLowerCase() }, select: { reason: true } });
+  return s ? (s.reason || 'unsubscribe') : null;
+}
+
+type DripHome = {
+  id: string;
+  name: string;
+  outreachEmail: string | null;
+  claimDripStep: number;
+  claimDripStartedAt: Date | null;
+};
+
+/** Send one drip touch. Returns true if the email was accepted. Refuses without postal (CAN-SPAM). */
+async function sendTouch(home: DripHome, touch: number, trigger: 'inquiry' | 'tour'): Promise<boolean> {
+  const secret = process.env['NEXTAUTH_SECRET'] || '';
+  const postal = postalAddress();
+  const email = home.outreachEmail?.trim();
+  if (!secret || !postal || !email) return false;
+  const count = await waitingCount(home.id);
+  return sendClaimDripEmail({
+    facilityName: home.name,
+    toEmail: email,
+    claimUrl: buildClaimUrl(home.id, email, secret),
+    unsubscribeUrl: unsubscribeUrl(email, secret),
+    postalAddress: postal,
+    touch,
+    waitingCount: count,
+    trigger,
+  });
+}
+
+/**
+ * Start the drip on the FIRST lead for an unclaimed home (sends touch 1). No-op if
+ * a drip is already started/stopped, the home is claimed, or there's no outreach
+ * email. Fire-and-forget; never throws.
+ */
+export async function startClaimDripOnLead(params: { homeId: string; trigger?: 'inquiry' | 'tour' }): Promise<void> {
+  const { homeId, trigger = 'inquiry' } = params;
+  try {
+    const home = await prisma.assistedLivingHome.findUnique({
+      where: { id: homeId },
+      select: {
+        id: true, name: true, outreachEmail: true, claimDripStep: true,
+        claimDripStartedAt: true, claimDripStoppedReason: true,
+        operator: { select: { user: { select: { email: true } } } },
+      },
+    });
+    if (!home) return;
+    if (!isUnclaimedHome(home.operator?.user?.email)) return; // claimed → handled by operator alerts
+    if (home.claimDripStartedAt || home.claimDripStoppedReason) return; // already started/stopped — count just grows
+    const email = home.outreachEmail?.trim();
+    if (!email) return; // no contact → public waiting counter drives the claim
+
+    // Don't start into a suppressed address.
+    const supp = await suppressionReason(email);
+    if (supp) {
+      await prisma.assistedLivingHome.update({ where: { id: home.id }, data: { claimDripStoppedReason: supp } });
+      return;
+    }
+
+    const sent = await sendTouch(home, 1, trigger);
+    if (!sent) return; // e.g. postal not configured — leave unstarted so it can start cleanly later
+    const now = new Date();
+    await prisma.assistedLivingHome.update({
+      where: { id: home.id },
+      data: {
+        claimDripStartedAt: now,
+        claimDripStep: 1,
+        claimDripNextAt: new Date(now.getTime() + DRIP_OFFSETS_DAYS[1] * DAY_MS),
+        claimNudgeLastSentAt: now,
+        claimDripStoppedReason: null,
+      },
+    });
+    console.log(`[claim-drip] started for "${home.name}" (${home.id}), touch 1 (${trigger})`);
+  } catch (error) {
+    captureError(error instanceof Error ? error : new Error(String(error)), {
+      tags: { feature: 'claim-drip' }, extra: { homeId, phase: 'start' },
+    });
+  }
+}
+
+/**
+ * Cron: advance every due drip by one touch. Checks hard-stop conditions first
+ * (claimed / suppressed / no email), sends the next escalating touch otherwise,
+ * and marks 'exhausted' after the final touch.
+ */
+export async function advanceClaimDrips(limit = 300): Promise<{ due: number; sent: number; stopped: number }> {
+  const now = new Date();
+  const due = await prisma.assistedLivingHome.findMany({
+    where: {
+      claimDripStartedAt: { not: null },
+      claimDripStoppedReason: null,
+      claimDripNextAt: { lte: now },
+      claimDripStep: { lt: MAX_DRIP_TOUCHES },
+    },
+    select: {
+      id: true, name: true, outreachEmail: true, claimDripStep: true, claimDripStartedAt: true,
+      operator: { select: { user: { select: { email: true } } } },
+    },
+    take: limit,
+  });
+
+  let sent = 0;
+  let stopped = 0;
+  for (const home of due) {
+    try {
+      const email = home.outreachEmail?.trim();
+      let stopReason: string | null = null;
+      if (!isUnclaimedHome(home.operator?.user?.email)) stopReason = 'claimed';
+      else if (!email) stopReason = 'no_email';
+      else stopReason = await suppressionReason(email);
+
+      if (stopReason) {
+        await prisma.assistedLivingHome.update({
+          where: { id: home.id },
+          data: { claimDripStoppedReason: stopReason, claimDripNextAt: null },
+        });
+        stopped++;
+        continue;
+      }
+
+      const nextTouch = (home.claimDripStep ?? 0) + 1; // 2..4
+      const ok = await sendTouch(home, nextTouch, 'inquiry');
+      if (!ok) continue; // transient (e.g. postal/email issue) — retry next run, don't advance
+      const exhausted = nextTouch >= MAX_DRIP_TOUCHES;
+      const startedAt = home.claimDripStartedAt!;
+      await prisma.assistedLivingHome.update({
+        where: { id: home.id },
+        data: {
+          claimDripStep: nextTouch,
+          claimNudgeLastSentAt: now,
+          claimDripNextAt: exhausted ? null : new Date(startedAt.getTime() + DRIP_OFFSETS_DAYS[nextTouch] * DAY_MS),
+          claimDripStoppedReason: exhausted ? 'exhausted' : null,
+        },
+      });
+      sent++;
+    } catch (error) {
+      captureError(error instanceof Error ? error : new Error(String(error)), {
+        tags: { feature: 'claim-drip' }, extra: { homeId: home.id, phase: 'advance' },
+      });
+    }
+  }
+  return { due: due.length, sent, stopped };
+}

--- a/src/lib/claim-engine/inquiry-claim-notification.ts
+++ b/src/lib/claim-engine/inquiry-claim-notification.ts
@@ -6,25 +6,18 @@
  * leads are never lost and surface on the operator dashboard the moment the home
  * is claimed (inquiries are keyed by `homeId`, which reassigns on claim).
  *
- * This function is the BEST-EFFORT notify layer on top of that capture: if we
- * know the operator's outreach email, mint a 45-day founder claim link and send
- * a Resend email (+ Twilio SMS when a phone is known). The notification IS the
- * claim CTA. When no contact is known, this no-ops and the public waiting-leads
- * counter on the listing is the organic claim driver instead.
+ * This is the BEST-EFFORT notify layer on top of that capture. As of the
+ * per-facility claim DRIP, it simply DELEGATES to `startClaimDripOnLead`: the
+ * first lead starts an email-only drip (touch 1) and the claim-drip cron advances
+ * touches 2-4; later leads just grow the public waiting count. EMAIL ONLY — no SMS
+ * in the cold pre-claim path (TCPA / A2P caution). When no outreach email is known
+ * this no-ops and the public waiting-leads counter is the organic claim driver.
  *
- * HIPAA: an inquiry may contain PHI (care needs). This path sends GENERIC copy
- * only — facility name + "a family is trying to reach you" — never inquiry/health
- * details. Actual content stays behind auth and is revealed only after claim.
- *
- * Idempotent (24h throttle via `claimNudgeLastSentAt`), non-blocking (callers
- * fire-and-forget), and Sentry-logged on failure — never throws.
+ * HIPAA: copy is GENERIC only — facility name + "a family is trying to reach you"
+ * — never inquiry/health details. Non-blocking; never throws.
  */
 
-import { prisma } from '@/lib/prisma';
-import { signClaimToken, DEFAULT_CLAIM_TOKEN_TTL_HOURS } from '@/lib/claim-token';
-import { sendInquiryClaimNudgeEmail } from '@/lib/email';
-import { smsService } from '@/lib/sms/sms-service';
-import { captureError } from '@/lib/sentry';
+import { startClaimDripOnLead } from './claim-drip';
 
 /** Sentinel operator that owns unclaimed/directory listings (see seed scripts). */
 export const DIRECTORY_UNCLAIMED_EMAIL = 'directory-unclaimed@carelinkai.system';
@@ -40,23 +33,6 @@ export function isUnclaimedHome(operatorUserEmail: string | null | undefined): b
   return (operatorUserEmail ?? '').toLowerCase() === DIRECTORY_UNCLAIMED_EMAIL;
 }
 
-function buildClaimUrl(homeId: string, operatorEmail: string, secret: string): string {
-  const now = Math.floor(Date.now() / 1000);
-  const token = signClaimToken(
-    {
-      operatorEmail: operatorEmail.toLowerCase(),
-      homeId,
-      clevelandFounder: true,
-      iat: now,
-      exp: now + DEFAULT_CLAIM_TOKEN_TTL_HOURS * 3600,
-    },
-    secret,
-  );
-  const appUrl =
-    process.env['NEXT_PUBLIC_APP_URL'] || process.env['NEXTAUTH_URL'] || 'https://getcarelinkai.com';
-  return `${appUrl.replace(/\/$/, '')}/auth/register?role=OPERATOR&claimToken=${encodeURIComponent(token)}`;
-}
-
 /**
  * Best-effort: nudge the operator of an unclaimed listing to claim, off the back
  * of a real inquiry. Safe to call on ANY inquiry — it self-filters to unclaimed
@@ -68,73 +44,10 @@ export async function notifyUnclaimedHomeInquiry(params: {
   /** What triggered the nudge. A tour is the hottest lead → more urgent copy. */
   trigger?: 'inquiry' | 'tour';
 }): Promise<void> {
-  const { homeId, inquiryId, trigger = 'inquiry' } = params;
-  try {
-    const home = await prisma.assistedLivingHome.findUnique({
-      where: { id: homeId },
-      select: {
-        id: true,
-        name: true,
-        outreachEmail: true,
-        outreachPhone: true,
-        claimNudgeLastSentAt: true,
-        operator: { select: { user: { select: { email: true } } } },
-      },
-    });
-
-    if (!home) return;
-    // Claimed homes are handled by the existing operator-alert path — skip.
-    if (!isUnclaimedHome(home.operator?.user?.email)) return;
-
-    const outreachEmail = home.outreachEmail?.trim();
-    const outreachPhone = home.outreachPhone?.trim();
-    // No bound email → nothing to send; the public waiting-leads counter drives
-    // the claim instead. (A phone alone can't bind a claim token to an account.)
-    if (!outreachEmail) return;
-
-    // Idempotency: don't re-nudge within the throttle window.
-    if (
-      home.claimNudgeLastSentAt &&
-      Date.now() - home.claimNudgeLastSentAt.getTime() < NUDGE_THROTTLE_HOURS * 3600 * 1000
-    ) {
-      return;
-    }
-
-    const secret = process.env['NEXTAUTH_SECRET'] || '';
-    if (!secret) {
-      console.error('[claim-engine] NEXTAUTH_SECRET not set — cannot mint claim link for nudge');
-      return;
-    }
-
-    const waitingCount = await prisma.inquiry.count({ where: { homeId, status: 'NEW' } });
-    const claimUrl = buildClaimUrl(home.id, outreachEmail, secret);
-
-    await sendInquiryClaimNudgeEmail({
-      facilityName: home.name,
-      toEmail: outreachEmail,
-      claimUrl,
-      waitingCount,
-      trigger,
-    });
-
-    if (outreachPhone) {
-      if (trigger === 'tour') {
-        await smsService.sendTourClaimNudge(outreachPhone, home.name, claimUrl);
-      } else {
-        await smsService.sendInquiryClaimNudge(outreachPhone, home.name, claimUrl);
-      }
-    }
-
-    await prisma.assistedLivingHome.update({
-      where: { id: home.id },
-      data: { claimNudgeLastSentAt: new Date() },
-    });
-
-    console.log(`[claim-engine] Sent inquiry→claim nudge for "${home.name}" (${home.id})`);
-  } catch (error) {
-    captureError(error instanceof Error ? error : new Error(String(error)), {
-      tags: { feature: 'inquiry-claim-notification' },
-      extra: { homeId, inquiryId },
-    });
-  }
+  // The per-facility claim DRIP owns all cold pre-claim outreach (email-only — no
+  // SMS, per TCPA/A2P caution). On the FIRST lead it starts the drip (touch 1);
+  // subsequent leads are no-ops here — the public waiting count grows and the
+  // claim-drip cron advances touches 2-4. startClaimDripOnLead self-filters to
+  // unclaimed homes with a bound outreach email and never throws.
+  await startClaimDripOnLead({ homeId: params.homeId, trigger: params.trigger ?? 'inquiry' });
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -312,6 +312,99 @@ export async function sendNewLeadOperatorEmail(args: {
 }
 
 /**
+ * One touch of the per-facility CLAIM DRIP (email-only). Escalating copy by touch
+ * (1 = lead nudge, 2 = growing demand, 3 = missing-leads/loss, 4 = final notice)
+ * that always surfaces the live waiting count. CAN-SPAM compliant: one-click
+ * unsubscribe link + company postal address + List-Unsubscribe / RFC 8058 headers.
+ * Generic copy only — never PHI. Returns false on failure.
+ */
+export async function sendClaimDripEmail(args: {
+  facilityName: string;
+  toEmail: string;
+  claimUrl: string;
+  unsubscribeUrl: string;
+  postalAddress: string;
+  touch: number; // 1..4
+  waitingCount: number;
+  trigger?: 'inquiry' | 'tour';
+}): Promise<boolean> {
+  try {
+    if (!process.env.RESEND_API_KEY) return false;
+    const facility = args.facilityName?.trim() || 'your community';
+    const n = Math.max(1, args.waitingCount || 1);
+    const fam = n === 1 ? 'family' : 'families';
+    const isTour = args.trigger === 'tour';
+
+    let subject: string;
+    let lead: string;
+    switch (args.touch) {
+      case 1:
+        subject = isTour
+          ? `A family wants to tour ${facility} — claim to confirm the visit`
+          : `A family is trying to reach ${facility} on CareLinkAI`;
+        lead = isTour
+          ? `A family wants to tour ${facility} on CareLinkAI.`
+          : `A family is trying to reach ${facility} on CareLinkAI.`;
+        break;
+      case 2:
+        subject = `${n} ${fam} waiting to hear from ${facility}`;
+        lead = `${n} ${fam} ${n === 1 ? 'is' : 'are'} now waiting to hear from ${facility} on CareLinkAI. Your free listing is unclaimed, so no one can respond yet.`;
+        break;
+      case 3:
+        subject = `You're missing leads at ${facility} (${n} waiting)`;
+        lead = `${facility} is missing leads. ${n} ${fam} ${n === 1 ? 'has' : 'have'} reached out on CareLinkAI and ${n === 1 ? 'is' : 'are'} still waiting because the listing is unclaimed.`;
+        break;
+      default: // 4 — final
+        subject = `Final notice: ${n} ${fam} waiting at ${facility}`;
+        lead = `Final notice — ${n} ${fam} ${n === 1 ? 'is' : 'are'} waiting to connect with ${facility} on CareLinkAI. This is the last email we'll send about these leads. Claim your free listing to respond before they choose another community.`;
+        break;
+    }
+    const cta = args.touch >= 3 ? 'Claim now &amp; respond' : `Claim ${escapeHtml(facility)}`;
+    const text =
+      `${lead}\n\n` +
+      `Claim your free listing in about 2 minutes to view and respond securely:\n${args.claimUrl}\n\n` +
+      `Details are kept private until you claim. There is no cost to claim or respond.\n\n` +
+      `${APP_NAME} · ${args.postalAddress}\n` +
+      `Unsubscribe (you won't be emailed about these leads again): ${args.unsubscribeUrl}`;
+    const html = `
+<!DOCTYPE html>
+<html><body style="font-family:Arial,sans-serif;color:#1f2937;line-height:1.5">
+  <p>${escapeHtml(lead)}</p>
+  <p><a href="${escapeHtml(args.claimUrl)}" style="display:inline-block;background:#0d9488;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600">${cta}</a></p>
+  <p style="color:#6b7280;font-size:13px">Details are kept private until you claim. There is no cost to claim or respond.</p>
+  <hr style="border:none;border-top:1px solid #e5e7eb;margin:16px 0"/>
+  <p style="color:#9ca3af;font-size:12px">
+    ${APP_NAME} · ${escapeHtml(args.postalAddress)}<br/>
+    <a href="${escapeHtml(args.unsubscribeUrl)}" style="color:#9ca3af">Unsubscribe</a> — you won't be emailed about these leads again.
+  </p>
+</body></html>`;
+
+    const { error } = await resend.emails.send({
+      from: `${APP_NAME} <${FROM_EMAIL}>`,
+      to: [args.toEmail],
+      subject,
+      text,
+      html,
+      headers: {
+        'List-Unsubscribe': `<${args.unsubscribeUrl}>, <mailto:${FROM_EMAIL}?subject=unsubscribe>`,
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+      },
+    });
+    if (error) {
+      captureError(error instanceof Error ? error : new Error(String((error as { message?: string })?.message ?? error)),
+        { tags: { feature: 'claim-drip' }, extra: { facilityName: facility, touch: args.touch } });
+      return false;
+    }
+    return true;
+  } catch (error) {
+    captureError(error instanceof Error ? error : new Error(String(error)), {
+      tags: { feature: 'claim-drip' }, extra: { facilityName: args.facilityName },
+    });
+    return false;
+  }
+}
+
+/**
  * PROACTIVE directory claim invite (distinct from sendInquiryClaimNudgeEmail).
  *
  * Used by the batch claim-nudge sender to invite an operator to claim their free


### PR DESCRIPTION
**Build-order item 3** — the per-facility claim drip, to your spec.

### Design
- **One active drip per facility**, started on the **first lead**, advanced by a daily cron. Subsequent leads are **no-ops** here — the public "N families waiting" count grows and the next scheduled touch reflects it (not per-lead).
- **Cadence:** days **0 / 3 / 7 / 14**, then **EXHAUSTED**.
- **Copy escalates per touch**, always surfacing the **live N-waiting count**:
  1. lead nudge ("a family is trying to reach / wants to tour")
  2. "N families now waiting to hear from <facility>"
  3. "You're missing leads at <facility> (N waiting)"
  4. "Final notice: N waiting… last email we'll send"
- **EMAIL ONLY, permanently** — no SMS in the cold pre-claim path (TCPA / A2P). SMS stays only for **claimed** operators (implied consent), unchanged.
- **CAN-SPAM:** every touch has one-click unsubscribe + company postal + `List-Unsubscribe` headers; the engine **refuses to send without `COMPANY_POSTAL_ADDRESS`**.
- **Hard stops:** `claimed` / `unsubscribe` / `bounce` / `no_email` / `exhausted` (checked before every touch).
- **Instrumentation:** `claimDripStep` records touches sent; `report-claim-drip.ts` attributes **claims by touch** (claimed-after-N-touches) + active/stopped breakdown.

### Changes
- **Schema** (migration `20260627000002`, additive): `claimDripStartedAt/Step/NextAt/StoppedReason` + index on `claimDripNextAt`.
- `src/lib/claim-engine/claim-drip.ts` (NEW): `startClaimDripOnLead` (touch 1) + `advanceClaimDrips` (cron).
- `notifyUnclaimedHomeInquiry` now **delegates** to the drip (removed the old inline email + SMS + 24h throttle). Inquiry/tour routes unchanged.
- `sendClaimDripEmail` (escalating, CAN-SPAM). `src/app/api/cron/claim-drip` (Bearer `CRON_SECRET`). `render.yaml` documents a daily schedule.

### Setup after merge (Render)
1. Migration deploys automatically.
2. Schedule a **daily** GET to `https://getcarelinkai.com/api/cron/claim-drip` with `Authorization: Bearer $CRON_SECRET` (render.yaml has a ready-to-uncomment block; or your existing external scheduler).
3. Confirm `COMPANY_POSTAL_ADDRESS` is set (it is) — the drip won't send without it.

`tsc`: 0 errors. Unit tests pass (incl. `inquiry-claim-notification` exports + reviews). No third-party data; generic copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_