### PR TITLE
chore(billing): decommission old paid-DP Stripe prices (DP-free cleanup)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,10 @@ STRIPE_PRICE_PROVIDER_LISTING="price_..."
 # Family Plus tier ($19/mo recurring)
 STRIPE_PRICE_FAMILY_PLUS="price_..."
 
-# Discharge Planner tiers
-STRIPE_PRICE_DISCHARGE_PLANNER="price_..."       # Individual: $99/seat/mo
-STRIPE_PRICE_DISCHARGE_PLANNER_DEPT="price_..."  # Department: $499/mo (up to 10 seats)
+# Discharge Planner tiers — DECOMMISSIONED 2026-06-27. DP access is FREE (#659);
+# revenue is operator-subscriptions only. Do NOT re-add STRIPE_PRICE_DISCHARGE_PLANNER
+# or STRIPE_PRICE_DISCHARGE_PLANNER_DEPT — the old Stripe Prices are being archived
+# and these vars must stay unset so no DP can be charged again.
 
 # Placement fee charged to operator on inquiry → resident conversion (in cents, default $500)
 PLACEMENT_FEE_CENTS=50000

--- a/scripts/archive-dp-stripe-prices.ts
+++ b/scripts/archive-dp-stripe-prices.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env npx tsx
+/**
+ * scripts/archive-dp-stripe-prices.ts
+ *
+ * DP-FREE CLEANUP. Discharge-planner access went free on 2026-06-27 (#659).
+ * The old paid-DP Stripe Prices must be archived so they can never back a new
+ * subscription again:
+ *   - STRIPE_PRICE_DISCHARGE_PLANNER       (Individual — $99/seat/mo)
+ *   - STRIPE_PRICE_DISCHARGE_PLANNER_DEPT  (Department — $499/mo)
+ *
+ * This sets `active: false` on each price in Stripe. By price IDs from env by
+ * default; pass --price-id <id> (repeatable) to target prices explicitly (handy
+ * if you've already removed the env vars from Render).
+ *
+ * IMPORTANT: archiving a price only blocks NEW subscriptions — it does NOT cancel
+ * existing ones. Run scripts/report-dp-subscriptions.ts first and cancel any live
+ * DP subscription in the Stripe dashboard. Order of operations on Render:
+ *   1. npx tsx scripts/report-dp-subscriptions.ts   → cancel any sub it flags
+ *   2. npx tsx scripts/archive-dp-stripe-prices.ts --force   → archive the prices
+ *   3. Remove STRIPE_PRICE_DISCHARGE_PLANNER[_DEPT] env vars from Render
+ *
+ * Dry-run by default. Run on Render (needs STRIPE_SECRET_KEY).
+ *   npx tsx scripts/archive-dp-stripe-prices.ts                    # DRY RUN (from env)
+ *   npx tsx scripts/archive-dp-stripe-prices.ts --force            # apply
+ *   npx tsx scripts/archive-dp-stripe-prices.ts --price-id price_X --force
+ */
+
+import Stripe from 'stripe';
+
+function argValues(flag: string): string[] {
+  const out: string[] = [];
+  const argv = process.argv;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === flag && argv[i + 1]) out.push(argv[i + 1]);
+  }
+  return out;
+}
+
+async function main() {
+  const secret = process.env['STRIPE_SECRET_KEY'];
+  if (!secret) {
+    console.error('⛔ STRIPE_SECRET_KEY not set. Run on Render.');
+    process.exit(1);
+  }
+  const force = process.argv.includes('--force');
+  const stripe = new Stripe(secret, { apiVersion: '2023-10-16' });
+
+  // Targets: explicit --price-id args win; otherwise the two DP env vars.
+  const explicit = argValues('--price-id');
+  const fromEnv = [
+    process.env['STRIPE_PRICE_DISCHARGE_PLANNER'],
+    process.env['STRIPE_PRICE_DISCHARGE_PLANNER_DEPT'],
+  ].filter((v): v is string => !!v);
+  const targets = Array.from(new Set(explicit.length ? explicit : fromEnv));
+
+  console.log(`\n=== Archive DP Stripe prices — ${force ? 'LIVE (--force)' : 'DRY RUN'} ===\n`);
+  if (targets.length === 0) {
+    console.log('✓ No DP price IDs found (env vars unset and no --price-id given). Nothing to archive — likely already cleaned up.');
+    return;
+  }
+
+  for (const priceId of targets) {
+    try {
+      const price = await stripe.prices.retrieve(priceId);
+      const amount = typeof price.unit_amount === 'number' ? `$${(price.unit_amount / 100).toFixed(2)}` : '—';
+      const interval = price.recurring?.interval ?? 'one-time';
+      const label = price.nickname || (typeof price.product === 'string' ? price.product : price.product?.id) || priceId;
+      console.log(`• ${priceId} — ${label} (${amount}/${interval}) — currently ${price.active ? 'ACTIVE' : 'already archived'}`);
+
+      if (!price.active) {
+        console.log('   ✓ already archived — skipping.\n');
+        continue;
+      }
+      if (force) {
+        await stripe.prices.update(priceId, { active: false });
+        console.log('   ✓ archived (active: false).\n');
+      } else {
+        console.log('   DRY RUN — would set active: false.\n');
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(`   ⚠ could not retrieve/update ${priceId}: ${msg}\n`);
+    }
+  }
+
+  console.log('Reminder: archiving does NOT cancel existing subscriptions.');
+  console.log('Run scripts/report-dp-subscriptions.ts and cancel any live DP sub in Stripe first.\n');
+}
+
+main().catch((e) => {
+  console.error('ERROR:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

DP access is free (#659), but the old paid-DP Stripe Prices still exist and were wired via `STRIPE_PRICE_DISCHARGE_PLANNER` + `STRIPE_PRICE_DISCHARGE_PLANNER_DEPT`. A discharge planner who subscribed before the cutover could still be sitting on one. This completes the teardown so a DP can never be charged again.

## What

- **`.env.example`** — removes the two DP price vars and replaces them with a `DECOMMISSIONED 2026-06-27` note so they aren't re-added. (Confirmed no *live code* references these vars — only docs + this example file.)
- **`scripts/archive-dp-stripe-prices.ts`** (new, dry-run default) — sets `active: false` on both prices in Stripe so neither can back a new subscription. Reads the IDs from env, or accepts explicit `--price-id` args (useful after the env vars are removed from Render).

## Operator runbook (on Render)

1. `npx tsx scripts/report-dp-subscriptions.ts` → cancel any live DP sub it flags in the Stripe dashboard.
2. `npx tsx scripts/archive-dp-stripe-prices.ts --force` → archive the two prices.
3. Remove `STRIPE_PRICE_DISCHARGE_PLANNER` + `STRIPE_PRICE_DISCHARGE_PLANNER_DEPT` from Render env.

> Archiving a price only blocks **new** subscriptions — it does **not** cancel existing ones. That's why step 1 (report + cancel) comes first.

## Scope

Config/example + one script (scripts are excluded from project `tsc`; typechecked standalone — clean). No app code, schema, or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_