### PR TITLE
feat(marketing): make discharge planners consistently FREE + discoverable signup

### DIFF
--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -126,9 +126,9 @@ const roleOptions = [
   },
   {
     id: "DISCHARGE_PLANNER" as UserRole,
-    label: "Healthcare Professional",
+    label: "Discharge Planner / Case Manager",
     description:
-      "I work at a hospital, rehab center, or healthcare facility",
+      "Hospital discharge planner, case manager, or social worker placing patients.",
     icon: <FiActivity className="h-5 w-5" />,
   },
   {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -753,7 +753,10 @@ export default function HomePage() {
                 <div className="inline-flex h-16 w-16 rounded-full bg-gradient-to-br from-secondary-500 to-primary-500 items-center justify-center mb-4">
                   <FiBriefcase className="text-white text-2xl" />
                 </div>
-                <h3 className="text-xl font-bold text-neutral-900">For Discharge Planners</h3>
+                <div className="flex items-center justify-center gap-2">
+                  <h3 className="text-xl font-bold text-neutral-900">For Discharge Planners</h3>
+                  <span className="text-xs font-bold bg-success-100 text-success-700 border border-success-200 rounded-full px-2.5 py-1 uppercase tracking-wide">Free</span>
+                </div>
               </div>
               <div className="space-y-4">
                 <div className="flex items-start">
@@ -785,7 +788,7 @@ export default function HomePage() {
                 </div>
               </div>
               <div className="mt-4 pt-4 border-t border-secondary-500/20 text-xs text-neutral-500 text-center">
-                Individual license <span className="font-semibold text-neutral-700">$99/mo</span> · Department (up to 10 seats) <span className="font-semibold text-neutral-700">$499/mo</span>
+                Always free — no card required.
               </div>
             </div>
           </div>
@@ -1123,13 +1126,16 @@ export default function HomePage() {
                   </div>
                 </div>
               </div>
-              <div className="mt-8 bg-gradient-to-r from-secondary-500/10 to-primary-500/10 rounded-xl p-6 flex flex-col sm:flex-row items-center justify-between gap-4 border border-secondary-500/20">
+              <div className="mt-8 bg-gradient-to-r from-secondary-50 to-success-50 rounded-xl p-6 flex flex-col sm:flex-row items-center justify-between gap-4 border-2 border-success-300">
                 <div>
-                  <div className="font-bold text-neutral-900 text-lg">Individual: $99/mo · Department (up to 10 seats): $499/mo</div>
-                  <div className="text-sm text-neutral-500 mt-1">14-day free trial. Individual planners or entire hospital departments — one invoice. Cancel anytime.</div>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-bold text-neutral-900 text-lg">Always free for discharge planners &amp; case managers</span>
+                    <span className="bg-success-500 text-white text-xs font-bold px-3 py-1 rounded-full uppercase tracking-wide">Free</span>
+                  </div>
+                  <div className="text-sm text-neutral-500 mt-1">Full access to AI placement search — no subscription, no credit card.</div>
                 </div>
                 <Link href="/auth/register?role=discharge_planner" className="bg-gradient-to-r from-secondary-500 to-primary-500 text-white px-6 py-3 rounded-lg font-semibold hover:opacity-90 transition-opacity whitespace-nowrap shadow-lg">
-                  Start Free →
+                  Get Free Access →
                 </Link>
               </div>
               </div>
@@ -1643,7 +1649,7 @@ export default function HomePage() {
               <AnimatePresence>
                 {openFaqIndex === 2 && (
                   <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} transition={{ duration: 0.25 }} className="overflow-hidden">
-                    <div className="px-6 pb-5 text-neutral-500"><p>For families, CareLinkAI is completely free to use - no credit card required. Care homes and healthcare professionals have subscription plans starting at $99/month with different tiers based on features and volume needs.</p></div>
+                    <div className="px-6 pb-5 text-neutral-500"><p>Families, caregivers, and discharge planners use CareLinkAI free — no credit card required. Care home operators have subscription plans starting at $99/month with different tiers based on features and volume needs.</p></div>
                   </motion.div>
                 )}
               </AnimatePresence>

--- a/src/components/marketing/DemoRequestForm.tsx
+++ b/src/components/marketing/DemoRequestForm.tsx
@@ -6,6 +6,7 @@ import { FiCheck, FiAlertCircle, FiArrowRight, FiLoader } from "react-icons/fi";
 const ROLE_OPTIONS = [
   { value: "operator", label: "Assisted Living Operator / Administrator" },
   { value: "family", label: "Family Member / Care Manager" },
+  { value: "discharge_planner", label: "Discharge Planner / Hospital Case Manager" },
   { value: "caregiver", label: "Caregiver / Care Professional" },
   { value: "provider", label: "Home Care Agency" },
   { value: "other", label: "Other" },


### PR DESCRIPTION
## Why

DP access is free (#659), but the marketing homepage + signup still showed DP pricing/trials and an ambiguous signup role. This makes it consistent and makes the DP signup path discoverable. **Operator / caregiver / family pricing untouched.**

## Changes (per item)

1. **"Who It Serves" → Discharge Planners panel** — removed `Individual: $99/mo · Department (up to 10 seats): $499/mo` + the 14-day-trial/"one invoice"/"Cancel anytime" copy + the "Start Free" CTA. Replaced with a **FREE** badge + **"Always free for discharge planners & case managers"** + **"Get Free Access"** CTA (mirrors the existing $0 DP card).
2. **"How It Works" → "For Discharge Planners" card** — removed the `Individual license $99/mo · Department (up to 10 seats) $499/mo` footer; added the green **FREE** badge next to the heading (same badge as *For Families* / *For Caregivers*); footer now reads **"Always free — no card required."**
3. **Remaining DP-pricing strings** — the FAQ answer no longer implies discharge planners pay: now *"Families, caregivers, and discharge planners use CareLinkAI free … Care home operators have subscription plans starting at $99/month."* All other `$99`/`$499` strings are operator/provider and were left intact — **including the operator GROWTH plan's "Discharge planner integration" feature line** (operator-paid feature, correct to keep).
4. **Signup role step** — relabeled the discharge-planner option: title **"Discharge Planner / Case Manager"**, subtext **"Hospital discharge planner, case manager, or social worker placing patients."** The option `id` stays `DISCHARGE_PLANNER`, so it still maps to the role, creates the `DischargePlannerProfile` (register API), and routes to `/discharge-planner` (register `page.tsx` line ~302). **Verified — only display text changed.**
5. **"Request a Demo" → "I am a…" dropdown** — added **"Discharge Planner / Hospital Case Manager"**.

## Verification

- Grepped `page.tsx`: no DP-tied `$99`/`$499`/14-day strings remain; every remaining one is operator (Starter $99 / Growth $499 / "Plans from $99/mo" / pricing-section trial banner) or provider (marketplace listing $99).
- `tsc`, `next lint` clean on all three files.

After deploy: homepage shows no DP pricing; the signup role reads "Discharge Planner / Case Manager."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_