### PR TITLE
feat(directory): load VA-collected approximate price/amenities onto unclaimed listings (item 2)

### DIFF
--- a/scripts/load-va-pricing-amenities.ts
+++ b/scripts/load-va-pricing-amenities.ts
@@ -1,0 +1,132 @@
+/**
+ * load-va-pricing-amenities.ts
+ *
+ * Loads VA-collected (Anita, phone) STARTING price ranges + amenities onto
+ * UNCLAIMED directory listings, flagged as APPROXIMATE / unverified so families
+ * see it's distinct from operator-verified data and so it's cleanly overridden
+ * when the operator claims and enters real values.
+ *
+ * Provenance: sets `preFilledFields.priceRange = 'VA_UNVERIFIED'` and/or
+ * `preFilledFields.amenities = 'VA_UNVERIFIED'`. The listing detail page shows a
+ * "Pending operator confirmation" note while the flag is set; the operator home
+ * edit route clears the flag the moment the operator saves price/amenities.
+ *
+ * SAFETY: only writes UNCLAIMED (directory-sentinel-owned) homes — never an
+ * operator's real data. Dry-run by default; prints the before→after per home.
+ *
+ * CSV (header row required): homeId,priceMin,priceMax,amenities
+ *   - priceMin   : starting monthly price (number). Blank = skip price for this row.
+ *   - priceMax   : optional upper bound (number) or blank.
+ *   - amenities  : pipe-separated list, NO commas (e.g. "Private rooms|Memory care|On-site nursing"). Blank = skip amenities.
+ *
+ * Usage (Render shell — has DATABASE_URL):
+ *   npx tsx scripts/load-va-pricing-amenities.ts --csv path/to/va_pricing.csv          # DRY RUN
+ *   npx tsx scripts/load-va-pricing-amenities.ts --csv path/to/va_pricing.csv --force   # apply
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { readFileSync } from 'fs';
+
+const prisma = new PrismaClient();
+const DIRECTORY_UNCLAIMED_EMAIL = 'directory-unclaimed@carelinkai.system';
+const VA_FLAG = 'VA_UNVERIFIED';
+
+type Row = { homeId: string; priceMin: number | null; priceMax: number | null; amenities: string[] | null };
+
+function parseCsv(path: string): Row[] {
+  const text = readFileSync(path, 'utf8').replace(/\r/g, '');
+  const lines = text.split('\n').map((l) => l.trim()).filter(Boolean);
+  if (lines.length === 0) return [];
+  const header = lines[0].toLowerCase().split(',').map((h) => h.trim());
+  const idx = (name: string) => header.indexOf(name);
+  const iHome = idx('homeid'), iMin = idx('pricemin'), iMax = idx('pricemax'), iAmen = idx('amenities');
+  if (iHome === -1) throw new Error('CSV must have a homeId column');
+  const rows: Row[] = [];
+  for (const line of lines.slice(1)) {
+    const cells = line.split(',');
+    const homeId = (cells[iHome] ?? '').trim();
+    if (!homeId) continue;
+    const minRaw = iMin !== -1 ? (cells[iMin] ?? '').trim() : '';
+    const maxRaw = iMax !== -1 ? (cells[iMax] ?? '').trim() : '';
+    const amenRaw = iAmen !== -1 ? (cells[iAmen] ?? '').trim() : '';
+    rows.push({
+      homeId,
+      priceMin: minRaw ? Number(minRaw) : null,
+      priceMax: maxRaw ? Number(maxRaw) : null,
+      amenities: amenRaw ? amenRaw.split('|').map((a) => a.trim()).filter(Boolean) : null,
+    });
+  }
+  return rows;
+}
+
+async function main() {
+  const force = process.argv.includes('--force');
+  const csvArg = process.argv.indexOf('--csv');
+  const csvPath = csvArg !== -1 ? process.argv[csvArg + 1] : null;
+  if (!csvPath) {
+    console.error('⛔ Pass --csv <path>. CSV header: homeId,priceMin,priceMax,amenities (amenities pipe-separated).');
+    process.exit(1);
+  }
+
+  const rows = parseCsv(csvPath);
+  console.log(`\n=== VA pricing/amenities load — ${force ? 'LIVE (--force)' : 'DRY RUN'} ===`);
+  console.log(`Rows: ${rows.length}\n`);
+
+  let applied = 0, skipped = 0;
+  for (const r of rows) {
+    const home = await prisma.assistedLivingHome.findUnique({
+      where: { id: r.homeId },
+      select: {
+        id: true, name: true, priceMin: true, priceMax: true, amenities: true, preFilledFields: true,
+        operator: { select: { user: { select: { email: true } } } },
+      },
+    });
+    if (!home) { console.log(`✗ ${r.homeId} not found — SKIP`); skipped++; continue; }
+
+    const ownerEmail = (home.operator?.user?.email ?? '').toLowerCase();
+    if (ownerEmail !== DIRECTORY_UNCLAIMED_EMAIL) {
+      console.log(`⚠ "${home.name}" is CLAIMED (operator=${ownerEmail || 'unknown'}) — SKIP (never overwrite operator data)`);
+      skipped++; continue;
+    }
+    if (Number.isNaN(r.priceMin as number) || Number.isNaN(r.priceMax as number)) {
+      console.log(`⚠ "${home.name}" — non-numeric price in CSV — SKIP`); skipped++; continue;
+    }
+
+    const prevPff = (home.preFilledFields && typeof home.preFilledFields === 'object' ? home.preFilledFields : {}) as Record<string, unknown>;
+    const data: any = {};
+    const pff: Record<string, unknown> = { ...prevPff };
+
+    if (r.priceMin != null) {
+      data.priceMin = r.priceMin;
+      if (r.priceMax != null) data.priceMax = r.priceMax;
+      pff.priceRange = VA_FLAG;
+    }
+    if (r.amenities && r.amenities.length > 0) {
+      data.amenities = r.amenities;
+      pff.amenities = VA_FLAG;
+    }
+
+    if (Object.keys(data).length === 0) { console.log(`– "${home.name}" — nothing to set — SKIP`); skipped++; continue; }
+    data.preFilledFields = pff;
+
+    console.log(`🏠 "${home.name}"`);
+    if (data.priceMin != null) console.log(`     price: ${home.priceMin ?? '(none)'} → starting $${r.priceMin}${r.priceMax != null ? `–$${r.priceMax}` : ''}/mo  [VA approx]`);
+    if (data.amenities) console.log(`     amenities: ${(home.amenities ?? []).length} → ${r.amenities!.length} [${r.amenities!.join(', ')}]  [VA approx]`);
+
+    if (force) {
+      await prisma.assistedLivingHome.update({ where: { id: home.id }, data });
+      console.log('   ✓ applied'); applied++;
+    } else {
+      console.log('   (dry run — would apply)'); applied++;
+    }
+  }
+
+  console.log('\n─────────────────────────────────────────────');
+  console.log(force ? `Applied: ${applied}, Skipped: ${skipped}` : `Would apply: ${applied}, Skipped: ${skipped}`);
+  console.log('Loaded values are flagged VA_UNVERIFIED → shown as "pending operator confirmation" and cleared on operator edit.');
+  if (!force) console.log('DRY RUN — re-run with --force to apply.');
+}
+
+main()
+  .catch((e) => { console.error('ERROR:', e); process.exit(1); })
+  .finally(async () => { await prisma.$disconnect(); });

--- a/src/app/api/homes/[id]/route.ts
+++ b/src/app/api/homes/[id]/route.ts
@@ -250,6 +250,10 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
       availability: home.capacity - home.currentOccupancy,
       gender: home.genderRestriction || 'ALL',
       amenities: home.amenities,
+      // VA-collected (phone) price/amenities are approximate until the operator
+      // confirms — surfaced as "pending operator confirmation", cleared on claim+edit.
+      pricePending: (home.preFilledFields as Record<string, unknown> | null)?.priceRange === 'VA_UNVERIFIED',
+      amenitiesPending: (home.preFilledFields as Record<string, unknown> | null)?.amenities === 'VA_UNVERIFIED',
       primaryPhoto,
       photos: (home.photos || []).map((p) => ({ id: p.id, url: p.url, caption: p.caption || '' })),
       operator: home.operator

--- a/src/app/api/operator/homes/[id]/route.ts
+++ b/src/app/api/operator/homes/[id]/route.ts
@@ -76,6 +76,15 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
       };
     }
 
+    // When the operator confirms price/amenities, clear the VA "pending" flag for
+    // that field so the approximate badge drops and their values become authoritative.
+    const prevPff = (home.preFilledFields && typeof home.preFilledFields === 'object' ? home.preFilledFields : {}) as Record<string, unknown>;
+    const pff = { ...prevPff };
+    let pffChanged = false;
+    if ((data.priceMin !== undefined || data.priceMax !== undefined) && pff.priceRange === 'VA_UNVERIFIED') { delete pff.priceRange; pffChanged = true; }
+    if (data.amenities !== undefined && pff.amenities === 'VA_UNVERIFIED') { delete pff.amenities; pffChanged = true; }
+    if (pffChanged) data.preFilledFields = pff;
+
     const updated = await prisma.assistedLivingHome.update({ where: { id: home.id }, data });
     return NextResponse.json({ id: updated.id });
   } catch (e) {

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -489,6 +489,7 @@ export function generateMockHomes(count: number = 12) {
       googleRating: null,
       googleRatingCount: null,
       googlePlaceId: null,
+      pricePending: false,
     };
   });
 }
@@ -811,6 +812,8 @@ export async function GET(request: NextRequest) {
           formattedMin: home.priceMin ? formatCurrency(Number(home.priceMin)) : null,
           formattedMax: home.priceMax ? formatCurrency(Number(home.priceMax)) : null,
         },
+        // VA-collected approximate price (pending operator confirmation) → card shows "~".
+        pricePending: (home.preFilledFields as Record<string, unknown> | null)?.priceRange === 'VA_UNVERIFIED',
         capacity: home.capacity,
         availability: home.capacity - home.currentOccupancy,
         gender: home.genderRestriction || 'ALL',

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -983,7 +983,14 @@ export default function HomeDetailPage() {
 
                 {/* Amenities */}
                 <div ref={amenitiesRef} className="mb-8 scroll-mt-20">
