### PR TITLE
fix(billing): harden operator money path — hide unconfigured tiers + bulletproof checkout

### DIFF
--- a/src/app/api/operator/billing/plans/route.ts
+++ b/src/app/api/operator/billing/plans/route.ts
@@ -1,0 +1,20 @@
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { availableOperatorPlans } from '@/lib/operator-plans';
+
+/**
+ * GET /api/operator/billing/plans
+ *
+ * Returns the operator plan tiers that are actually purchasable right now —
+ * those with a configured Stripe Price ID. The billing UI (onboarding wizard
+ * Step 4 + SubscriptionManager) uses this to hide any tier that would dead-end
+ * at Stripe checkout. Stripe price IDs live only in server env, so the client
+ * cannot determine this on its own.
+ *
+ * Not sensitive (reveals only which tier names are buyable), so it is left
+ * unauthenticated to keep the wizard's first paint fast.
+ */
+export async function GET() {
+  return NextResponse.json({ available: availableOperatorPlans() });
+}

--- a/src/app/api/operator/billing/subscribe/route.ts
+++ b/src/app/api/operator/billing/subscribe/route.ts
@@ -6,13 +6,9 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { stripe } from '@/lib/stripe';
 import { UserRole } from '@prisma/client';
+import { priceIdForPlan, planLabel } from '@/lib/operator-plans';
 
