### PR TITLE
fix(ux): persist /homes/[id] favorite + add /auth/logout route (item 3a, 3b)

### DIFF
--- a/src/app/auth/logout/page.tsx
+++ b/src/app/auth/logout/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+import { signOut } from 'next-auth/react';
+
+/**
+ * Logout route. Some flows navigate here directly (e.g. settings → "log out of all
+ * devices", or a stale /auth/logout link/bookmark) — previously a 404. Signs the
+ * user out via NextAuth and returns them to the login page.
+ */
+export default function LogoutPage() {
+  useEffect(() => {
+    signOut({ callbackUrl: '/auth/login' });
+  }, []);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-neutral-50 text-sm text-neutral-500">
+      Signing you out…
+    </div>
+  );
+}

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -49,6 +49,9 @@ import PricingCalculator from "@/components/homes/PricingCalculator";
 import type { PricingEstimate } from "@/components/homes/PricingCalculator";
 import { getCloudinaryAvatar, isCloudinaryUrl } from "@/lib/cloudinaryUrl";
 import { buildInquiryPayload } from "@/lib/inquiries/payload";
+import { useSession } from "next-auth/react";
+import toast from "react-hot-toast";
+import { toggleFavorite as toggleFavoriteApi } from "@/lib/favoritesService";
 
 // Dynamically import the SimpleMap component with SSR disabled
 const SimpleMap = dynamic(
@@ -269,6 +272,7 @@ const CARE_LEVELS = [
 export default function HomeDetailPage() {
   const params = useParams();
   const router = useRouter();
+  const { status: authStatus } = useSession();
   const { id } = params;
   
   // State for the home data
@@ -360,7 +364,10 @@ export default function HomeDetailPage() {
           if (!cancelled) setLoadError('Malformed response');
           return;
         }
-        if (!cancelled) setRealHome(j.data);
+        if (!cancelled) {
+          setRealHome(j.data);
+          setIsFavorite(Boolean(j.data?.isFavorited));
+        }
       } catch (e: any) {
         if (!cancelled) setLoadError(e?.message || 'Network error');
       } finally {
@@ -664,10 +671,33 @@ export default function HomeDetailPage() {
     }
   };
   
-  // Toggle favorite
-  const toggleFavorite = () => {
-    setIsFavorite(!isFavorite);
-    // In a real app, we would save this to the user's profile
+  // Toggle favorite — persists to the user's saved homes (matches /search). Anon
+  // visitors can browse freely; saving prompts signup (not a login wall).
+  const toggleFavorite = async () => {
+    if (authStatus !== 'authenticated') {
+      toast(
+        (t) => (
+          <span>
+            Create a free account to save homes.{' '}
+            <a href="/auth/register" className="font-semibold text-teal-700 underline" onClick={() => toast.dismiss(t.id)}>
+              Sign up
+            </a>
+          </span>
+        ),
+        { duration: 6000 },
+      );
+      return;
+    }
+    const homeId = realHome?.id;
+    if (!homeId) return;
+    const next = !isFavorite;
+    setIsFavorite(next); // optimistic
+    try {
+      await toggleFavoriteApi(homeId);
+    } catch {
+      setIsFavorite(!next); // revert on error
+      toast.error('Could not update your saved homes. Please try again.');
+    }
   };
   
   // Handle pricing estimate updates


### PR DESCRIPTION
Two of the minor loose ends (item 3).

### 3a — Listing "Save" now persists
The `/homes/[id]` Save button was a **local no-op** (`setIsFavorite(!isFavorite)`). Now it:
- **Persists** via the favorites API (`toggleFavorite`), matching `/search`.
- **Initializes** from the listing's `isFavorited` (returned by `/api/homes/[id]`).
- For **anonymous** visitors, prompts signup (toast) instead of silently toggling — same as `/search` (not a login wall).
- Reverts on error.

### 3b — `/auth/logout` no longer 404s
`settings/account` ("log out of all devices") pushes to `/auth/logout`, which didn't exist. Added a small client page that calls NextAuth `signOut({ callbackUrl: '/auth/login' })`.

`tsc`: 0 errors. (Item 3c — Brookdale Westlake place-ID verify — is covered by the existing `fix-conflated-google-ratings.ts` script from #654; verification notes in the chat.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_