-                  <h2 className="mb-4 text-xl font-semibold text-neutral-800">Amenities & Services</h2>
+                  <div className="mb-4 flex flex-wrap items-center gap-2">
+                    <h2 className="text-xl font-semibold text-neutral-800">Amenities & Services</h2>
+                    {realHome.amenitiesPending && Array.isArray(realHome.amenities) && realHome.amenities.length > 0 && (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800">
+                        Approximate · pending operator confirmation
+                      </span>
+                    )}
+                  </div>
                   {Array.isArray(realHome.amenities) && realHome.amenities.length > 0 ? (
                     <div className="rounded-lg border border-neutral-200 bg-white p-6">
                       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
@@ -1042,6 +1049,11 @@ export default function HomeDetailPage() {
                               : `Up to ${formatCurrency(realHome.priceRange.max)}`}
                           </p>
                           <p className="text-sm text-neutral-500 mt-1">per month</p>
+                          {realHome.pricePending && (
+                            <p className="mt-2 inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800">
+                              Approximate starting price · pending operator confirmation
+                            </p>
+                          )}
                         </div>
                         <p className="text-sm text-neutral-600 mb-4">
                           Actual costs vary based on care level, room type, and additional services required. Contact the facility for a personalized quote.

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1111,8 +1111,8 @@ function SearchPageContent() {
                           </div>
                           
                           <div className="mt-auto flex items-center justify-between">
-                            <span className="text-sm font-semibold text-neutral-900">
-                              {home.priceRange.formattedMin}<span className="text-xs font-normal text-neutral-500">/mo+</span>
+                            <span className="text-sm font-semibold text-neutral-900" title={home.pricePending ? 'Approximate — pending operator confirmation' : undefined}>
+                              {home.pricePending && home.priceRange.formattedMin ? '~' : ''}{home.priceRange.formattedMin}<span className="text-xs font-normal text-neutral-500">/mo+</span>
                             </span>
                             <div className="flex items-center gap-2">
                               <button
@@ -1304,14 +1304,14 @@ function SearchPageContent() {
                           <div className="mt-auto flex items-center justify-between">
                             <div>
                               {home.priceRange.formattedMin ? (
-                                <>
+                                <span title={home.pricePending ? 'Approximate — pending operator confirmation' : undefined}>
                                   <span className="text-lg font-semibold text-neutral-800">
-                                    {home.priceRange.formattedMin}
+                                    {home.pricePending ? '~' : ''}{home.priceRange.formattedMin}
                                   </span>
                                   <span className="text-sm text-neutral-500">
                                     {home.priceRange.formattedMax ? ` - ${home.priceRange.formattedMax}/mo` : "/mo"}
                                   </span>
-                                </>
+                                </span>
                               ) : (
                                 <span className="text-sm font-medium text-neutral-500">Price on request</span>
                               )}

--- a/src/lib/searchService.ts
+++ b/src/lib/searchService.ts
@@ -113,6 +113,8 @@ export interface SearchResultItem {
   googleRating?: number | null;
   googleRatingCount?: number | null;
   googlePlaceId?: string | null;
+  /** VA-collected approximate price, pending operator confirmation (card shows "~"). */
+  pricePending?: boolean;
 }
 
 /**


### PR DESCRIPTION
VA (Anita) phone-collects starting prices + amenities while pushing claims. This adds a simple CSV load that enriches **unclaimed** listings, **flagged approximate** so it's visibly distinct from operator-verified data and cleanly **overridden on claim + edit**.

### Load — `scripts/load-va-pricing-amenities.ts` (NEW)
CSV header: `homeId,priceMin,priceMax,amenities` (amenities **pipe-separated**, no commas). Per row, sets `priceMin`/`priceMax` + `amenities` and tags provenance `preFilledFields.priceRange='VA_UNVERIFIED'` / `amenities='VA_UNVERIFIED'`. **Only writes sentinel-owned (unclaimed) homes** — never an operator's data. Dry-run default.
```
npx tsx scripts/load-va-pricing-amenities.ts --csv va_pricing.csv          # DRY RUN
npx tsx scripts/load-va-pricing-amenities.ts --csv va_pricing.csv --force   # apply
```

### Visibly distinct (honest)
- `/homes/[id]`: amber **"Approximate · pending operator confirmation"** note on the price and amenities sections.
- Search cards: price prefixed with **`~`** + a tooltip ("Approximate — pending operator confirmation").
- `/api/homes/[id]` + `/api/search` expose `pricePending` / `amenitiesPending` from the flag.

### Overridden on claim + entry
The operator home **PATCH** clears the `VA_UNVERIFIED` flag for any field the operator saves (price and/or amenities) → their values become authoritative and the approximate badge drops automatically. (Loads also never touch claimed homes.)

`tsc`: 0 errors. No schema change (uses existing `priceMin/priceMax/amenities/preFilledFields`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_