### PR TITLE
test(concierge): automated e2e + routing/PHI tests for the DP concierge flow

### DIFF
--- a/.github/workflows/e2e-family.yml
+++ b/.github/workflows/e2e-family.yml
@@ -358,6 +358,95 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  e2e-concierge:
+    # Discharge-planner concierge placement flow regression guard (PR #671).
+    # Scoped to the single spec; self-seeds via /api/dev/* (ALLOW_DEV_ENDPOINTS=1).
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: carelinkai_marketplace
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: ${{ secrets.E2E_NEXTAUTH_SECRET }}
+      ALLOW_DEV_ENDPOINTS: "1"
+      ALLOW_INSECURE_AUTH_COOKIE: "1"
+      PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+      # Ephemeral service-container DB only — NEVER prod (see note in the other
+      # e2e jobs). ALLOW_DEV_ENDPOINTS seeding must not reach a real database.
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/carelinkai_marketplace?schema=public
+      S3_DISABLE: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies (including dev)
+        run: npm ci --include=dev
+
+      - name: Get Playwright version
+        id: pw-version
+        shell: bash
+        run: |
+          v=$(npx playwright --version | awk '{print $2}')
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
+      - name: Cache Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: next-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            next-cache-${{ runner.os }}-
+
+      - name: Prepare database schema
+        run: npx prisma migrate deploy
+
+      - name: Build app
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright (DP concierge flow)
+        run: |
+          npx playwright test --config=playwright.e2e.config.ts e2e/concierge-flow.spec.ts --workers=1 --reporter=line
+
+      - name: Upload Playwright test artifacts (Concierge flow) (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results-concierge
+          path: |
+            test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
   e2e-merge-reports:
     name: Merge Playwright reports
     runs-on: ubuntu-latest

--- a/__tests__/concierge.email.test.ts
+++ b/__tests__/concierge.email.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Concierge admin-notification email — PHI safety + correct routing.
+ *
+ * Verifies sendConciergeRequestNotification (the only outbound side effect of a
+ * concierge submit) emits a PHI-FREE message to the admin inbox: DP identity +
+ * a deep link only, with explicit "details kept in-app / never emailed" language.
+ */
+
+const mockSend = jest.fn().mockResolvedValue({ data: { id: 'email_test_1' }, error: null });
+jest.mock('resend', () => ({ Resend: jest.fn().mockImplementation(() => ({ emails: { send: mockSend } })) }));
+jest.mock('@/lib/sentry', () => ({ captureError: jest.fn() }));
+
+import { sendConciergeRequestNotification } from '@/lib/email';
+
+describe('sendConciergeRequestNotification — PHI-free admin alert', () => {
+  beforeEach(() => {
+    mockSend.mockClear();
+    process.env.RESEND_API_KEY = 're_test_key';
+    process.env.ADMIN_NOTIFY_EMAIL = 'chris@getcarelinkai.com';
+    delete process.env.CLAIM_NOTIFY_EMAIL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://getcarelinkai.com';
+  });
+
+  it('sends to the admin inbox with a deep link and no patient data', async () => {
+    const ok = await sendConciergeRequestNotification({
+      requestId: 'search-xyz',
+      dpName: 'Pat Planner',
+      dpOrganization: 'County Hospital',
+    });
+    expect(ok).toBe(true);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+
+    const payload = mockSend.mock.calls[0][0];
+    expect(payload.to).toEqual(['chris@getcarelinkai.com']);
+
+    const blob = JSON.stringify(payload);
+    // Deep link into the admin concierge queue (where the PHI actually lives).
+    expect(blob).toContain('/admin/concierge/search-xyz');
+    // DP identity is fine to include (not PHI).
+    expect(blob).toContain('Pat Planner');
+    // Explicitly tells the admin the details are in-app, not in the email.
+    expect(blob.toLowerCase()).toMatch(/in-app|never emailed/);
+  });
+
+  it('no-ops safely when RESEND_API_KEY is absent', async () => {
+    delete process.env.RESEND_API_KEY;
+    const ok = await sendConciergeRequestNotification({ requestId: 's1' });
+    expect(ok).toBe(false);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/concierge.routing.test.ts
+++ b/__tests__/concierge.routing.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Concierge ROUTING + PHI unit tests (reliable, no e2e harness limits).
+ *
+ * Proves the safety-critical contract of POST /api/discharge-planner/concierge:
+ *  - the request is routed to CareLinkAI (admin) — it flags the PlacementSearch
+ *    and persists the patient intake IN-APP; it creates NO per-home
+ *    PlacementRequest and calls NO operator-email function (the only outbound
+ *    side effect is the PHI-free admin notification);
+ *  - the admin notification is called with ONLY {requestId, dpName, dpOrganization}
+ *    — structurally impossible to leak patient data.
+ */
+
+jest.mock('@/lib/auth-utils', () => ({ requireRole: jest.fn() }));
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    placementSearch: { findUnique: jest.fn(), update: jest.fn() },
+    user: { findUnique: jest.fn() },
+  },
+}));
+jest.mock('@/lib/email', () => ({ sendConciergeRequestNotification: jest.fn().mockResolvedValue(true) }));
+jest.mock('@/lib/sentry', () => ({ captureError: jest.fn() }));
+
+import { POST } from '@/app/api/discharge-planner/concierge/route';
+import { requireRole } from '@/lib/auth-utils';
+import { prisma } from '@/lib/prisma';
+import { sendConciergeRequestNotification } from '@/lib/email';
+
+function makeReq(body: unknown) {
+  return { json: async () => body } as any;
+}
+
+const PATIENT = {
+  patientName: 'J.D.',
+  patientAge: '82',
+  medicalNeeds: 'advanced dementia with wandering; needs secured memory care',
+  timeline: 'urgent',
+  paymentType: 'medicaid',
+  additionalNotes: 'daughter is POA',
+};
+
+describe('POST /api/discharge-planner/concierge — routing + PHI safety', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ id: 'dp-1', role: 'DISCHARGE_PLANNER' });
+    (prisma.placementSearch.findUnique as jest.Mock).mockResolvedValue({ id: 'search-1', userId: 'dp-1' });
+    (prisma.placementSearch.update as jest.Mock).mockResolvedValue({});
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      firstName: 'Pat', lastName: 'Planner',
+      dischargePlannerProfile: { organization: 'County Hospital' },
+    });
+  });
+
+  it('routes to admin, persists patientInfo in-app, and creates no operator-bound request', async () => {
+    const res = await POST(makeReq({ searchId: 'search-1', patientInfo: PATIENT }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, status: 'SUBMITTED' });
+
+    // The search is flagged concierge + SUBMITTED and the intake is stored IN-APP.
+    const updateArg = (prisma.placementSearch.update as jest.Mock).mock.calls[0][0];
+    expect(updateArg.where).toEqual({ id: 'search-1' });
+    expect(updateArg.data.isConcierge).toBe(true);
+    expect(updateArg.data.conciergeStatus).toBe('SUBMITTED');
+    expect(updateArg.data.patientInfo).toEqual(PATIENT);
+    expect(updateArg.data.conciergeSubmittedAt).toBeInstanceOf(Date);
+
+    // No per-home PlacementRequest is created → nothing routed to an operator.
+    expect((prisma as any).placementRequest).toBeUndefined();
+  });
+
+  it('fires a PHI-FREE admin notification (DP identity + requestId only)', async () => {
+    await POST(makeReq({ searchId: 'search-1', patientInfo: PATIENT }));
+
+    expect(sendConciergeRequestNotification).toHaveBeenCalledTimes(1);
+    const arg = (sendConciergeRequestNotification as jest.Mock).mock.calls[0][0];
+    // Exactly the non-PHI fields — no patient data, no free-text query.
+    expect(arg).toEqual({ requestId: 'search-1', dpName: 'Pat Planner', dpOrganization: 'County Hospital' });
+
+    const blob = JSON.stringify(arg).toLowerCase();
+    for (const leak of ['dementia', 'j.d.', 'medicaid', 'poa', 'wandering', 'medicalneeds']) {
+      expect(blob).not.toContain(leak);
+    }
+  });
+
+  it('rejects a search owned by a different DP (no cross-tenant submit)', async () => {
+    (prisma.placementSearch.findUnique as jest.Mock).mockResolvedValue({ id: 'search-1', userId: 'other-dp' });
+    const res = await POST(makeReq({ searchId: 'search-1', patientInfo: PATIENT }));
+    expect(res.status).toBe(403);
+    expect(prisma.placementSearch.update).not.toHaveBeenCalled();
+    expect(sendConciergeRequestNotification).not.toHaveBeenCalled();
+  });
+
+  it('requires care needs (min-necessary validation)', async () => {
+    const res = await POST(makeReq({ searchId: 'search-1', patientInfo: { ...PATIENT, medicalNeeds: '' } }));
+    expect(res.status).toBe(400);
+    expect(prisma.placementSearch.update).not.toHaveBeenCalled();
+  });
+});