-const PLAN_PRICE_MAP: Record<string, string | undefined> = {
-  STARTER:      process.env['STRIPE_PRICE_STARTER'],
-  PROFESSIONAL: process.env['STRIPE_PRICE_PROFESSIONAL'],
-  GROWTH:       process.env['STRIPE_PRICE_GROWTH'],
-  AGENCY:       process.env['STRIPE_PRICE_AGENCY'],
-};
+const SUPPORT_EMAIL = 'hello@getcarelinkai.com';
 
 /**
  * POST /api/operator/billing/subscribe
@@ -38,10 +34,15 @@ export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => ({}));
   const plan: string = (body.plan || 'STARTER').toUpperCase();
 
-  const priceId = PLAN_PRICE_MAP[plan];
+  // A tier is only purchasable if its Stripe Price ID is configured. If not, this
+  // is a config gap (e.g. STRIPE_PRICE_AGENCY unset) — never show the operator an
+  // env-var name; log the detail server-side and point them to support. The UI
+  // hides unconfigured tiers, so reaching here means a stale client or direct call.
+  const priceId = priceIdForPlan(plan);
   if (!priceId) {
+    console.error(`[billing/subscribe] No Stripe Price ID for plan "${plan}" — STRIPE_PRICE_${plan} is not set.`);
     return NextResponse.json(
-      { error: `No Stripe Price ID configured for plan "${plan}". Set STRIPE_PRICE_${plan} in your environment variables.` },
+      { error: `The ${planLabel(plan)} plan isn't available for self-serve checkout yet. Email ${SUPPORT_EMAIL} and we'll set you up.` },
       { status: 400 }
     );
   }
@@ -49,21 +50,6 @@ export async function POST(request: NextRequest) {
   const operator = await prisma.operator.findUnique({ where: { userId: user.id } });
   if (!operator) {
     return NextResponse.json({ error: 'Operator not found' }, { status: 404 });
-  }
-
-  // Create or retrieve Stripe customer
-  let stripeCustomerId = operator.stripeCustomerId;
-  if (!stripeCustomerId) {
-    const customer = await stripe.customers.create({
-      email: user.email!,
-      name: `${user.firstName} ${user.lastName}`.trim() || operator.companyName,
-      metadata: { operatorId: operator.id, userId: user.id },
-    });
-    stripeCustomerId = customer.id;
-    await prisma.operator.update({
-      where: { id: operator.id },
-      data: { stripeCustomerId },
-    });
   }
 
   // Derive the base URL from the incoming request so the success/cancel URLs always
@@ -77,19 +63,53 @@ export async function POST(request: NextRequest) {
     : request.headers.get('origin');
   const appUrl = requestOrigin || process.env['NEXT_PUBLIC_APP_URL'] || 'https://getcarelinkai.com';
 
-  const checkoutSession = await stripe.checkout.sessions.create({
-    customer: stripeCustomerId,
-    mode: 'subscription',
-    line_items: [{ price: priceId, quantity: 1 }],
-    subscription_data: {
-      trial_period_days: 14,
-      metadata: { operatorId: operator.id, plan },
-    },
-    success_url: `${appUrl}/operator/billing?subscription=success`,
-    cancel_url: `${appUrl}/operator/billing?subscription=canceled`,
-    metadata: { operatorId: operator.id, plan },
-    allow_promotion_codes: false,
-  });
+  // Everything that talks to Stripe is wrapped so a Stripe/network failure returns
+  // a clean, actionable message instead of a bodyless 500 that dead-ends the
+  // operator mid-checkout (lost MRR + lost trust).
+  try {
+    // Create or retrieve Stripe customer
+    let stripeCustomerId = operator.stripeCustomerId;
+    if (!stripeCustomerId) {
+      const customer = await stripe.customers.create({
+        email: user.email!,
+        name: `${user.firstName} ${user.lastName}`.trim() || operator.companyName,
+        metadata: { operatorId: operator.id, userId: user.id },
+      });
+      stripeCustomerId = customer.id;
+      await prisma.operator.update({
+        where: { id: operator.id },
+        data: { stripeCustomerId },
+      });
+    }
 
-  return NextResponse.json({ url: checkoutSession.url });
+    const checkoutSession = await stripe.checkout.sessions.create({
+      customer: stripeCustomerId,
+      mode: 'subscription',
+      line_items: [{ price: priceId, quantity: 1 }],
+      subscription_data: {
+        trial_period_days: 14,
+        metadata: { operatorId: operator.id, plan },
+      },
+      success_url: `${appUrl}/operator/billing?subscription=success`,
+      cancel_url: `${appUrl}/operator/billing?subscription=canceled`,
+      metadata: { operatorId: operator.id, plan },
+      allow_promotion_codes: false,
+    });
+
+    if (!checkoutSession.url) {
+      console.error('[billing/subscribe] Stripe returned a checkout session with no URL.');
+      return NextResponse.json(
+        { error: `We couldn't start checkout right now. Please try again in a moment, or email ${SUPPORT_EMAIL}.` },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json({ url: checkoutSession.url });
+  } catch (err) {
+    console.error('[billing/subscribe] Stripe error:', err);
+    return NextResponse.json(
+      { error: `We couldn't start checkout right now. Please try again in a moment, or email ${SUPPORT_EMAIL}.` },
+      { status: 502 }
+    );
+  }
 }

--- a/src/app/api/operator/billing/switch-plan/route.ts
+++ b/src/app/api/operator/billing/switch-plan/route.ts
@@ -6,20 +6,9 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { stripe } from '@/lib/stripe';
 import { UserRole } from '@prisma/client';
+import { priceIdForPlan, planLabel } from '@/lib/operator-plans';
 
-const PLAN_PRICE_MAP: Record<string, string | undefined> = {
-  STARTER:      process.env['STRIPE_PRICE_STARTER'],
-  PROFESSIONAL: process.env['STRIPE_PRICE_PROFESSIONAL'],
-  GROWTH:       process.env['STRIPE_PRICE_GROWTH'],
-  AGENCY:       process.env['STRIPE_PRICE_AGENCY'],
-};
-
-const PLAN_LABEL: Record<string, string> = {
-  STARTER:      'Starter',
-  PROFESSIONAL: 'Professional',
-  GROWTH:       'Growth',
-  AGENCY:       'Agency',
-};
+const SUPPORT_EMAIL = 'hello@getcarelinkai.com';
 
 /**
  * POST /api/operator/billing/switch-plan
@@ -43,10 +32,11 @@ export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => ({}));
   const plan: string = (body.plan || '').toUpperCase();
 
-  const priceId = PLAN_PRICE_MAP[plan];
+  const priceId = priceIdForPlan(plan);
   if (!priceId) {
+    console.error(`[switch-plan] No Stripe Price ID for plan "${plan}" — STRIPE_PRICE_${plan} is not set.`);
     return NextResponse.json(
-      { error: `No Stripe Price ID configured for plan "${plan}".` },
+      { error: `The ${planLabel(plan)} plan isn't available yet. Email ${SUPPORT_EMAIL} and we'll set you up.` },
       { status: 400 }
     );
   }
@@ -102,10 +92,12 @@ export async function POST(request: NextRequest) {
       data: { subscriptionPlan: plan as any },
     });
 
-    return NextResponse.json({ success: true, plan, label: PLAN_LABEL[plan] });
-  } catch (err: any) {
+    return NextResponse.json({ success: true, plan, label: planLabel(plan) });
+  } catch (err) {
     console.error('[switch-plan] Stripe error:', err);
-    const message = err?.raw?.message || err?.message || 'Stripe error';
-    return NextResponse.json({ error: message }, { status: 500 });
+    return NextResponse.json(
+      { error: `We couldn't switch your plan right now. Please try again in a moment, or email ${SUPPORT_EMAIL}.` },
+      { status: 502 }
+    );
   }
 }

--- a/src/app/operator/onboarding/[step]/page.tsx
+++ b/src/app/operator/onboarding/[step]/page.tsx
@@ -218,6 +218,10 @@ export default function OperatorOnboardingStepPage() {
   // Only used on Step 3 when the operator manually enters a token
   const [manualToken, setManualToken] = useState("");
   const [claimApplied, setClaimApplied] = useState(false);
+  // Which paid tiers are actually purchasable (have a configured Stripe price).
+  // null = not loaded yet; before it loads we hide AGENCY so a tier that would
+  // dead-end at checkout never flashes. Once loaded we render exactly this set.
+  const [availablePlans, setAvailablePlans] = useState<string[] | null>(null);
 
   // Apply an onboarding-status payload to local state (reused by polling).
   const applyStatus = (d: any) => {
@@ -291,6 +295,15 @@ export default function OperatorOnboardingStepPage() {
 
     return () => { cancelled = true; };
   }, [status]);
+
+  // Learn which paid tiers are purchasable so the plan picker hides any tier
+  // whose Stripe price isn't configured (e.g. AGENCY) — no broken checkout clicks.
+  useEffect(() => {
+    fetch("/api/operator/billing/plans")
+      .then((r) => r.json())
+      .then((d) => { if (Array.isArray(d?.available)) setAvailablePlans(d.available); })
+      .catch(() => {});
+  }, []);
 
   // Poll the status endpoint while enrichment is running; stop when it resolves.
   useEffect(() => {
@@ -994,9 +1007,12 @@ export default function OperatorOnboardingStepPage() {
                   </button>
                 </div>
               ) : (
-                /* Paid plans */
+                /* Paid plans — only those actually purchasable (configured Stripe price).
+                   Before availability loads, hide AGENCY so a dead-end tier never flashes. */
                 <div className="space-y-3">
