### PR TITLE
fix(email): route claim-admin alert to chris@ + add Reply-To on operator outreach

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,3 +165,13 @@ CRON_SECRET="..."
 # CAN-SPAM: real physical mailing address shown in cold-outreach (claim-nudge) email footers.
 # REQUIRED before scripts/send-claim-nudges.ts will --force. e.g. "1234 Main St, Cleveland, OH 44114"
 COMPANY_POSTAL_ADDRESS=""
+
+# Where "new claim" admin notifications go when an operator claims a listing.
+# Defaults to chris@getcarelinkai.com. (Legacy CLAIM_NOTIFY_EMAIL still honored as a fallback.)
+ADMIN_NOTIFY_EMAIL="chris@getcarelinkai.com"
+# Optional cc on the claim notification; leave unset for none. A cc equal to the
+# primary recipient is dropped automatically.
+# CLAIM_NOTIFY_CC=""
+# Monitored inbox that operator REPLIES to cold/outreach emails land in (Reply-To).
+# Defaults to ADMIN_NOTIFY_EMAIL / chris@getcarelinkai.com; the From stays noreply@.
+# OUTREACH_REPLY_TO="chris@getcarelinkai.com"

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -22,6 +22,13 @@ const FROM_EMAIL = process.env.EMAIL_FROM || 'noreply@getcarelinkai.com';
 const APP_NAME = 'CareLinkAI';
 const TOKEN_EXPIRY_HOURS = 24;
 
+// Monitored inbox that operator REPLIES to cold/outreach emails should land in.
+// FROM_EMAIL is a noreply address, so without an explicit reply-to an interested
+// operator who just hits "Reply" is lost. Defaults to chris@getcarelinkai.com;
+// override with OUTREACH_REPLY_TO (falls back to ADMIN_NOTIFY_EMAIL).
+const OUTREACH_REPLY_TO =
+  process.env.OUTREACH_REPLY_TO || process.env.ADMIN_NOTIFY_EMAIL || 'chris@getcarelinkai.com';
+
 /**
  * Send a verification email to a new user
  * 
@@ -92,9 +99,10 @@ function escapeHtml(s: string): string {
  * Sentry, but never block the claim itself (the caller never awaits the result
  * in a way that affects the response).
  *
- * Recipient defaults to profyt7@gmail.com (overridable via CLAIM_NOTIFY_EMAIL),
- * cc'd to chris@getcarelinkai.com (overridable / disableable via
- * CLAIM_NOTIFY_CC — set to empty string to drop the cc).
+ * Recipient defaults to chris@getcarelinkai.com (the business inbox), overridable
+ * via ADMIN_NOTIFY_EMAIL (or the legacy CLAIM_NOTIFY_EMAIL, kept for back-compat).
+ * Optional cc via CLAIM_NOTIFY_CC — set to empty string to drop it; a cc that
+ * equals the primary recipient is dropped automatically.
  */
 export async function sendOperatorClaimNotification(args: {
   facilityName: string;
@@ -105,10 +113,11 @@ export async function sendOperatorClaimNotification(args: {
   homeId?: string;
   status?: string;
 }): Promise<boolean> {
-  const to = process.env.CLAIM_NOTIFY_EMAIL || 'profyt7@gmail.com';
-  // cc defaults to chris@; CLAIM_NOTIFY_CC='' explicitly drops it.
-  const ccRaw = process.env.CLAIM_NOTIFY_CC ?? 'chris@getcarelinkai.com';
-  const cc = ccRaw.trim() ? [ccRaw.trim()] : undefined;
+  const to = process.env.ADMIN_NOTIFY_EMAIL || process.env.CLAIM_NOTIFY_EMAIL || 'chris@getcarelinkai.com';
+  // Optional cc (CLAIM_NOTIFY_CC=''  drops it). Default to none; drop a cc that
+  // just duplicates the primary recipient.
+  const ccRaw = (process.env.CLAIM_NOTIFY_CC ?? '').trim();
+  const cc = ccRaw && ccRaw.toLowerCase() !== to.toLowerCase() ? [ccRaw] : undefined;
   try {
     if (!process.env.RESEND_API_KEY) {
       console.error('[Resend] RESEND_API_KEY not configured — skipping operator claim notification');
@@ -232,6 +241,7 @@ export async function sendInquiryClaimNudgeEmail(args: {
     const { data, error } = await resend.emails.send({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [args.toEmail],
+      replyTo: OUTREACH_REPLY_TO,
       subject,
       text,
       html,
@@ -293,6 +303,7 @@ export async function sendNewLeadOperatorEmail(args: {
     const { error } = await resend.emails.send({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [args.toEmail],
+      replyTo: OUTREACH_REPLY_TO,
       subject,
       text,
       html,
@@ -382,6 +393,7 @@ export async function sendClaimDripEmail(args: {
     const { error } = await resend.emails.send({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [args.toEmail],
+      replyTo: OUTREACH_REPLY_TO,
       subject,
       text,
       html,
@@ -479,6 +491,7 @@ export async function sendDirectoryClaimInviteEmail(args: {
     const { data, error } = await resend.emails.send({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [args.toEmail],
+      replyTo: OUTREACH_REPLY_TO,
       subject,
       text,
       html,


### PR DESCRIPTION
## Context

Answers two founder asks about claim notifications, plus a config fix.

## 1. New-claim admin notification → chris@getcarelinkai.com

A claim-admin email **already exists** (OL-079, `sendOperatorClaimNotification`) and is wired fire-and-forget into **both** claim routes (operator self-claim → ACTIVE, admin claim → PENDING_REVIEW). It was **not** absent — but its primary recipient defaulted to `profyt7@gmail.com` (personal Gmail), with chris@ only as cc.

- Primary recipient default changed to **chris@getcarelinkai.com**.
- Now overridable via **`ADMIN_NOTIFY_EMAIL`** (the legacy `CLAIM_NOTIFY_EMAIL` is still honored as a fallback so any existing Render value keeps working).
- The cc (`CLAIM_NOTIFY_CC`) now defaults to none, and a cc equal to the primary recipient is dropped automatically (no more chris-cc-chris).
- Body is already PHI-safe: facility name, operator name/email, timestamp, admin deep link — no resident/health data.

## 2. Reply-To on operator outreach emails

`email.ts` had **no `reply_to` on any send** — so an operator who hit "Reply" on a claim-nudge reached the `noreply@getcarelinkai.com` From address (a black hole).

- Added a shared **`OUTREACH_REPLY_TO`** (defaults to chris@getcarelinkai.com, overridable; falls back to `ADMIN_NOTIFY_EMAIL`) applied to the four operator-facing cold/outreach senders: **inquiry claim-nudge, claim drip, directory claim invite, and the new-lead operator alert**.
- From stays `noreply@` (deliverability); only Reply-To changes, so operator replies now land in a monitored inbox.

## Config

Documented `ADMIN_NOTIFY_EMAIL`, `CLAIM_NOTIFY_CC`, `OUTREACH_REPLY_TO` in `.env.example`.

## Scope

`src/lib/email.ts` + `.env.example`. No schema, no behavior change beyond recipient/reply-to. `tsc` + `next lint` clean.

> Separately investigated the "46 nudged on 2026-06-26" funnel question — **not a drip auto-blast** (the drip only fires per real inquiry/tour and is idempotent per home). Detail in the session chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_