--- a/e2e/concierge-flow.spec.ts
+++ b/e2e/concierge-flow.spec.ts
@@ -1,0 +1,215 @@
+import { test, expect, type APIRequestContext, type Browser, type Page } from '@playwright/test';
+
+/**
+ * Discharge-planner CONCIERGE flow regression guard (PR #671).
+ *
+ * Proves a DP can complete the in-app concierge flow AND that it is safely
+ * routed: the request goes to the CareLinkAI admin queue (never auto-emailed to
+ * an operator), patient data is persisted in-app, and the request is access-
+ * controlled.
+ *
+ * Self-seeds via dev endpoints (ALLOW_DEV_ENDPOINTS=1). Each role runs in its own
+ * browser context (isolated cookie jar) so role switches don't race on the
+ * shared session cookie — the failure mode that parked operator-claim-flow.
+ *
+ * Harness limits (asserted at other layers, see report):
+ *  - No ANTHROPIC key in CI → the AI search is seeded via /api/dev/placement-search
+ *    instead of /api/discharge-planner/search; the DP submit itself uses the REAL
+ *    POST /api/discharge-planner/concierge (the exact payload the modal sends).
+ *  - No email capture in CI → "no operator email" is proven structurally here
+ *    (zero PlacementRequest rows created) and the PHI-free admin notification is
+ *    proven in __tests__/concierge.routing.test.ts + concierge.email.test.ts.
+ */
+
+const ts = Date.now();
+const uniq = (p: string) => `${p}-${ts}-${Math.floor(Math.random() * 1e4)}@test.carelinkai.com`;
+const QUERY_MARKER = `E2ECONCIERGE${ts}`; // distinctive token to locate the request in the admin UI
+
+async function login(page: Page, email: string) {
+  await page.goto('/');
+  const status = await page.evaluate(async (e) => {
+    const r = await fetch('/api/dev/login', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: e }), credentials: 'include',
+    });
+    return r.status;
+  }, email);
+  expect(status, `dev-login for ${email}`).toBe(200);
+}
+
+async function api(page: Page, method: string, path: string, body?: unknown) {
+  return page.evaluate(async ({ method, path, body }) => {
+    const r = await fetch(path, {
+      method,
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+      credentials: 'include',
+    });
+    let json: any = null;
+    try { json = await r.json(); } catch { /* no body */ }
+    return { status: r.status, json };
+  }, { method, path, body });
+}
+
+async function newRolePage(browser: Browser, email: string): Promise<Page> {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await login(page, email);
+  return page;
+}
+
+test.describe('@critical DP concierge placement flow', () => {
+  test('DP submits → routes to admin queue (no operator email) → admin curates → DP sees shortlist', async ({
+    browser,
+    request,
+  }) => {
+    const dpEmail = uniq('dp-concierge');
+    const dp2Email = uniq('dp-other');
+    const opEmail = uniq('op-seed');
+    const adminEmail = 'admin@carelinkai.com';
+
+    // ---- Seed (dev endpoints; no auth) ----
+    const opRes = await request.post('/api/dev/upsert-operator', {
+      data: {
+        email: opEmail,
+        companyName: 'Concierge Seed Homes',
+        homes: [
+          { name: 'Lakeview Memory Care', capacity: 12 },
+          { name: 'Maple Assisted Living', capacity: 16 },
+        ],
+      },
+    });
+    expect(opRes.ok()).toBeTruthy();
+    const homes = (await opRes.json()).homes as Array<{ id: string; name: string }>;
+    expect(homes.length).toBe(2);
+
+    await request.post('/api/dev/upsert-admin', { data: { email: adminEmail } });
+    const dpRes = await request.post('/api/dev/upsert-discharge-planner', {
+      data: { email: dpEmail, organization: 'County Hospital' },
+    });
+    expect(dpRes.ok()).toBeTruthy();
+    await request.post('/api/dev/upsert-discharge-planner', { data: { email: dp2Email, organization: 'Other Clinic' } });
+
+    // Seed an AI search (stands in for /api/discharge-planner/search; no ANTHROPIC in CI).
+    const searchRes = await request.post('/api/dev/placement-search', {
+      data: {
+        email: dpEmail,
+        queryText: `${QUERY_MARKER} memory care near 44114, Medicaid, urgent, secured unit`,
+        matches: homes.map((h, i) => ({
+          homeId: h.id, homeName: h.name, address: `${100 + i} Main St, Cleveland, OH 44114`,
+          score: 95 - i * 5, reasoning: 'Strong fit on care level + location.',
+          careTypes: ['ASSISTED'], availableBeds: 3 - i, startingPrice: 4500 + i * 500, amenities: ['wifi'],
+        })),
+      },
+    });
+    expect(searchRes.ok()).toBeTruthy();
+    const searchId = (await searchRes.json()).searchId as string;
+    expect(searchId).toBeTruthy();
+
+    // ---------------------------------------------------------------
+    // ITEM 1 — DP logs in and reaches /discharge-planner with no error
+    // ---------------------------------------------------------------
+    const dpPage = await newRolePage(browser, dpEmail);
+    await dpPage.goto('/discharge-planner', { waitUntil: 'domcontentloaded' });
+    await expect(dpPage.getByText('Discharge Planning Assistant')).toBeVisible({ timeout: 30000 });
+
+    // ---------------------------------------------------------------
+    // ITEM 2 — DP submits the concierge request (real endpoint, min-necessary fields)
+    // ---------------------------------------------------------------
+    const patientInfo = {
+      patientName: 'J.D.', patientAge: '82',
+      medicalNeeds: 'advanced dementia with wandering; needs secured memory care',
+      timeline: 'urgent', paymentType: 'medicaid', additionalNotes: 'POA is daughter',
+    };
+    const submit = await api(dpPage, 'POST', '/api/discharge-planner/concierge', { searchId, patientInfo });
+    expect(submit.status, JSON.stringify(submit.json)).toBe(200);
+    expect(submit.json).toMatchObject({ ok: true, status: 'SUBMITTED' });
+
+    // ---------------------------------------------------------------
+    // ITEM 4/5/7 — routed to admin, patientInfo persisted in-app, NO operator-bound request
+    // ---------------------------------------------------------------
+    const afterSubmit = await request.get(`/api/dev/placement-search?id=${searchId}`);
+    const st1 = await afterSubmit.json();
+    expect(st1.isConcierge).toBe(true);
+    expect(st1.conciergeStatus).toBe('SUBMITTED');
+    expect(st1.patientInfo?.medicalNeeds).toContain('dementia'); // persisted in-app
+    expect(st1.placementRequestCount).toBe(0);                   // nothing routed to an operator
+
+    // ---------------------------------------------------------------
+    // ITEM 3 (part 1) — DP dashboard shows the request as Submitted
+    // ---------------------------------------------------------------
+    await dpPage.goto('/discharge-planner/concierge', { waitUntil: 'domcontentloaded' });
+    await expect(dpPage.getByText(QUERY_MARKER, { exact: false })).toBeVisible({ timeout: 30000 });
+    await expect(dpPage.getByText(/our care team will start curating/i)).toBeVisible();
+
+    // ---------------------------------------------------------------
+    // ITEM 8 — access control
+    // ---------------------------------------------------------------
+    // Anonymous: no admin detail, no DP list.
+    const anonCtx = await browser.newContext();
+    const anonPage = await anonCtx.newPage();
+    await anonPage.goto('/');
+    const anonAdmin = await api(anonPage, 'GET', `/api/admin/concierge/${searchId}`);
+    expect(anonAdmin.status).toBe(401);
+    const anonDp = await api(anonPage, 'GET', '/api/discharge-planner/concierge');
+    expect(anonDp.status).toBe(401);
+
+    // An OPERATOR cannot read the admin concierge detail.
+    const opPage = await newRolePage(browser, opEmail);
+    const opAdmin = await api(opPage, 'GET', `/api/admin/concierge/${searchId}`);
+    expect(opAdmin.status).toBe(403);
+
+    // A DIFFERENT DP cannot see this DP's concierge request.
+    const dp2Page = await newRolePage(browser, dp2Email);
+    const dp2List = await api(dp2Page, 'GET', '/api/discharge-planner/concierge');
+    expect(dp2List.status).toBe(200);
+    const dp2Ids = (dp2List.json?.requests ?? []).map((r: any) => r.id);
+    expect(dp2Ids).not.toContain(searchId);
+
+    // ---------------------------------------------------------------
+    // ITEM 9 + ITEM 4 (UI) — admin sees it in /admin/concierge, pre-populated with candidates, curates
+    // ---------------------------------------------------------------
+    const adminPage = await newRolePage(browser, adminEmail);
+    await adminPage.goto('/admin/concierge', { waitUntil: 'domcontentloaded' });
+    await expect(adminPage.getByText(QUERY_MARKER, { exact: false })).toBeVisible({ timeout: 30000 });
+
+    // Detail is pre-populated with the AI candidate matches.
+    const detail = await api(adminPage, 'GET', `/api/admin/concierge/${searchId}`);
+    expect(detail.status).toBe(200);
+    expect(detail.json?.request?.searchResults?.matches?.length).toBe(2);
+    expect(detail.json?.request?.patientInfo?.medicalNeeds).toContain('dementia');
+
+    // ITEM 3 (progression) — admin marks Matching; DP sees Matching.
+    const matching = await api(adminPage, 'PATCH', `/api/admin/concierge/${searchId}`, { action: 'matching' });
+    expect(matching.status).toBe(200);
+    await dpPage.goto('/discharge-planner/concierge', { waitUntil: 'domcontentloaded' });
+    await expect(dpPage.getByText(/care team is reviewing availability/i)).toBeVisible({ timeout: 30000 });
+
+    // Admin curates a shortlist (1 home, with note + confirmed availability) and sends it.
+    const respond = await api(adminPage, 'PATCH', `/api/admin/concierge/${searchId}`, {
+      action: 'respond',
+      curatedHomes: [{ homeId: homes[0].id, note: 'Secured dementia unit, strong staffing.', confirmedAvailability: '2 beds, ready this week' }],
+      conciergeNote: 'Two great options — Lakeview can tour Thursday.',
+    });
+    expect(respond.status, JSON.stringify(respond.json)).toBe(200);
+    expect(respond.json).toMatchObject({ ok: true, status: 'SHORTLIST_READY', curatedCount: 1 });
+
+    // State: shortlist saved, STILL zero operator-bound requests.
+    const afterRespond = await (await request.get(`/api/dev/placement-search?id=${searchId}`)).json();
+    expect(afterRespond.conciergeStatus).toBe('SHORTLIST_READY');
+    expect(Array.isArray(afterRespond.curatedHomes) && afterRespond.curatedHomes.length).toBe(1);
+    expect(afterRespond.curatedHomes[0].name).toBe(homes[0].name);
+    expect(afterRespond.placementRequestCount).toBe(0);
+
+    // ---------------------------------------------------------------
+    // ITEM 3 (part 2) — DP sees the curated shortlist + a "request a tour" action
+    // ---------------------------------------------------------------
+    await dpPage.goto('/discharge-planner/concierge', { waitUntil: 'domcontentloaded' });
+    await expect(dpPage.getByText(/your curated shortlist/i)).toBeVisible({ timeout: 30000 });
+    await expect(dpPage.getByText(homes[0].name)).toBeVisible();
+    await expect(dpPage.getByText(/2 beds, ready this week/i)).toBeVisible();
+    const tour = dpPage.getByRole('link', { name: /request a tour/i }).first();
+    await expect(tour).toBeVisible();
+    await expect(tour).toHaveAttribute('href', new RegExp(`/homes/${homes[0].id}`));
+  });
+});

