### PR TITLE
feat(discharge-planner): in-app concierge placement flow (AI-matched, care-team-verified)

### DIFF
--- a/prisma/migrations/20260628000001_placement_concierge/migration.sql
+++ b/prisma/migrations/20260628000001_placement_concierge/migration.sql
@@ -1,10 +1,21 @@
 -- Concierge (Wizard-of-Oz) placement fields on PlacementSearch.
 -- Additive + idempotent. Patient data stays in-app (never emailed).
-ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "isConcierge" BOOLEAN NOT NULL DEFAULT false;
-ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeStatus" TEXT;
-ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "patientInfo" JSONB;
-ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "curatedHomes" JSONB;
-ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeNote" TEXT;
-ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeSubmittedAt" TIMESTAMP(3);
-ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeRespondedAt" TIMESTAMP(3);
-CREATE INDEX IF NOT EXISTS "PlacementSearch_conciergeStatus_idx" ON "PlacementSearch" ("conciergeStatus");
+--
+-- NOTE: "PlacementSearch" has no creating migration in this repo (it was created
+-- via `prisma db push` historically), so a fresh `prisma migrate deploy` (e.g. the
+-- e2e CI database) has no such table. Guard on its existence so this migration
+-- applies cleanly where the table exists (prod) and is a safe no-op where it does
+-- not — instead of aborting the whole migrate-deploy step.
+DO $$
+BEGIN
+  IF to_regclass('"PlacementSearch"') IS NOT NULL THEN
+    ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "isConcierge" BOOLEAN NOT NULL DEFAULT false;
+    ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeStatus" TEXT;
+    ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "patientInfo" JSONB;
+    ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "curatedHomes" JSONB;
+    ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeNote" TEXT;
+    ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeSubmittedAt" TIMESTAMP(3);
+    ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeRespondedAt" TIMESTAMP(3);
+    CREATE INDEX IF NOT EXISTS "PlacementSearch_conciergeStatus_idx" ON "PlacementSearch" ("conciergeStatus");
+  END IF;
+END $$;