-                  {PLANS.map((plan) => (
+                  {PLANS.filter((plan) =>
+                    availablePlans === null ? plan.key !== "AGENCY" : availablePlans.includes(plan.key)
+                  ).map((plan) => (
                     <div
                       key={plan.key}
                       className={`rounded-xl border p-4 ${

--- a/src/components/operator/billing/SubscriptionManager.tsx
+++ b/src/components/operator/billing/SubscriptionManager.tsx
@@ -82,6 +82,9 @@ export default function SubscriptionManager() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [showPlanChange, setShowPlanChange] = useState(false);
+  // Tiers with a configured Stripe price. null = not loaded; until then we hide
+  // AGENCY so a tier that would dead-end at checkout never appears as buyable.
+  const [availablePlans, setAvailablePlans] = useState<string[] | null>(null);
 
   useEffect(() => {
     Promise.all([
@@ -94,6 +97,11 @@ export default function SubscriptionManager() {
       })
       .catch(() => setError('Could not load billing data.'))
       .finally(() => setLoading(false));
+
+    fetch('/api/operator/billing/plans')
+      .then((r) => r.json())
+      .then((d) => { if (Array.isArray(d?.available)) setAvailablePlans(d.available); })
+      .catch(() => {});
   }, []);
 
   async function handleSubscribe(plan: string) {
@@ -165,6 +173,13 @@ export default function SubscriptionManager() {
   const currentPlan = subscription?.subscriptionPlan;
   const planDetails = currentPlan ? PLAN_DETAILS[currentPlan] : null;
   const currentRank = currentPlan ? (PLAN_RANK[currentPlan] ?? 0) : 0;
+  // Show a tier if it's purchasable (configured Stripe price) or it's the
+  // operator's current plan. Until availability loads, hide AGENCY so a tier
+  // that would dead-end at checkout never appears.
+  const visiblePlans = PLAN_ORDER.filter((plan) =>
+    plan === currentPlan ||
+    (availablePlans === null ? plan !== 'AGENCY' : availablePlans.includes(plan))
+  );
 
   return (
     <div className="space-y-4">
@@ -238,7 +253,7 @@ export default function SubscriptionManager() {
             Select a new plan — changes take effect immediately with prorated billing.
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {PLAN_ORDER.map((plan) => {
+            {visiblePlans.map((plan) => {
               const details = PLAN_DETAILS[plan];
               const isCurrent = plan === currentPlan;
               const isUpgrade = PLAN_RANK[plan] > currentRank;
@@ -352,7 +367,7 @@ export default function SubscriptionManager() {
             Choose a plan — 14-day free trial, no credit card required at signup
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-            {PLAN_ORDER.map((plan) => {
+            {visiblePlans.map((plan) => {
               const details = PLAN_DETAILS[plan];
               const isLoading = actionLoading === plan;
               return (

--- a/src/lib/operator-plans.ts
+++ b/src/lib/operator-plans.ts
@@ -1,0 +1,52 @@
+/**
+ * Single source of truth for which operator subscription tiers are actually
+ * PURCHASABLE right now. A tier is purchasable only if its Stripe Price ID is
+ * configured in the environment (STRIPE_PRICE_<PLAN>).
+ *
+ * Why this exists: the billing UI must never offer a "buy" button for a tier
+ * that would dead-end at Stripe checkout — that loses MRR at the goal line.
+ * (OL-055: the AGENCY tier was visible in the wizard but STRIPE_PRICE_AGENCY is
+ * unset, so clicking it 400s.) The wizard and the billing manager call the
+ * /api/operator/billing/plans endpoint to learn the purchasable set and hide
+ * the rest. The subscribe/switch-plan routes use these helpers server-side as
+ * the authoritative gate.
+ *
+ * Stripe price IDs live only in server env, so anything that needs the
+ * purchasable set in the browser must go through the API endpoint.
+ */
+
+export const OPERATOR_PLAN_KEYS = ['STARTER', 'PROFESSIONAL', 'GROWTH', 'AGENCY'] as const;
+export type OperatorPlanKey = (typeof OPERATOR_PLAN_KEYS)[number];
+
+export const OPERATOR_PLAN_LABELS: Record<OperatorPlanKey, string> = {
+  STARTER: 'Starter',
+  PROFESSIONAL: 'Professional',
+  GROWTH: 'Growth',
+  AGENCY: 'Agency',
+};
+
+/** Stripe Price ID for a plan, or undefined if not configured. Server-only (reads env). */
+export function priceIdForPlan(plan: string): string | undefined {
+  const map: Record<string, string | undefined> = {
+    STARTER:      process.env['STRIPE_PRICE_STARTER'],
+    PROFESSIONAL: process.env['STRIPE_PRICE_PROFESSIONAL'],
+    GROWTH:       process.env['STRIPE_PRICE_GROWTH'],
+    AGENCY:       process.env['STRIPE_PRICE_AGENCY'],
+  };
+  return map[plan.toUpperCase()];
+}
+
+/** True if a plan can be self-serve purchased (its Stripe price is configured). */
+export function isPlanPurchasable(plan: string): boolean {
+  return !!priceIdForPlan(plan);
+}
+
+/** The subset of operator plans that are currently purchasable. Server-only. */
+export function availableOperatorPlans(): OperatorPlanKey[] {
+  return OPERATOR_PLAN_KEYS.filter((p) => isPlanPurchasable(p));
+}
+
+/** Human label for a plan key (falls back to the raw key). */
+export function planLabel(plan: string): string {
+  return OPERATOR_PLAN_LABELS[plan.toUpperCase() as OperatorPlanKey] ?? plan;
+}


### PR DESCRIPTION
## Why

The bottleneck is **conversion → subscription**. A broken checkout loses MRR at the goal line and burns operator trust. This closes the two ways that path could break.

## 1. Unconfigured tiers were clickable (OL-055)

The **AGENCY** tier showed a buy button in both the onboarding wizard (Step 4) and the billing manager, but `STRIPE_PRICE_AGENCY` is unset — so clicking it dead-ended at a `400`.

- **New `src/lib/operator-plans.ts`** — single source of truth for which tiers are purchasable (those with a configured `STRIPE_PRICE_*`). Dedups the price map that was copy-pasted across the subscribe + switch-plan routes.
- **New `GET /api/operator/billing/plans`** — exposes the purchasable set to the client (Stripe price IDs are server-only env, so the browser can't know this otherwise).
- **Wizard Step 4 + SubscriptionManager** now **hide any tier that isn't purchasable**. AGENCY stays hidden until its price is configured; the billing manager still shows an operator's *current* plan even if its price were later unset.

## 2. Checkout could fail with a bodyless 500

The subscribe route's Stripe calls were **unwrapped** — a Stripe/network error returned no JSON body, so the UI showed a generic failure with no path forward.

- Wrapped customer + checkout-session creation in `try/catch` → clean, actionable message (`502` + support email) instead of a dead-end.
- Added a guard for a checkout session with no URL.
- **Stopped leaking env-var names** (`Set STRIPE_PRICE_AGENCY…`) to operators — that detail is now logged server-side; the operator sees a friendly "contact us" message.
- `switch-plan` gets the same treatment (friendly messages, no raw Stripe error text, no env-var hints).

## Scope / safety

- Revenue stays **operator-subscriptions only** — no pricing or plan changes.
- New endpoint is unauthenticated by design (reveals only which tier names are buyable; keeps the wizard's first paint fast).
- `tsc` clean, `next lint` clean on all touched files. No schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_