--- a/prisma/migrations/20260628000002_backfill_placement_tables/migration.sql
+++ b/prisma/migrations/20260628000002_backfill_placement_tables/migration.sql
@@ -1,0 +1,73 @@
+-- Backfill the PlacementSearch / PlacementRequest tables + their enums.
+--
+-- These models exist in schema.prisma but were created via `prisma db push`
+-- historically — there is no CREATE TABLE for them in the migration history
+-- (OL-105). A fresh `prisma migrate deploy` (e2e CI DB, disaster recovery, any
+-- new env) therefore lacked them, which (a) broke the DP search + concierge
+-- features there and (b) made the concierge migration (20260628000001) a no-op.
+--
+-- This migration is fully idempotent: CREATE TYPE is guarded, tables use
+-- CREATE TABLE IF NOT EXISTS, indexes use IF NOT EXISTS. In production (where the
+-- tables already exist from db push) every statement is a no-op; on a fresh DB it
+-- creates the complete current-schema tables (incl. the concierge columns added
+-- by 20260628000001). Ordered AFTER the concierge migration so prod — which has
+-- already applied 20260628000001 — simply no-ops this one.
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PlacementStatus') THEN
+    CREATE TYPE "PlacementStatus" AS ENUM ('SEARCHING', 'COMPLETED', 'CANCELLED');
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'RequestStatus') THEN
+    CREATE TYPE "RequestStatus" AS ENUM ('PENDING', 'SENT', 'VIEWED', 'RESPONDED', 'ACCEPTED', 'DECLINED');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "PlacementSearch" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "queryText" TEXT NOT NULL,
+  "parsedCriteria" JSONB NOT NULL,
+  "searchResults" JSONB NOT NULL,
+  "status" "PlacementStatus" NOT NULL DEFAULT 'SEARCHING',
+  "isConcierge" BOOLEAN NOT NULL DEFAULT false,
+  "conciergeStatus" TEXT,
+  "patientInfo" JSONB,
+  "curatedHomes" JSONB,
+  "conciergeNote" TEXT,
+  "conciergeSubmittedAt" TIMESTAMP(3),
+  "conciergeRespondedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PlacementSearch_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "PlacementSearch_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "PlacementRequest" (
+  "id" TEXT NOT NULL,
+  "searchId" TEXT NOT NULL,
+  "homeId" TEXT NOT NULL,
+  "patientInfo" JSONB NOT NULL,
+  "status" "RequestStatus" NOT NULL DEFAULT 'PENDING',
+  "emailSentAt" TIMESTAMP(3),
+  "emailDeliveryStatus" TEXT,
+  "homeResponse" TEXT,
+  "homeResponseAt" TIMESTAMP(3),
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PlacementRequest_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "PlacementRequest_searchId_fkey" FOREIGN KEY ("searchId") REFERENCES "PlacementSearch"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "PlacementRequest_homeId_fkey" FOREIGN KEY ("homeId") REFERENCES "AssistedLivingHome"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "PlacementSearch_userId_idx" ON "PlacementSearch" ("userId");
+CREATE INDEX IF NOT EXISTS "PlacementSearch_status_idx" ON "PlacementSearch" ("status");
+CREATE INDEX IF NOT EXISTS "PlacementSearch_createdAt_idx" ON "PlacementSearch" ("createdAt");
+CREATE INDEX IF NOT EXISTS "PlacementSearch_conciergeStatus_idx" ON "PlacementSearch" ("conciergeStatus");
+CREATE INDEX IF NOT EXISTS "PlacementRequest_searchId_idx" ON "PlacementRequest" ("searchId");
+CREATE INDEX IF NOT EXISTS "PlacementRequest_homeId_idx" ON "PlacementRequest" ("homeId");
+CREATE INDEX IF NOT EXISTS "PlacementRequest_status_idx" ON "PlacementRequest" ("status");
+CREATE INDEX IF NOT EXISTS "PlacementRequest_createdAt_idx" ON "PlacementRequest" ("createdAt");

--- a/prisma/migrations/20260628000003_userrole_add_discharge_planner/migration.sql
+++ b/prisma/migrations/20260628000003_userrole_add_discharge_planner/migration.sql
@@ -1,0 +1,13 @@
+-- Backfill the DISCHARGE_PLANNER value on the UserRole enum.
+--
+-- Like the PlacementSearch tables (OL-105), this enum value was added to
+-- schema.prisma via `prisma db push` and never captured in a migration — every
+-- other UserRole value is present in the migration history, but DISCHARGE_PLANNER
+-- is not. A fresh `prisma migrate deploy` (e2e CI DB, new env) therefore builds a
+-- UserRole enum WITHOUT it, so creating a discharge-planner user fails with
+-- "invalid input value for enum UserRole: DISCHARGE_PLANNER".
+--
+-- Idempotent (IF NOT EXISTS): a no-op in prod (where db push already added it),
+-- adds it on a fresh DB. PG 12+ permits ADD VALUE inside a transaction as long as
+-- the value is not used in the same transaction (it isn't here).
+ALTER TYPE "UserRole" ADD VALUE IF NOT EXISTS 'DISCHARGE_PLANNER';

--- a/src/app/api/dev/placement-search/route.ts
+++ b/src/app/api/dev/placement-search/route.ts
@@ -1,0 +1,82 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * DEV-ONLY PlacementSearch helper (ALLOW_DEV_ENDPOINTS=1).
+ *
+ * POST: seed a COMPLETED PlacementSearch for a DP with caller-supplied AI
+ *   "matches" — stands in for /api/discharge-planner/search, which needs
+ *   ANTHROPIC_API_KEY (absent in CI). Body: { email, queryText, matches:[...] }.
+ *   Returns { searchId }.
+ *
+ * GET ?id=...: read raw concierge-relevant state for assertions, incl. a
+ *   placementRequestCount so a test can prove the concierge path created NO
+ *   per-home PlacementRequest rows (i.e. nothing was routed to an operator).
+ */
+export async function POST(req: NextRequest) {
+  if (process.env['ALLOW_DEV_ENDPOINTS'] !== '1') {
+    return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+  }
+  try {
+    const body = await req.json().catch(() => ({} as any));
+    const email: string | undefined = body.email?.toLowerCase?.();
+    const queryText: string = body.queryText || 'Memory care near 44114, Medicaid, urgent';
+    const matches: any[] = Array.isArray(body.matches) ? body.matches : [];
+    if (!email) return NextResponse.json({ error: 'email required' }, { status: 400 });
+
+    const user = await prisma.user.findUnique({ where: { email }, select: { id: true } });
+    if (!user) return NextResponse.json({ error: 'user not found' }, { status: 404 });
+
+    const search = await prisma.placementSearch.create({
+      data: {
+        userId: user.id,
+        queryText,
+        parsedCriteria: {},
+        searchResults: { matches },
+        status: 'COMPLETED',
+      },
+      select: { id: true },
+    });
+    return NextResponse.json({ success: true, searchId: search.id });
+  } catch (e) {
+    console.error('dev placement-search POST error', e);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  if (process.env['ALLOW_DEV_ENDPOINTS'] !== '1') {
+    return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+  }
+  try {
+    const id = new URL(req.url).searchParams.get('id');
+    if (!id) return NextResponse.json({ error: 'id required' }, { status: 400 });
+    const s = await prisma.placementSearch.findUnique({
+      where: { id },
+      select: {
+        id: true, isConcierge: true, conciergeStatus: true, patientInfo: true,
+        curatedHomes: true, conciergeNote: true,
+        _count: { select: { placementRequests: true } },
+        user: { select: { email: true } },
+      },
+    });
+    if (!s) return NextResponse.json({ error: 'not found' }, { status: 404 });
+    return NextResponse.json({
+      id: s.id,
+      isConcierge: s.isConcierge,
+      conciergeStatus: s.conciergeStatus,
+      patientInfo: s.patientInfo,
+      curatedHomes: s.curatedHomes,
+      conciergeNote: s.conciergeNote,
+      placementRequestCount: s._count.placementRequests,
+      userEmail: s.user?.email ?? null,
+    });
+  } catch (e) {
+    console.error('dev placement-search GET error', e);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/dev/upsert-discharge-planner/route.ts
+++ b/src/app/api/dev/upsert-discharge-planner/route.ts
@@ -1,0 +1,44 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { UserRole, UserStatus } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import bcrypt from 'bcryptjs';
+
+// DEV-ONLY: create/refresh a DISCHARGE_PLANNER user + DischargePlannerProfile.
+// Enabled only when ALLOW_DEV_ENDPOINTS=1. Mirrors upsert-family/upsert-operator.
+export async function POST(req: NextRequest) {
+  if (process.env['ALLOW_DEV_ENDPOINTS'] !== '1') {
+    return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+  }
+  try {
+    const body = await req.json().catch(() => ({} as any));
+    const email: string = ((body.email as string) || 'dp+e2e@carelinkai.com').toLowerCase();
+    const rawPassword: string = (body.password as string) || 'Planner123!';
+    const firstName: string = (body.firstName as string) || 'Demo';
+    const lastName: string = (body.lastName as string) || 'Planner';
+    const organization: string | null = (body.organization as string) ?? null;
+
+    const passwordHash = await bcrypt.hash(rawPassword, 10);
+
+    const user = await prisma.user.upsert({
+      where: { email },
+      update: { passwordHash, role: UserRole.DISCHARGE_PLANNER, status: UserStatus.ACTIVE, emailVerified: new Date(), firstName, lastName },
+      create: { email, passwordHash, role: UserRole.DISCHARGE_PLANNER, status: UserStatus.ACTIVE, firstName, lastName, emailVerified: new Date() },
+      select: { id: true },
+    });
+
+    await prisma.dischargePlannerProfile.upsert({
+      where: { userId: user.id },
+      update: { organization },
+      create: { userId: user.id, organization },
+    });
+
+    return NextResponse.json({ success: true, userId: user.id, email });
+  } catch (e) {
+    console.error('dev upsert-discharge-planner error', e);
+    return NextResponse.json({ success: false, error: 'Server error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## What

Automated test coverage proving a discharge planner can complete the in-app concierge flow (PR #671) **and** that it's safe + correctly routed. Spread across two layers because the CI e2e harness has no email capture and no `ANTHROPIC_API_KEY`:

### Playwright e2e — `e2e/concierge-flow.spec.ts` (new `e2e-concierge` CI job)
- DP logs in → reaches `/discharge-planner` → submits via the **real** `POST /api/discharge-planner/concierge`.
- Asserts: routed to the admin queue (visible in `/admin/concierge`, pre-populated with the AI candidate matches), status progresses **Submitted → Matching → Shortlist ready**, DP then sees the curated shortlist + a **"request a tour"** link to `/homes/<id>`.
- Asserts **no operator-bound `PlacementRequest` row is created** (nothing routed to an operator / the unclaimed sentinel), and access control (anon → 401, operator → 403 on admin detail, a different DP can't see it).
- Each role runs in its **own browser context** (isolated cookie jar) to avoid the session-cookie race that parked `operator-claim-flow`.

### Routing/PHI unit tests (reliable, no harness limits)
- `__tests__/concierge.routing.test.ts` — the submit route flags the search + persists `patientInfo` **in-app**, creates **no** operator request, and calls the admin notification with **only** `{requestId, dpName, dpOrganization}` (structurally impossible to leak patient data); cross-tenant submit rejected; care-needs validation enforced.
- `__tests__/concierge.email.test.ts` — the admin notification is **PHI-free** (DP identity + deep link, "details kept in-app / never emailed"); no-ops without a key.

## Per-item coverage

| # | Assertion | Proven by | Result |
|---|-----------|-----------|--------|
| 1 | DP reaches `/discharge-planner` | e2e (UI) | ✅ |
| 2 | DP submits min-necessary fields, success | e2e (real POST) | ✅ |
| 3 | Status Submitted→Matching→Shortlist ready + DP sees shortlist + tour action | e2e (UI) | ✅ |
| 4 | Routed to `/admin/concierge`, NOT auto-emailed | e2e (admin UI + API) | ✅ |
| 5 | No operator email / nothing to sentinel | e2e (0 `PlacementRequest` rows) + routing unit test | ✅ |
| 6 | PHI-safe admin notification, no patient detail | unit (email + route) | ✅ |
| 7 | Patient data in-app only, not in email | unit (route persists; notify args PHI-free) | ✅ |
| 8 | Access-controlled (other DP / operator / anon) | e2e (401/403/scoped) | ✅ |
| 9 | Admin sees candidates, curates, "Send to DP" reflects to DP | e2e (real PATCH + UI) | ✅ |

> Items 6/7 are asserted at the unit layer because CI has **no email-capture mechanism** (RESEND unset → sends no-op); item 2's submit uses the real endpoint with the exact modal payload because the AI search step needs `ANTHROPIC_API_KEY` (absent in CI) — that step is seeded via a dev endpoint. No product behavior was changed to make anything pass.

## Also fixes OL-105 (required for this to run at all)

The e2e DB is built with `prisma migrate deploy`, and `PlacementSearch`/`PlacementRequest` had **no creating migration** (db-push drift) — so the table didn't exist and the concierge test couldn't run. Migration `20260628000002` backfills both tables + their enums idempotently (`CREATE TABLE/TYPE IF NOT EXISTS`): a **no-op in prod**, and creates them on a fresh `migrate deploy` DB. Closes OL-105.

New dev-only seed endpoints (`/api/dev/upsert-discharge-planner`, `/api/dev/placement-search`) gated by `ALLOW_DEV_ENDPOINTS`.

`tsc`, `next lint`, `prisma validate` clean; the two jest suites pass locally (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_