--- a/prisma/migrations/20260628000001_placement_concierge/migration.sql
+++ b/prisma/migrations/20260628000001_placement_concierge/migration.sql
@@ -1,0 +1,10 @@
+-- Concierge (Wizard-of-Oz) placement fields on PlacementSearch.
+-- Additive + idempotent. Patient data stays in-app (never emailed).
+ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "isConcierge" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeStatus" TEXT;
+ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "patientInfo" JSONB;
+ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "curatedHomes" JSONB;
+ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeNote" TEXT;
+ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeSubmittedAt" TIMESTAMP(3);
+ALTER TABLE "PlacementSearch" ADD COLUMN IF NOT EXISTS "conciergeRespondedAt" TIMESTAMP(3);
+CREATE INDEX IF NOT EXISTS "PlacementSearch_conciergeStatus_idx" ON "PlacementSearch" ("conciergeStatus");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2135,6 +2135,16 @@ model PlacementSearch {
   parsedCriteria     Json               // AI-extracted criteria
   searchResults      Json               // Matched homes with scores
   status             PlacementStatus    @default(SEARCHING)
+  // Concierge (Wizard-of-Oz) placement: the DP submits a patient's needs IN THE APP
+  // and CareLinkAI (admin) curates a shortlist by hand, then sends it back IN THE APP.
+  // No PHI ever leaves the app — patientInfo stays here and is never emailed.
+  isConcierge          Boolean          @default(false)
+  conciergeStatus      String?          // SUBMITTED | MATCHING | SHORTLIST_READY
+  patientInfo          Json?            // minimum-necessary intake; in-app storage only
+  curatedHomes         Json?            // [{ homeId, name, address, note, confirmedAvailability }]
+  conciergeNote        String?          // overall care-team message to the DP
+  conciergeSubmittedAt DateTime?
+  conciergeRespondedAt DateTime?
   createdAt          DateTime           @default(now())
   updatedAt          DateTime           @updatedAt
   user               User               @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -2143,6 +2153,7 @@ model PlacementSearch {
   @@index([userId])
   @@index([status])
   @@index([createdAt])
+  @@index([conciergeStatus])
 }
 
 /// Placement request sent to homes

--- a/src/app/admin/concierge/[id]/page.tsx
+++ b/src/app/admin/concierge/[id]/page.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { toast } from 'react-hot-toast';
+import {
+  ArrowLeft, Loader2, Send, CheckCircle, Star, MapPin, Bed, User, ClipboardList, Clock,
+} from 'lucide-react';
+
+type Match = {
+  homeId: string;
+  homeName: string;
+  address?: string;
+  score?: number;
+  reasoning?: string;
+  careTypes?: string[];
+  availableBeds?: number;
+  startingPrice?: number;
+  contactEmail?: string;
+  contactPhone?: string;
+};
+
+type PatientInfo = {
+  patientName?: string;
+  patientAge?: string;
+  medicalNeeds?: string;
+  timeline?: string;
+  paymentType?: string;
+  additionalNotes?: string;
+  preferredHomeId?: string;
+  preferredHomeName?: string;
+};
+
+type Detail = {
+  id: string;
+  queryText: string;
+  parsedCriteria: any;
+  searchResults: { matches?: Match[] } | null;
+  patientInfo: PatientInfo | null;
+  conciergeStatus: string | null;
+  curatedHomes: { homeId: string; note?: string; confirmedAvailability?: string }[] | null;
+  conciergeNote: string | null;
+  conciergeSubmittedAt: string | null;
+  conciergeRespondedAt: string | null;
+  user: {
+    firstName: string | null; lastName: string | null; email: string | null; phone: string | null;
+    dischargePlannerProfile: { organization: string | null; title: string | null } | null;
+  } | null;
+};
+
+type Selection = { included: boolean; note: string; confirmedAvailability: string };
+
+export default function AdminConciergeCuratePage() {
+  const params = useParams();
+  const router = useRouter();
+  const id = String(params?.id ?? '');
+
+  const [detail, setDetail] = useState<Detail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sel, setSel] = useState<Record<string, Selection>>({});
+  const [note, setNote] = useState('');
+  const [saving, setSaving] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/concierge/${id}`, { cache: 'no-store' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || 'Failed to load');
+      const d: Detail = data.request;
+      setDetail(d);
+      setNote(d.conciergeNote ?? '');
+      // Seed selections from a prior shortlist if present.
+      const prior = new Map((d.curatedHomes ?? []).map((c) => [c.homeId, c]));
+      const seed: Record<string, Selection> = {};
+      (d.searchResults?.matches ?? []).forEach((m) => {
+        const p = prior.get(m.homeId);
+        seed[m.homeId] = {
+          included: !!p,
+          note: p?.note ?? '',
+          confirmedAvailability: p?.confirmedAvailability ?? '',
+        };
+      });
+      setSel(seed);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => { if (id) load(); }, [id, load]);
+
+  const update = (homeId: string, patch: Partial<Selection>) =>
+    setSel((prev) => ({ ...prev, [homeId]: { ...prev[homeId], ...patch } }));
+
+  const markMatching = async () => {
+    setSaving('matching');
+    try {
+      const res = await fetch(`/api/admin/concierge/${id}`, {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'matching' }),
+      });
+      if (!res.ok) throw new Error((await res.json())?.error || 'Failed');
+      toast.success('Marked as Matching');
+      load();
+    } catch (e: any) {
+      toast.error(e?.message || 'Failed');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const sendShortlist = async () => {
+    const curatedHomes = Object.entries(sel)
+      .filter(([, s]) => s.included)
+      .map(([homeId, s]) => ({ homeId, note: s.note, confirmedAvailability: s.confirmedAvailability }));
+    if (curatedHomes.length === 0) {
+      toast.error('Select at least one home for the shortlist');
+      return;
+    }
+    setSaving('respond');
+    try {
+      const res = await fetch(`/api/admin/concierge/${id}`, {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'respond', curatedHomes, conciergeNote: note }),
+      });
+      if (!res.ok) throw new Error((await res.json())?.error || 'Failed');
+      toast.success('Shortlist sent to the discharge planner');
+      router.push('/admin/concierge');
+    } catch (e: any) {
+      toast.error(e?.message || 'Failed');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  if (loading) {
+    return <div className="p-8 flex items-center justify-center text-neutral-500"><Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading…</div>;
+  }
+  if (error || !detail) {
+    return (
+      <div className="p-8 max-w-3xl mx-auto">
+        <div className="bg-error-50 border border-error-200 rounded-xl p-4 text-error-700 text-sm">{error || 'Not found'}</div>
+        <Link href="/admin/concierge" className="inline-flex items-center gap-1 text-primary-600 mt-4 text-sm"><ArrowLeft className="h-4 w-4" /> Back to queue</Link>
+      </div>
+    );
+  }
+
+  const p = detail.patientInfo ?? {};
+  const matches = detail.searchResults?.matches ?? [];
+  const dpName = [detail.user?.firstName, detail.user?.lastName].filter(Boolean).join(' ') || detail.user?.email || 'Discharge planner';
+  const selectedCount = Object.values(sel).filter((s) => s.included).length;
+  const isReady = detail.conciergeStatus === 'SHORTLIST_READY';
+
+  return (
+    <div className="p-4 md:p-6 max-w-5xl mx-auto space-y-6">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <Link href="/admin/concierge" className="inline-flex items-center gap-1 text-primary-600 text-sm font-medium"><ArrowLeft className="h-4 w-4" /> Back to queue</Link>
+        <span className="text-xs text-neutral-500 flex items-center gap-1">
+          <Clock className="h-3 w-3" />
+          Submitted {detail.conciergeSubmittedAt ? new Date(detail.conciergeSubmittedAt).toLocaleString() : '—'}
+          {isReady && detail.conciergeRespondedAt ? ` · Sent ${new Date(detail.conciergeRespondedAt).toLocaleString()}` : ''}
+        </span>
+      </div>
+
+      {/* DP + patient intake */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="bg-white rounded-2xl shadow p-5">
+          <h2 className="text-sm font-semibold text-neutral-700 mb-2 flex items-center gap-2"><User className="h-4 w-4 text-primary-600" /> Discharge planner</h2>
+          <p className="font-semibold text-neutral-900">{dpName}</p>
+          {detail.user?.dischargePlannerProfile?.organization && <p className="text-sm text-neutral-600">{detail.user.dischargePlannerProfile.organization}</p>}
+          <p className="text-sm text-neutral-500 mt-1">{detail.user?.email}{detail.user?.phone ? ` · ${detail.user.phone}` : ''}</p>
+        </div>
+
+        <div className="bg-white rounded-2xl shadow p-5">
+          <h2 className="text-sm font-semibold text-neutral-700 mb-2 flex items-center gap-2"><ClipboardList className="h-4 w-4 text-primary-600" /> Patient intake <span className="text-xs font-normal text-neutral-400">(in-app only)</span></h2>
+          <dl className="text-sm text-neutral-700 space-y-1">
+            {(p.patientName || p.patientAge) && <div><span className="font-medium">Patient:</span> {p.patientName || '—'}{p.patientAge ? `, age ${p.patientAge}` : ''}</div>}
+            {p.timeline && <div><span className="font-medium">Timeline:</span> {p.timeline}</div>}
+            {p.paymentType && <div><span className="font-medium">Payment:</span> {p.paymentType}</div>}
+            {p.preferredHomeName && <div><span className="font-medium">DP preferred:</span> {p.preferredHomeName}</div>}
+            {p.medicalNeeds && <div className="pt-1"><span className="font-medium">Care needs:</span> {p.medicalNeeds}</div>}
+            {p.additionalNotes && <div className="pt-1"><span className="font-medium">Notes:</span> {p.additionalNotes}</div>}
+          </dl>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-2xl shadow p-5">
+        <h2 className="text-sm font-semibold text-neutral-700 mb-1">Original request</h2>
+        <p className="text-sm text-neutral-700">{detail.queryText}</p>
+      </div>
+
+      {/* Curate */}
+      <div className="bg-white rounded-2xl shadow p-5">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-base font-semibold text-neutral-900">Curate the shortlist</h2>
+          <span className="text-sm text-neutral-500">{selectedCount} selected</span>
+        </div>
+
+        {matches.length === 0 ? (
+          <p className="text-sm text-neutral-500">No AI candidate matches were stored for this search.</p>
+        ) : (
+          <div className="space-y-3">
+            {matches.map((m) => {
+              const s = sel[m.homeId] ?? { included: false, note: '', confirmedAvailability: '' };
+              return (
+                <div key={m.homeId} className={`border rounded-xl p-4 transition-colors ${s.included ? 'border-primary-300 bg-primary-50/40' : 'border-neutral-200'}`}>
+                  <div className="flex items-start gap-3">
+                    <input
+                      type="checkbox" checked={s.included}
+                      onChange={(e) => update(m.homeId, { included: e.target.checked })}
+                      className="mt-1.5 h-4 w-4 rounded border-neutral-300 text-primary-600 focus:ring-primary-500"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-semibold text-neutral-900">{m.homeName}</span>
+                        {typeof m.score === 'number' && (
+                          <span className="inline-flex items-center gap-1 bg-primary-100 text-primary-800 px-2 py-0.5 rounded-full text-xs font-medium"><Star className="h-3 w-3 fill-current" /> {m.score}</span>
+                        )}
+                        <Link href={`/homes/${m.homeId}`} target="_blank" className="text-xs text-primary-600 underline">view</Link>
+                      </div>
+                      <div className="text-xs text-neutral-500 flex items-center gap-3 mt-0.5 flex-wrap">
+                        {m.address && <span className="inline-flex items-center gap-1"><MapPin className="h-3 w-3" /> {m.address}</span>}
+                        {typeof m.availableBeds === 'number' && <span className="inline-flex items-center gap-1"><Bed className="h-3 w-3" /> {m.availableBeds} beds</span>}
+                      </div>
+                      {m.reasoning && <p className="text-sm text-neutral-600 mt-2">{m.reasoning}</p>}
+
+                      {s.included && (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
+                          <input
+                            value={s.confirmedAvailability}
+                            onChange={(e) => update(m.homeId, { confirmedAvailability: e.target.value })}
+                            placeholder="Confirmed availability (e.g., 2 beds, ready now)"
+                            className="px-3 py-2 border border-neutral-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                          />
+                          <input
+                            value={s.note}
+                            onChange={(e) => update(m.homeId, { note: e.target.value })}
+                            placeholder="Note to the DP about this home"
+                            className="px-3 py-2 border border-neutral-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                          />
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="mt-5">
+          <label className="block text-sm font-semibold text-neutral-700 mb-2">Message to the discharge planner (optional)</label>
+          <textarea
+            value={note} onChange={(e) => setNote(e.target.value)} rows={3}
+            placeholder="e.g., Here are three strong options with confirmed availability. Two can do a tour this week…"
+            className="w-full px-4 py-3 border border-neutral-300 rounded-lg text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
+          />
+        </div>
+
+        <div className="flex items-center gap-3 mt-5 flex-wrap">
+          <button
+            onClick={markMatching} disabled={!!saving}
+            className="px-4 py-2.5 border border-neutral-300 text-neutral-700 rounded-lg text-sm font-medium hover:bg-neutral-50 disabled:opacity-50 inline-flex items-center gap-2"
+          >
+            {saving === 'matching' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Clock className="h-4 w-4" />} Mark as Matching
+          </button>
+          <button
+            onClick={sendShortlist} disabled={!!saving || selectedCount === 0}
+            className="px-5 py-2.5 bg-gradient-to-r from-primary-600 to-purple-600 text-white rounded-lg text-sm font-semibold hover:from-primary-700 hover:to-purple-700 disabled:opacity-50 inline-flex items-center gap-2"
+          >
+            {saving === 'respond' ? <Loader2 className="h-4 w-4 animate-spin" /> : isReady ? <CheckCircle className="h-4 w-4" /> : <Send className="h-4 w-4" />}
+            {isReady ? 'Re-send updated shortlist' : 'Send shortlist to DP'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/concierge/page.tsx
+++ b/src/app/admin/concierge/page.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { Inbox, Clock, CheckCircle, Loader2, ArrowRight, Stethoscope } from 'lucide-react';
+
+type Row = {
+  id: string;
+  queryText: string;
+  conciergeStatus: 'SUBMITTED' | 'MATCHING' | 'SHORTLIST_READY' | null;
+  conciergeSubmittedAt: string | null;
+  conciergeRespondedAt: string | null;
+  curatedHomes: { homeId: string }[] | null;
+  createdAt: string;
+  user: {
+    firstName: string | null;
+    lastName: string | null;
+    email: string | null;
+    dischargePlannerProfile: { organization: string | null } | null;
+  } | null;
+};
+
+const FILTERS = [
+  { key: 'OPEN', label: 'Open' },
+  { key: 'SUBMITTED', label: 'Submitted' },
+  { key: 'MATCHING', label: 'Matching' },
+  { key: 'SHORTLIST_READY', label: 'Sent' },
+  { key: 'ALL', label: 'All' },
+] as const;
+
+function StatusBadge({ status }: { status: Row['conciergeStatus'] }) {
+  if (status === 'SHORTLIST_READY')
+    return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-success-100 text-success-800"><CheckCircle className="h-3 w-3" /> Sent</span>;
+  if (status === 'MATCHING')
+    return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800"><Loader2 className="h-3 w-3" /> Matching</span>;
+  return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800"><Inbox className="h-3 w-3" /> Submitted</span>;
+}
+
+export default function AdminConciergeQueuePage() {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [filter, setFilter] = useState<(typeof FILTERS)[number]['key']>('OPEN');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const qs = filter === 'OPEN' || filter === 'ALL' ? '' : `?status=${filter}`;
+      const res = await fetch(`/api/admin/concierge${qs}`, { cache: 'no-store' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || 'Failed to load');
+      let list: Row[] = Array.isArray(data.requests) ? data.requests : [];
+      if (filter === 'OPEN') list = list.filter((r) => r.conciergeStatus !== 'SHORTLIST_READY');
+      setRows(list);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load the queue');
+    } finally {
+      setLoading(false);
+    }
+  }, [filter]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const dpName = (r: Row) =>
+    [r.user?.firstName, r.user?.lastName].filter(Boolean).join(' ') || r.user?.email || 'Discharge planner';
+
+  return (
+    <div className="p-4 md:p-6 max-w-5xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-neutral-900 flex items-center gap-2">
+          <Stethoscope className="h-6 w-6 text-primary-600" /> Concierge queue
+        </h1>
+        <p className="text-neutral-600 text-sm mt-1">
+          Discharge-planner placement requests routed to CareLinkAI. Curate a shortlist and send it back in-app.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setFilter(f.key)}
+            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+              filter === f.key ? 'bg-primary-600 text-white' : 'bg-white border border-neutral-200 text-neutral-700 hover:bg-neutral-50'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16 text-neutral-500">
+          <Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading…
+        </div>
+      ) : error ? (
+        <div className="bg-error-50 border border-error-200 rounded-xl p-4 text-error-700 text-sm">{error}</div>
+      ) : rows.length === 0 ? (
+        <div className="bg-white rounded-2xl shadow p-10 text-center text-neutral-500">
+          <Inbox className="h-10 w-10 text-neutral-300 mx-auto mb-3" />
+          Nothing here right now.
+        </div>
+      ) : (
+        <div className="bg-white rounded-2xl shadow divide-y divide-neutral-100">
+          {rows.map((r) => (
+            <Link
+              key={r.id}
+              href={`/admin/concierge/${r.id}`}
+              className="flex items-center justify-between gap-4 p-4 hover:bg-neutral-50 transition-colors"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-semibold text-neutral-900 truncate">{dpName(r)}</span>
+                  {r.user?.dischargePlannerProfile?.organization && (
+                    <span className="text-xs text-neutral-500 truncate">· {r.user.dischargePlannerProfile.organization}</span>
+                  )}
+                </div>
+                <p className="text-sm text-neutral-600 truncate max-w-xl">{r.queryText}</p>
+                <p className="text-xs text-neutral-400 mt-1 flex items-center gap-1">
+                  <Clock className="h-3 w-3" />
+                  {r.conciergeSubmittedAt ? new Date(r.conciergeSubmittedAt).toLocaleString() : new Date(r.createdAt).toLocaleString()}
+                  {r.conciergeStatus === 'SHORTLIST_READY' && r.curatedHomes ? ` · ${r.curatedHomes.length} homes sent` : ''}
+                </p>
+              </div>
+              <div className="flex items-center gap-3 shrink-0">
+                <StatusBadge status={r.conciergeStatus} />
+                <ArrowRight className="h-4 w-4 text-neutral-400" />
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/concierge/[id]/route.ts
+++ b/src/app/api/admin/concierge/[id]/route.ts
@@ -1,0 +1,149 @@
+/**
+ * GET   /api/admin/concierge/[id]   — full concierge request (patient intake +
+ *                                      AI candidate matches + current shortlist).
+ * PATCH /api/admin/concierge/[id]   — curate / advance:
+ *   { action: 'matching' }                              → mark "Matching" (in progress)
+ *   { action: 'respond', curatedHomes, conciergeNote }  → save curated shortlist
+ *                                                          + mark "Shortlist ready"
+ *
+ * curatedHomes in: [{ homeId, note?, confirmedAvailability? }] — the server
+ * enriches each with the home's current name + address before storing, so the
+ * DP-facing shortlist is self-contained.
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { requireRole } from '@/lib/auth-utils';
+import { UserRole } from '@prisma/client';
+
+function authErr(error: any): NextResponse | null {
+  if (error?.name === 'UnauthenticatedError') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (error?.name === 'UnauthorizedError') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  return null;
+}
+
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await requireRole([UserRole.ADMIN]);
+    const row = await prisma.placementSearch.findUnique({
+      where: { id: params.id },
+      select: {
+        id: true,
+        queryText: true,
+        parsedCriteria: true,
+        searchResults: true,
+        patientInfo: true,
+        isConcierge: true,
+        conciergeStatus: true,
+        curatedHomes: true,
+        conciergeNote: true,
+        conciergeSubmittedAt: true,
+        conciergeRespondedAt: true,
+        createdAt: true,
+        user: {
+          select: {
+            firstName: true, lastName: true, email: true, phone: true,
+            dischargePlannerProfile: { select: { organization: true, title: true } },
+          },
+        },
+      },
+    });
+    if (!row || !row.isConcierge) {
+      return NextResponse.json({ error: 'Concierge request not found' }, { status: 404 });
+    }
+    return NextResponse.json({ request: row });
+  } catch (error: any) {
+    const a = authErr(error);
+    if (a) return a;
+    console.error('[admin/concierge/:id] get error:', error);
+    return NextResponse.json({ error: 'Failed to load request' }, { status: 500 });
+  }
+}
+
+const curatedSchema = z.object({
+  homeId: z.string().min(1),
+  note: z.string().optional(),
+  confirmedAvailability: z.string().optional(),
+});
+const patchSchema = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('matching') }),
+  z.object({
+    action: z.literal('respond'),
+    curatedHomes: z.array(curatedSchema).min(1, 'Add at least one home to the shortlist'),
+    conciergeNote: z.string().optional(),
+  }),
+]);
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await requireRole([UserRole.ADMIN]);
+    const body = await request.json().catch(() => ({}));
+    const parsed = patchSchema.parse(body);
+
+    const existing = await prisma.placementSearch.findUnique({
+      where: { id: params.id },
+      select: { id: true, isConcierge: true },
+    });
+    if (!existing || !existing.isConcierge) {
+      return NextResponse.json({ error: 'Concierge request not found' }, { status: 404 });
+    }
+
+    if (parsed.action === 'matching') {
+      await prisma.placementSearch.update({
+        where: { id: params.id },
+        data: { conciergeStatus: 'MATCHING' },
+      });
+      return NextResponse.json({ ok: true, status: 'MATCHING' });
+    }
+
+    // action === 'respond' — enrich curated homes with current name/address.
+    const homeIds = parsed.curatedHomes.map((h) => h.homeId);
+    const homes = await prisma.assistedLivingHome.findMany({
+      where: { id: { in: homeIds } },
+      select: { id: true, name: true, address: { select: { street: true, city: true, state: true, zipCode: true } } },
+    });
+    const byId = new Map(homes.map((h) => [h.id, h]));
+
+    const curated = parsed.curatedHomes
+      .filter((h) => byId.has(h.homeId))
+      .map((h) => {
+        const home = byId.get(h.homeId)!;
+        const a = home.address;
+        const address = a ? `${a.street}, ${a.city}, ${a.state} ${a.zipCode}` : '';
+        return {
+          homeId: h.homeId,
+          name: home.name,
+          address,
+          note: h.note?.trim() || '',
+          confirmedAvailability: h.confirmedAvailability?.trim() || '',
+        };
+      });
+
+    if (curated.length === 0) {
+      return NextResponse.json({ error: 'None of the selected homes exist anymore.' }, { status: 400 });
+    }
+
+    await prisma.placementSearch.update({
+      where: { id: params.id },
+      data: {
+        curatedHomes: curated,
+        conciergeNote: parsed.conciergeNote?.trim() || null,
+        conciergeStatus: 'SHORTLIST_READY',
+        conciergeRespondedAt: new Date(),
+      },
+    });
+
+    return NextResponse.json({ ok: true, status: 'SHORTLIST_READY', curatedCount: curated.length });
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.issues[0]?.message ?? 'Invalid request' }, { status: 400 });
+    }
+    const a = authErr(error);
+    if (a) return a;
+    console.error('[admin/concierge/:id] patch error:', error);
+    return NextResponse.json({ error: 'Could not update the request.' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/concierge/route.ts
+++ b/src/app/api/admin/concierge/route.ts
@@ -1,0 +1,60 @@
+/**
+ * GET /api/admin/concierge
+ * Admin concierge queue: discharge-planner placement requests routed to CareLinkAI.
+ * Optional ?status=SUBMITTED|MATCHING|SHORTLIST_READY filter.
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { requireRole } from '@/lib/auth-utils';
+import { UserRole } from '@prisma/client';
+
+const VALID = ['SUBMITTED', 'MATCHING', 'SHORTLIST_READY'];
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireRole([UserRole.ADMIN]);
+    const status = new URL(request.url).searchParams.get('status');
+
+    const where: any = { isConcierge: true };
+    if (status && VALID.includes(status)) where.conciergeStatus = status;
+
+    const rows = await prisma.placementSearch.findMany({
+      where,
+      select: {
+        id: true,
+        queryText: true,
+        conciergeStatus: true,
+        conciergeSubmittedAt: true,
+        conciergeRespondedAt: true,
+        curatedHomes: true,
+        createdAt: true,
+        user: {
+          select: {
+            firstName: true,
+            lastName: true,
+            email: true,
+            dischargePlannerProfile: { select: { organization: true } },
+          },
+        },
+      },
+      orderBy: [{ conciergeSubmittedAt: 'desc' }],
+      take: 200,
+    });
+
+    // Open = needs Chris's attention (not yet sent back).
+    const openCount = rows.filter((r) => r.conciergeStatus !== 'SHORTLIST_READY').length;
+    return NextResponse.json({ requests: rows, total: rows.length, openCount });
+  } catch (error: any) {
+    if (error?.name === 'UnauthenticatedError') {
+      return NextResponse.json({ error: 'Unauthorized', requests: [] }, { status: 401 });
+    }
+    if (error?.name === 'UnauthorizedError') {
+      return NextResponse.json({ error: 'Forbidden', requests: [] }, { status: 403 });
+    }
+    console.error('[admin/concierge] list error:', error);
+    return NextResponse.json({ error: 'Failed to load queue', requests: [] }, { status: 500 });
+  }
+}

--- a/src/app/api/discharge-planner/concierge/route.ts
+++ b/src/app/api/discharge-planner/concierge/route.ts
@@ -1,0 +1,129 @@
+/**
+ * Discharge-planner CONCIERGE placement requests.
+ *
+ * POST /api/discharge-planner/concierge
+ *   Body: { searchId, patientInfo }
+ *   Routes a placement request to CareLinkAI (admin) instead of auto-emailing
+ *   operators. Persists the patient intake IN-APP on the PlacementSearch and
+ *   notifies the care team (PHI-free email). This is the pilot default — the
+ *   old direct-to-operator email path black-holes on unclaimed (sentinel) homes.
+ *
+ * GET /api/discharge-planner/concierge
+ *   The current DP's concierge requests with status + curated shortlist.
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { requireRole } from '@/lib/auth-utils';
+import { UserRole } from '@prisma/client';
+import { sendConciergeRequestNotification } from '@/lib/email';
+import { captureError } from '@/lib/sentry';
+
+// Minimum-necessary intake. Kept in-app; never emailed out.
+const patientInfoSchema = z.object({
+  patientName: z.string().optional(),
+  patientAge: z.string().optional(),
+  medicalNeeds: z.string().min(1, 'Describe the care needs'),
+  timeline: z.string().optional(),
+  paymentType: z.string().optional(),
+  additionalNotes: z.string().optional(),
+  preferredHomeId: z.string().optional(),
+  preferredHomeName: z.string().optional(),
+});
+
+const submitSchema = z.object({
+  searchId: z.string().min(1),
+  patientInfo: patientInfoSchema,
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireRole([UserRole.DISCHARGE_PLANNER, UserRole.ADMIN]);
+    const body = await request.json().catch(() => ({}));
+    const { searchId, patientInfo } = submitSchema.parse(body);
+
+    // The search must exist and belong to this DP (admins may act on any).
+    const search = await prisma.placementSearch.findUnique({
+      where: { id: searchId },
+      select: { id: true, userId: true },
+    });
+    if (!search) {
+      return NextResponse.json({ error: 'Search not found' }, { status: 404 });
+    }
+    if (search.userId !== user.id && user.role !== UserRole.ADMIN) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    await prisma.placementSearch.update({
+      where: { id: searchId },
+      data: {
+        isConcierge: true,
+        conciergeStatus: 'SUBMITTED',
+        patientInfo,
+        conciergeSubmittedAt: new Date(),
+      },
+    });
+
+    // PHI-free admin alert (DP identity + link only). Fire-and-forget.
+    const dp = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: {
+        firstName: true,
+        lastName: true,
+        dischargePlannerProfile: { select: { organization: true } },
+      },
+    });
+    void sendConciergeRequestNotification({
+      requestId: searchId,
+      dpName: [dp?.firstName, dp?.lastName].filter(Boolean).join(' ') || undefined,
+      dpOrganization: dp?.dischargePlannerProfile?.organization || undefined,
+    });
+
+    return NextResponse.json({ ok: true, status: 'SUBMITTED' });
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.issues[0]?.message ?? 'Invalid request' }, { status: 400 });
+    }
+    if (error?.message?.includes('Unauthorized') || error?.name === 'UnauthorizedError') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    if (error?.name === 'UnauthenticatedError') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    console.error('[concierge] submit error:', error);
+    captureError(error instanceof Error ? error : new Error(String(error)), { tags: { feature: 'concierge' } });
+    return NextResponse.json({ error: 'Could not submit your request. Please try again.' }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  try {
+    const user = await requireRole([UserRole.DISCHARGE_PLANNER, UserRole.ADMIN]);
+    const rows = await prisma.placementSearch.findMany({
+      where: { userId: user.id, isConcierge: true },
+      select: {
+        id: true,
+        queryText: true,
+        conciergeStatus: true,
+        curatedHomes: true,
+        conciergeNote: true,
+        conciergeSubmittedAt: true,
+        conciergeRespondedAt: true,
+        patientInfo: true,
+        createdAt: true,
+      },
+      orderBy: { conciergeSubmittedAt: 'desc' },
+      take: 100,
+    });
+    return NextResponse.json({ requests: rows, total: rows.length });
+  } catch (error: any) {
+    if (error?.name === 'UnauthenticatedError') {
+      return NextResponse.json({ error: 'Unauthorized', requests: [] }, { status: 401 });
+    }
+    console.error('[concierge] list error:', error);
+    return NextResponse.json({ error: 'Failed to load concierge requests', requests: [] }, { status: 500 });
+  }
+}

--- a/src/app/discharge-planner/_components/DischargePlannerDashboard.tsx
+++ b/src/app/discharge-planner/_components/DischargePlannerDashboard.tsx
@@ -343,6 +343,15 @@ export default function DischargePlannerDashboard() {
           </Link>
 
           <Link
+            href="/discharge-planner/concierge"
+            className="p-4 border-2 border-neutral-200 rounded-lg hover:border-primary-500 hover:bg-primary-50 transition-colors group"
+          >
+            <FiUsers className="text-primary-600 mb-2 group-hover:scale-110 transition-transform" size={24} />
+            <p className="font-medium text-neutral-900">Concierge</p>
+            <p className="text-xs text-neutral-600 mt-1">Care-team shortlists</p>
+          </Link>
+
+          <Link
             href="/discharge-planner/history"
             className="p-4 border-2 border-neutral-200 rounded-lg hover:border-success-500 hover:bg-success-50 transition-colors group"
           >

--- a/src/app/discharge-planner/concierge/page.tsx
+++ b/src/app/discharge-planner/concierge/page.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import DashboardLayout from '@/components/layout/DashboardLayout';
+import {
+  ShieldCheck, Search, Clock, Loader2, CheckCircle, MapPin, CalendarCheck, ListChecks, Inbox,
+} from 'lucide-react';
+
+type CuratedHome = {
+  homeId: string;
+  name: string;
+  address?: string;
+  note?: string;
+  confirmedAvailability?: string;
+};
+
+type ConciergeRequest = {
+  id: string;
+  queryText: string;
+  conciergeStatus: 'SUBMITTED' | 'MATCHING' | 'SHORTLIST_READY' | null;
+  curatedHomes: CuratedHome[] | null;
+  conciergeNote: string | null;
+  conciergeSubmittedAt: string | null;
+  conciergeRespondedAt: string | null;
+  createdAt: string;
+};
+
+const STEPS = ['SUBMITTED', 'MATCHING', 'SHORTLIST_READY'] as const;
+const STEP_LABEL: Record<string, string> = {
+  SUBMITTED: 'Submitted',
+  MATCHING: 'Matching',
+  SHORTLIST_READY: 'Shortlist ready',
+};
+
+function StatusTimeline({ status }: { status: ConciergeRequest['conciergeStatus'] }) {
+  const activeIdx = Math.max(0, STEPS.indexOf((status ?? 'SUBMITTED') as any));
+  return (
+    <div className="flex items-center gap-2">
+      {STEPS.map((step, i) => {
+        const done = i <= activeIdx;
+        const isReady = step === 'SHORTLIST_READY' && status === 'SHORTLIST_READY';
+        return (
+          <div key={step} className="flex items-center gap-2">
+            <span
+              className={`inline-flex items-center gap-1 text-xs font-medium px-2.5 py-1 rounded-full ${
+                isReady
+                  ? 'bg-success-100 text-success-800'
+                  : done
+                  ? 'bg-primary-100 text-primary-800'
+                  : 'bg-neutral-100 text-neutral-500'
+              }`}
+            >
+              {step === 'SUBMITTED' && <Inbox className="h-3 w-3" />}
+              {step === 'MATCHING' && (done && !isReady && status === 'MATCHING' ? <Loader2 className="h-3 w-3 animate-spin" /> : <Clock className="h-3 w-3" />)}
+              {step === 'SHORTLIST_READY' && <CheckCircle className="h-3 w-3" />}
+              {STEP_LABEL[step]}
+            </span>
+            {i < STEPS.length - 1 && <span className={`h-0.5 w-5 ${i < activeIdx ? 'bg-primary-300' : 'bg-neutral-200'}`} />}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function DischargePlannerConciergePage() {
+  const [requests, setRequests] = useState<ConciergeRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/discharge-planner/concierge', { cache: 'no-store' });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data?.error || 'Failed to load');
+        setRequests(Array.isArray(data.requests) ? data.requests : []);
+      } catch (e: any) {
+        setError(e?.message || 'Failed to load your concierge requests');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  return (
+    <DashboardLayout title="Concierge">
+      <div className="p-4 md:p-6 max-w-5xl mx-auto space-y-6">
+        {/* Header */}
+        <div className="bg-gradient-to-r from-primary-600 to-purple-600 rounded-2xl shadow-lg p-8 text-white">
+          <p className="inline-flex items-center gap-1.5 text-xs font-semibold bg-white/15 rounded-full px-3 py-1 mb-2">
+            <ShieldCheck className="h-4 w-4" /> AI-matched, care-team-verified
+          </p>
+          <h1 className="text-3xl font-bold mb-1">Concierge placements</h1>
+          <p className="text-primary-100 max-w-2xl">
+            Describe a patient&apos;s needs and our care team sends you a curated, availability-checked
+            shortlist — right here in the app. Patient details stay private and are never emailed.
+          </p>
+          <Link
+            href="/discharge-planner/search"
+            className="mt-5 inline-flex items-center gap-2 bg-white text-primary-700 px-6 py-3 rounded-lg font-medium hover:bg-primary-50 transition-colors shadow-md"
+          >
+            <Search className="h-5 w-5" /> Start a new placement
+          </Link>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-16 text-neutral-500">
+            <Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading your requests…
+          </div>
+        ) : error ? (
+          <div className="bg-error-50 border border-error-200 rounded-xl p-4 text-error-700 text-sm">{error}</div>
+        ) : requests.length === 0 ? (
+          <div className="bg-white rounded-2xl shadow p-10 text-center">
+            <ListChecks className="h-10 w-10 text-neutral-300 mx-auto mb-3" />
+            <p className="font-medium text-neutral-800">No concierge requests yet</p>
+            <p className="text-sm text-neutral-500 mt-1">
+              Run a placement search, then choose <span className="font-medium">Request a shortlist</span>.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-5">
+            {requests.map((r) => {
+              const ready = r.conciergeStatus === 'SHORTLIST_READY';
+              const homes = Array.isArray(r.curatedHomes) ? r.curatedHomes : [];
+              return (
+                <div key={r.id} className="bg-white rounded-2xl shadow-lg overflow-hidden">
+                  <div className="p-6">
+                    <div className="flex items-start justify-between gap-4 flex-wrap">
+                      <div className="min-w-0">
+                        <p className="text-sm text-neutral-500 mb-1">
+                          Submitted {r.conciergeSubmittedAt ? new Date(r.conciergeSubmittedAt).toLocaleDateString() : new Date(r.createdAt).toLocaleDateString()}
+                        </p>
+                        <p className="text-neutral-800 font-medium line-clamp-2">{r.queryText}</p>
+                      </div>
+                      <StatusTimeline status={r.conciergeStatus} />
+                    </div>
+
+                    {!ready ? (
+                      <div className="mt-5 p-4 rounded-xl bg-primary-50 border border-primary-100 text-sm text-primary-800 flex items-center gap-2">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        {r.conciergeStatus === 'MATCHING'
+                          ? 'Our care team is reviewing availability and curating your shortlist.'
+                          : 'Received — our care team will start curating your shortlist shortly.'}
+                      </div>
+                    ) : (
+                      <div className="mt-5">
+                        {r.conciergeNote && (
+                          <div className="mb-4 p-4 rounded-xl bg-success-50 border border-success-100 text-sm text-success-900">
+                            <span className="font-semibold">From your CareLinkAI care team: </span>{r.conciergeNote}
+                          </div>
+                        )}
+                        <h4 className="text-sm font-semibold text-neutral-700 mb-3 flex items-center gap-2">
+                          <CheckCircle className="h-4 w-4 text-success-600" /> Your curated shortlist ({homes.length})
+                        </h4>
+                        <div className="space-y-3">
+                          {homes.map((h) => (
+                            <div key={h.homeId} className="border border-neutral-200 rounded-xl p-4">
+                              <div className="flex items-start justify-between gap-4 flex-wrap">
+                                <div className="min-w-0">
+                                  <p className="font-semibold text-neutral-900">{h.name}</p>
+                                  {h.address && (
+                                    <p className="text-sm text-neutral-500 flex items-center gap-1 mt-0.5">
+                                      <MapPin className="h-3.5 w-3.5" /> {h.address}
+                                    </p>
+                                  )}
+                                  {h.confirmedAvailability && (
+                                    <p className="text-sm text-success-700 mt-2 inline-flex items-center gap-1">
+                                      <CheckCircle className="h-3.5 w-3.5" /> Availability: {h.confirmedAvailability}
+                                    </p>
+                                  )}
+                                  {h.note && <p className="text-sm text-neutral-700 mt-2">{h.note}</p>}
+                                </div>
+                                <Link
+                                  href={`/homes/${h.homeId}`}
+                                  className="shrink-0 inline-flex items-center gap-2 bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors"
+                                >
+                                  <CalendarCheck className="h-4 w-4" /> View &amp; request a tour
+                                </Link>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/discharge-planner/search/_components/PlacementRequestModal.tsx
+++ b/src/app/discharge-planner/search/_components/PlacementRequestModal.tsx
@@ -2,91 +2,103 @@
 
 import { useState, Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
-import { X, Send, CheckCircle, AlertCircle } from 'lucide-react';
+import { X, Send, CheckCircle, AlertCircle, ShieldCheck } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 
 interface PlacementRequestModalProps {
   isOpen: boolean;
   onClose: () => void;
-  home: {
+  /** Optional "preferred" home the DP clicked from results (concierge hint only). */
+  home?: {
     homeId: string;
     homeName: string;
-    address: string;
-    contactEmail?: string;
-  };
+    address?: string;
+  } | null;
   searchId: string;
+  /** 'concierge' (default) routes to CareLinkAI; 'direct' is the legacy operator email. */
+  mode?: 'concierge' | 'direct';
+  onSubmitted?: () => void;
 }
 
-export default function PlacementRequestModal({ isOpen, onClose, home, searchId }: PlacementRequestModalProps) {
-  const [formData, setFormData] = useState({
+export default function PlacementRequestModal({
+  isOpen,
+  onClose,
+  home,
+  searchId,
+  mode = 'concierge',
+  onSubmitted,
+}: PlacementRequestModalProps) {
+  const concierge = mode !== 'direct';
+
+  const emptyForm = {
     patientName: '',
     patientAge: '',
     medicalNeeds: '',
     timeline: 'immediate',
     paymentType: 'private',
     additionalNotes: '',
-  });
-
+  };
+  const [formData, setFormData] = useState(emptyForm);
   const [isSending, setIsSending] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
-    if (!e || !e.target) return;
+    if (!e?.target) return;
     const { name, value } = e.target;
     if (!name) return;
-    setFormData(prev => ({ ...prev, [name]: value }));
+    setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
-    // Validate required fields before submission
-    if (!formData.patientName || !formData.patientAge || !formData.medicalNeeds) {
-      setError('Please fill in all required fields');
+
+    // Minimum-necessary: care needs are required; patient name is optional
+    // (initials are fine). Direct mode keeps the stricter legacy validation.
+    if (!formData.medicalNeeds || (!concierge && (!formData.patientName || !formData.patientAge))) {
+      setError(concierge ? 'Please describe the care needs.' : 'Please fill in all required fields.');
       return;
     }
-    
+
     setIsSending(true);
     setError(null);
 
     try {
-      const response = await fetch('/api/discharge-planner/placement-request', {
+      const url = concierge
+        ? '/api/discharge-planner/concierge'
+        : '/api/discharge-planner/placement-request';
+      const body = concierge
+        ? {
+            searchId,
+            patientInfo: {
+              ...formData,
+              ...(home?.homeId ? { preferredHomeId: home.homeId, preferredHomeName: home.homeName } : {}),
+            },
+          }
+        : { searchId, homeId: home?.homeId, patientInfo: formData };
+
+      const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          searchId,
-          homeId: home?.homeId,
-          patientInfo: formData,
-        }),
+        body: JSON.stringify(body),
       });
-
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData?.error || 'Failed to send placement request');
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data?.error || 'Failed to submit request');
       }
 
-      const data = await response.json();
       setSuccess(true);
-      toast.success('Placement request sent successfully!');
+      toast.success(concierge ? 'Sent to the CareLinkAI care team' : 'Placement request sent');
+      onSubmitted?.();
 
-      // Auto-close after 2 seconds
       setTimeout(() => {
         onClose();
         setSuccess(false);
-        setFormData({
-          patientName: '',
-          patientAge: '',
-          medicalNeeds: '',
-          timeline: 'immediate',
-          paymentType: 'private',
-          additionalNotes: '',
-        });
-      }, 2000);
+        setFormData(emptyForm);
+      }, 1800);
     } catch (err: any) {
-      console.error('Placement request error:', err);
-      setError(err?.message || 'Failed to send placement request');
-      toast.error(err?.message || 'Failed to send request');
+      setError(err?.message || 'Failed to submit request');
+      toast.error(err?.message || 'Failed to submit request');
     } finally {
       setIsSending(false);
     }
@@ -97,12 +109,8 @@ export default function PlacementRequestModal({ isOpen, onClose, home, searchId 
       <Dialog as="div" className="relative z-50" onClose={onClose}>
         <Transition.Child
           as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
+          enter="ease-out duration-300" enterFrom="opacity-0" enterTo="opacity-100"
+          leave="ease-in duration-200" leaveFrom="opacity-100" leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-black bg-opacity-40" />
         </Transition.Child>
@@ -111,15 +119,10 @@ export default function PlacementRequestModal({ isOpen, onClose, home, searchId 
           <div className="flex min-h-full items-center justify-center p-4 text-center">
             <Transition.Child
               as={Fragment}
-              enter="ease-out duration-300"
-              enterFrom="opacity-0 scale-95"
-              enterTo="opacity-100 scale-100"
-              leave="ease-in duration-200"
-              leaveFrom="opacity-100 scale-100"
-              leaveTo="opacity-0 scale-95"
+              enter="ease-out duration-300" enterFrom="opacity-0 scale-95" enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200" leaveFrom="opacity-100 scale-100" leaveTo="opacity-0 scale-95"
             >
               <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white p-8 text-left align-middle shadow-xl transition-all">
-                {/* Close Button */}
                 <button
                   onClick={onClose}
                   className="absolute top-4 right-4 p-2 text-neutral-400 hover:text-neutral-600 transition-colors"
@@ -127,141 +130,131 @@ export default function PlacementRequestModal({ isOpen, onClose, home, searchId 
                   <X className="h-5 w-5" />
                 </button>
 
-                {/* Success State */}
                 {success ? (
                   <div className="text-center py-8">
                     <div className="mx-auto w-16 h-16 bg-success-100 rounded-full flex items-center justify-center mb-4">
                       <CheckCircle className="h-10 w-10 text-success-600" />
                     </div>
-                    <h3 className="text-2xl font-bold text-neutral-900 mb-2">Request Sent Successfully!</h3>
-                    <p className="text-neutral-600">The facility will receive your placement request shortly.</p>
+                    <h3 className="text-2xl font-bold text-neutral-900 mb-2">
+                      {concierge ? 'Request submitted' : 'Request Sent Successfully!'}
+                    </h3>
+                    <p className="text-neutral-600">
+                      {concierge
+                        ? 'Our care team is building your shortlist. Track it under Concierge.'
+                        : 'The facility will receive your placement request shortly.'}
+                    </p>
                   </div>
                 ) : (
                   <>
-                    {/* Header */}
-                    <Dialog.Title as="h3" className="text-2xl font-bold text-neutral-900 mb-2">
-                      Send Placement Request
+                    <Dialog.Title as="h3" className="text-2xl font-bold text-neutral-900 mb-1">
+                      {concierge ? 'Request a CareLinkAI shortlist' : 'Send Placement Request'}
                     </Dialog.Title>
-                    <p className="text-neutral-600 mb-6">
-                      To: <span className="font-semibold">{home?.homeName || 'Unknown Home'}</span>
-                    </p>
+                    {concierge ? (
+                      <div className="mb-5">
+                        <p className="inline-flex items-center gap-1.5 text-sm font-medium text-primary-700 bg-primary-50 border border-primary-100 rounded-full px-3 py-1">
+                          <ShieldCheck className="h-4 w-4" /> AI-matched, care-team-verified
+                        </p>
+                        <p className="text-neutral-600 text-sm mt-2">
+                          Share the patient&apos;s needs. Our care team reviews real-time availability and
+                          sends you a curated shortlist in the app — patient details stay private and are
+                          never emailed.
+                          {home?.homeName ? (
+                            <> We&apos;ll note your interest in <span className="font-semibold">{home.homeName}</span>.</>
+                          ) : null}
+                        </p>
+                      </div>
+                    ) : (
+                      <p className="text-neutral-600 mb-6">
+                        To: <span className="font-semibold">{home?.homeName || 'Unknown Home'}</span>
+                      </p>
+                    )}
 
-                    {/* Form */}
-                    <form onSubmit={handleSubmit} className="space-y-6">
-                      {/* Patient Name */}
+                    <form onSubmit={handleSubmit} className="space-y-5">
                       <div>
                         <label htmlFor="patientName" className="block text-sm font-semibold text-neutral-700 mb-2">
-                          Patient Name *
+                          Patient Name or Initials {concierge ? '(optional)' : '*'}
                         </label>
                         <input
-                          type="text"
-                          id="patientName"
-                          name="patientName"
-                          value={formData.patientName}
-                          onChange={handleChange}
-                          required
+                          type="text" id="patientName" name="patientName"
+                          value={formData.patientName} onChange={handleChange}
+                          required={!concierge}
                           className="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                          placeholder="John Doe"
-                          autoComplete="name"
-                        />
-                      </div>
-
-                      {/* Patient Age */}
-                      <div>
-                        <label htmlFor="patientAge" className="block text-sm font-semibold text-neutral-700 mb-2">
-                          Patient Age *
-                        </label>
-                        <input
-                          type="number"
-                          id="patientAge"
-                          name="patientAge"
-                          value={formData.patientAge}
-                          onChange={handleChange}
-                          required
-                          min="0"
-                          max="150"
-                          className="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                          placeholder="78"
+                          placeholder={concierge ? 'e.g., J.D.' : 'John Doe'}
                           autoComplete="off"
                         />
                       </div>
 
-                      {/* Medical Needs */}
+                      <div>
+                        <label htmlFor="patientAge" className="block text-sm font-semibold text-neutral-700 mb-2">
+                          Patient Age {concierge ? '(optional)' : '*'}
+                        </label>
+                        <input
+                          type="number" id="patientAge" name="patientAge"
+                          value={formData.patientAge} onChange={handleChange}
+                          required={!concierge} min="0" max="150"
+                          className="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                          placeholder="78" autoComplete="off"
+                        />
+                      </div>
+
                       <div>
                         <label htmlFor="medicalNeeds" className="block text-sm font-semibold text-neutral-700 mb-2">
-                          Medical Needs & Care Requirements *
+                          Care Needs &amp; Requirements *
                         </label>
                         <textarea
-                          id="medicalNeeds"
-                          name="medicalNeeds"
-                          value={formData.medicalNeeds}
-                          onChange={handleChange}
-                          required
-                          rows={4}
+                          id="medicalNeeds" name="medicalNeeds"
+                          value={formData.medicalNeeds} onChange={handleChange}
+                          required rows={4}
                           className="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
                           placeholder="E.g., Moderate Alzheimer's, requires 24/7 supervision, physical therapy 3x/week..."
                         />
                       </div>
 
-                      {/* Timeline */}
-                      <div>
-                        <label htmlFor="timeline" className="block text-sm font-semibold text-neutral-700 mb-2">
-                          Timeline for Placement *
-                        </label>
-                        <select
-                          id="timeline"
-                          name="timeline"
-                          value={formData.timeline}
-                          onChange={handleChange}
-                          required
-                          className="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                        >
-                          <option value="immediate">Immediate (within 1 week)</option>
-                          <option value="urgent">Urgent (1-2 weeks)</option>
-                          <option value="planned">Planned (2-4 weeks)</option>
-                          <option value="flexible">Flexible (1+ months)</option>
-                        </select>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                          <label htmlFor="timeline" className="block text-sm font-semibold text-neutral-700 mb-2">
+                            Timeline
+                          </label>
+                          <select
+                            id="timeline" name="timeline" value={formData.timeline} onChange={handleChange}
+                            className="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                          >
+                            <option value="immediate">Immediate (within 1 week)</option>
+                            <option value="urgent">Urgent (1-2 weeks)</option>
+                            <option value="planned">Planned (2-4 weeks)</option>
+                            <option value="flexible">Flexible (1+ months)</option>
+                          </select>
+                        </div>
+                        <div>
+                          <label htmlFor="paymentType" className="block text-sm font-semibold text-neutral-700 mb-2">
+                            Payment Type
+                          </label>
+                          <select
+                            id="paymentType" name="paymentType" value={formData.paymentType} onChange={handleChange}
+                            className="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                          >
+                            <option value="private">Private Pay</option>
+                            <option value="medicare">Medicare</option>
+                            <option value="medicaid">Medicaid</option>
+                            <option value="insurance">Private Insurance</option>
+                            <option value="va">VA Benefits</option>
+                            <option value="mixed">Mixed/Multiple Sources</option>
+                          </select>
+                        </div>
                       </div>
 
-                      {/* Payment Type */}
-                      <div>
-                        <label htmlFor="paymentType" className="block text-sm font-semibold text-neutral-700 mb-2">
-                          Payment Type *
-                        </label>
-                        <select
-                          id="paymentType"
-                          name="paymentType"
-                          value={formData.paymentType}
-                          onChange={handleChange}
-                          required
-                          className="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                        >
-                          <option value="private">Private Pay</option>
-                          <option value="medicare">Medicare</option>
-                          <option value="medicaid">Medicaid</option>
-                          <option value="insurance">Private Insurance</option>
-                          <option value="va">VA Benefits</option>
-                          <option value="mixed">Mixed/Multiple Sources</option>
-                        </select>
-                      </div>
-
-                      {/* Additional Notes */}
                       <div>
                         <label htmlFor="additionalNotes" className="block text-sm font-semibold text-neutral-700 mb-2">
                           Additional Notes (Optional)
                         </label>
                         <textarea
-                          id="additionalNotes"
-                          name="additionalNotes"
-                          value={formData.additionalNotes}
-                          onChange={handleChange}
-                          rows={3}
+                          id="additionalNotes" name="additionalNotes"
+                          value={formData.additionalNotes} onChange={handleChange} rows={3}
                           className="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
-                          placeholder="Any special requirements or preferences..."
+                          placeholder="Location preferences, room type, special requirements..."
                         />
                       </div>
 
-                      {/* Error Display */}
                       {error && (
                         <div className="p-4 bg-error-50 border border-error-200 rounded-lg flex items-start gap-2">
                           <AlertCircle className="h-5 w-5 text-error-600 flex-shrink-0 mt-0.5" />
@@ -269,30 +262,26 @@ export default function PlacementRequestModal({ isOpen, onClose, home, searchId 
                         </div>
                       )}
 
-                      {/* Actions */}
-                      <div className="flex items-center gap-3 pt-4">
+                      <div className="flex items-center gap-3 pt-2">
                         <button
-                          type="button"
-                          onClick={onClose}
+                          type="button" onClick={onClose} disabled={isSending}
                           className="flex-1 px-6 py-3 border border-neutral-300 text-neutral-700 rounded-lg font-semibold hover:bg-neutral-50 transition-colors"
-                          disabled={isSending}
                         >
                           Cancel
                         </button>
                         <button
-                          type="submit"
-                          disabled={isSending}
+                          type="submit" disabled={isSending}
                           className="flex-1 bg-gradient-to-r from-primary-600 to-purple-600 text-white py-3 px-6 rounded-lg font-semibold hover:from-primary-700 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 flex items-center justify-center gap-2"
                         >
                           {isSending ? (
                             <>
                               <div className="animate-spin h-5 w-5 border-2 border-white border-t-transparent rounded-full" />
-                              <span>Sending...</span>
+                              <span>Submitting...</span>
                             </>
                           ) : (
                             <>
                               <Send className="h-4 w-4" />
-                              <span>Send Request</span>
+                              <span>{concierge ? 'Submit to CareLinkAI' : 'Send Request'}</span>
                             </>
                           )}
                         </button>

--- a/src/app/discharge-planner/search/_components/SearchResults.tsx
+++ b/src/app/discharge-planner/search/_components/SearchResults.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { MapPin, Bed, DollarSign, CheckCircle, Send, Phone, Mail, Star, RefreshCw } from 'lucide-react';
+import { MapPin, Bed, DollarSign, CheckCircle, Send, Phone, Mail, Star, RefreshCw, ShieldCheck } from 'lucide-react';
 import PlacementRequestModal from './PlacementRequestModal';
 
 interface SearchResult {
@@ -32,8 +32,16 @@ export default function SearchResults({ searchId, query, matches, totalMatches }
   const [refreshingAvailability, setRefreshingAvailability] = useState(false);
   const [availabilityFetchedAt, setAvailabilityFetchedAt] = useState<string | null>(null);
 
+  // Concierge is the pilot default: a request routes to the CareLinkAI care team
+  // (in-app), never an auto-email to the operator. Clicking a specific home just
+  // records it as a preferred option for the curator.
   const handleSendRequest = (home: SearchResult) => {
     setSelectedHome(home);
+    setIsModalOpen(true);
+  };
+
+  const handleConcierge = () => {
+    setSelectedHome(null);
     setIsModalOpen(true);
   };
 
@@ -94,6 +102,29 @@ export default function SearchResults({ searchId, query, matches, totalMatches }
           <p className="text-sm text-neutral-700">
             <span className="font-semibold">Your search:</span> {query}
           </p>
+        </div>
+      </div>
+
+      {/* Concierge CTA — the pilot default. Routes to the CareLinkAI care team in-app. */}
+      <div className="bg-gradient-to-r from-primary-600 to-purple-600 rounded-2xl shadow-lg p-6 text-white">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <p className="inline-flex items-center gap-1.5 text-xs font-semibold bg-white/15 rounded-full px-3 py-1 mb-2">
+              <ShieldCheck className="h-4 w-4" /> AI-matched, care-team-verified
+            </p>
+            <h3 className="text-xl font-bold">Have CareLinkAI build your shortlist</h3>
+            <p className="text-primary-100 text-sm mt-1 max-w-xl">
+              Share the patient&apos;s needs once. Our care team confirms real-time availability and sends
+              a curated shortlist back to you in the app. Patient details stay private — never emailed.
+            </p>
+          </div>
+          <button
+            onClick={handleConcierge}
+            className="shrink-0 bg-white text-primary-700 py-3 px-6 rounded-xl font-semibold hover:bg-primary-50 transition-colors inline-flex items-center justify-center gap-2 shadow-md"
+          >
+            <Send className="h-4 w-4" />
+            Request a shortlist
+          </button>
         </div>
       </div>
 
@@ -234,7 +265,7 @@ export default function SearchResults({ searchId, query, matches, totalMatches }
                   className="bg-gradient-to-r from-primary-600 to-purple-600 text-white py-3 px-6 rounded-xl font-semibold hover:from-primary-700 hover:to-purple-700 transition-all duration-200 flex items-center gap-2 shadow-lg hover:shadow-xl"
                 >
                   <Send className="h-4 w-4" />
-                  <span>Send Placement Request</span>
+                  <span>Request via CareLinkAI</span>
                 </button>
               </div>
             </div>
@@ -242,15 +273,14 @@ export default function SearchResults({ searchId, query, matches, totalMatches }
         ))}
       </div>
 
-      {/* Placement Request Modal */}
-      {selectedHome && (
-        <PlacementRequestModal
-          isOpen={isModalOpen}
-          onClose={handleCloseModal}
-          home={selectedHome}
-          searchId={searchId}
-        />
-      )}
+      {/* Concierge request modal (home is an optional "preferred" hint). */}
+      <PlacementRequestModal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        home={selectedHome}
+        searchId={searchId}
+        mode="concierge"
+      />
     </div>
   );
 }

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -132,6 +132,7 @@ const navItems: NavItem[] = [
     children: [
       { name: "AI Match", icon: <FiZap size={18} />, href: "/dashboard/find-care", showInMobileBar: true, roleRestriction: ["FAMILY", "OPERATOR", "ADMIN"] },
       { name: "Discharge Planner", icon: <Stethoscope size={18} />, href: "/discharge-planner", showInMobileBar: true, roleRestriction: ["DISCHARGE_PLANNER"] },
+      { name: "Concierge", icon: <Stethoscope size={18} />, href: "/discharge-planner/concierge", showInMobileBar: false, roleRestriction: ["DISCHARGE_PLANNER"] },
     ]
   },
   
@@ -280,6 +281,7 @@ const navItems: NavItem[] = [
       { name: "Inquiries", icon: <FiFileText size={18} />, href: "/admin/inquiries", showInMobileBar: false, roleRestriction: ["ADMIN"] },
       { name: "Affiliates", icon: <FiUsers size={18} />, href: "/admin/affiliates", showInMobileBar: false, roleRestriction: ["ADMIN"] },
       { name: "Discharge Planners", icon: <FiFileText size={18} />, href: "/admin/discharge-planners", showInMobileBar: false, roleRestriction: ["ADMIN"] },
+      { name: "Concierge Queue", icon: <Stethoscope size={18} />, href: "/admin/concierge", showInMobileBar: false, roleRestriction: ["ADMIN"] },
       { name: "Analytics", icon: <FiBarChart2 size={18} />, href: "/admin/analytics", showInMobileBar: false, roleRestriction: ["ADMIN"] },
       { name: "Audit Logs", icon: <FiFileText size={18} />, href: "/admin/audit-logs", showInMobileBar: false, roleRestriction: ["ADMIN"] },
       { name: "ePHI Access Log", icon: <FiShield size={18} />, href: "/admin/phi-access", showInMobileBar: false, roleRestriction: ["ADMIN"] },

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -188,6 +188,66 @@ export async function sendOperatorClaimNotification(args: {
 }
 
 /**
+ * Notify the care team (admin) that a discharge planner submitted an in-app
+ * CONCIERGE placement request, so Chris can curate a shortlist. This is the
+ * "Wizard of Oz" path — the DP sees an AI-powered concierge; behind the scenes
+ * a human curates.
+ *
+ * HIPAA: this email is intentionally PHI-FREE. It NEVER includes patient details
+ * or the DP's free-text query (which can contain patient info). It carries only
+ * the DP's name/org and a deep link into the admin concierge queue, where the
+ * patient data lives behind auth. Fire-and-forget; logs + Sentry on failure.
+ *
+ * Recipient defaults to chris@getcarelinkai.com, overridable via ADMIN_NOTIFY_EMAIL.
+ */
+export async function sendConciergeRequestNotification(args: {
+  /** Concierge request id (PlacementSearch id) for the admin deep link. */
+  requestId: string;
+  /** Display name of the submitting discharge planner, if known. */
+  dpName?: string;
+  /** DP organization, if known. */
+  dpOrganization?: string;
+}): Promise<boolean> {
+  const to = process.env.ADMIN_NOTIFY_EMAIL || process.env.CLAIM_NOTIFY_EMAIL || 'chris@getcarelinkai.com';
+  try {
+    if (!process.env.RESEND_API_KEY) {
+      console.error('[Resend] RESEND_API_KEY not configured — skipping concierge request notification');
+      return false;
+    }
+    const who = [args.dpName?.trim(), args.dpOrganization?.trim()].filter(Boolean).join(' · ') || 'A discharge planner';
+    const appUrl = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com').replace(/\/$/, '');
+    const adminLink = `${appUrl}/admin/concierge/${args.requestId}`;
+    const { data, error } = await resend.emails.send({
+      from: `${APP_NAME} <${FROM_EMAIL}>`,
+      to: [to],
+      replyTo: OUTREACH_REPLY_TO,
+      subject: '🧑‍⚕️ New concierge placement request',
+      text:
+        `${who} submitted a concierge placement request on CareLinkAI.\n\n` +
+        `Patient details are kept in-app (never emailed). Review and build the shortlist here:\n${adminLink}\n`,
+      html:
+        `<p>${escapeHtml(who)} submitted a <strong>concierge placement request</strong> on CareLinkAI.</p>` +
+        `<p style="color:#6b7280;font-size:13px">Patient details are kept in-app (never emailed).</p>` +
+        `<p><a href="${escapeHtml(adminLink)}">Review &amp; build the shortlist →</a></p>`,
+    });
+    if (error) {
+      console.error('[Resend] Error sending concierge request notification:', error);
+      captureError(error instanceof Error ? error : new Error(String((error as { message?: string })?.message ?? error)),
+        { tags: { feature: 'concierge-notification' }, extra: { requestId: args.requestId } });
+      return false;
+    }
+    console.log('[Resend] ✅ Concierge request notification sent. Email ID:', data?.id);
+    return true;
+  } catch (error) {
+    console.error('[Resend] Exception sending concierge request notification:', error);
+    captureError(error instanceof Error ? error : new Error(String(error)), {
+      tags: { feature: 'concierge-notification' }, extra: { requestId: args.requestId },
+    });
+    return false;
+  }
+}
+
+/**
  * Inquiry→claim "pull" engine (OL-083): when a family inquires on an UNCLAIMED
  * listing and we know the operator's outreach email, nudge them to claim their
  * free listing so they can respond. The notification IS the claim CTA.


### PR DESCRIPTION
## Goal

A discharge planner submits a patient's needs **in the app** and gets a CareLinkAI-curated shortlist back **in the app**. Behind the scenes Chris curates (Wizard of Oz); to the DP it's an AI-powered concierge. **No PHI in email, no bypassing the software.** This replaces the manual email concierge and the old direct-to-operator email path (which black-holed on unclaimed/sentinel listings).

Reuses the existing DP role, AI placement search, intake modal, `PlacementSearch` model, and DP dashboard — the new parts are routing + an admin curate view + surfacing results to the DP.

## 1. Routing (concierge is the pilot default)

- New **`POST /api/discharge-planner/concierge`** routes a request to CareLinkAI: flags the `PlacementSearch` (`isConcierge`, status `SUBMITTED`), stores the **minimum-necessary patient intake in-app**, and notifies **chris@** via a **PHI-free** email (`sendConciergeRequestNotification` — DP identity + admin deep link only; never patient data or the free-text query, which can contain PHI).
- The search results UI now leads with **"Have CareLinkAI build your shortlist"** and every per-home button routes to concierge (clicking a home records it as a *preferred* hint). The legacy direct-to-operator email endpoint is **no longer invoked from the UI**.

## 2. Admin concierge queue

- **`/admin/concierge`** (queue) + **`/admin/concierge/[id]`** (curate) — admin-gated by the existing `admin/layout.tsx`.
- Chris sees the **patient intake + the AI candidate matches pre-populated**, includes/excludes homes, adds a **per-home note + confirmed availability** and an **overall message**, then **"Send shortlist to DP."** Can also mark **"Matching"** while working.
- APIs: `GET /api/admin/concierge`, `GET`/`PATCH /api/admin/concierge/[id]` (`action: 'matching' | 'respond'`). On respond, the server enriches each curated home with its current name/address so the DP view is self-contained.

## 3. DP-facing

- **`/discharge-planner/concierge`** shows each request's status (**Submitted → Matching → Shortlist ready**), the curated shortlist (home + confirmed availability + care-team note), and a **"View & request a tour"** link reusing the existing home/tour flow.
- Framing throughout: **"AI-matched, care-team-verified"** — honest (real AI search + human review; never claims fully automated). Nav links added for DP (Concierge) and Admin (Concierge Queue); a dashboard quick-action too.

## 4. PII/PHI

- Patient data stays in the app's storage (`PlacementSearch.patientInfo`, minimum-necessary fields) and is **never emailed**. The admin alert and all outreach remain PHI-free.

## Schema

Additive idempotent migration `20260628000001_placement_concierge` adds `isConcierge` / `conciergeStatus` / `patientInfo` / `curatedHomes` / `conciergeNote` / `conciergeSubmittedAt` / `conciergeRespondedAt` (+ index) to `PlacementSearch`. No destructive changes.

## Notes / limitations

- The curate set is the search's stored AI candidates; if a search returned zero matches there's nothing to curate (Chris would re-run the search). Fine for the pilot.
- The old `POST /api/discharge-planner/placement-request` (direct operator email) is left in place but unreferenced by the UI; can be removed later.

`tsc` clean, `next lint` clean, `prisma validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_