### PR TITLE
fix(dp): hide sentinel address + neutralize $0/0-bed cards; clarify post-signup verify UX

### DIFF
--- a/src/app/api/discharge-planner/search/route.ts
+++ b/src/app/api/discharge-planner/search/route.ts
@@ -15,6 +15,9 @@ import { captureError } from "@/lib/sentry";
 import { getAnthropicClient, requireAnthropicKey } from "@/lib/ai/claude";
 import { sanitizeCareLevels, buildLocationWhere } from "@/lib/discharge-planner/criteria";
 
+// Sentinel operator that owns unclaimed/directory listings — must never surface to a DP.
+const DIRECTORY_UNCLAIMED_EMAIL = "directory-unclaimed@carelinkai.system";
+
 const searchRequestSchema = z.object({
   query: z.string().min(10, "Query must be at least 10 characters"),
 });
@@ -269,6 +272,15 @@ Consider: timeline urgency/bed availability, care level match, payment type, loc
           ? `${home.address.street}, ${home.address.city}, ${home.address.state} ${home.address.zipCode}`
           : "Address not available";
 
+        // Unclaimed/directory listings are owned by the sentinel operator. Never
+        // expose that internal address (or any operator contact) to a DP — and
+        // treat their price/occupancy data as UNVERIFIED so the card shows a
+        // neutral state instead of a misleading "$0/mo" / "0 beds".
+        const ownerEmail = (home.operator?.user?.email ?? "").toLowerCase();
+        const isUnclaimed = ownerEmail === DIRECTORY_UNCLAIMED_EMAIL;
+        const priceMin = home.priceMin != null ? parseFloat(home.priceMin.toString()) : 0;
+        const beds = home.capacity - home.currentOccupancy;
+
         return {
           homeId: home.id,
           homeName: home.name,
@@ -276,11 +288,15 @@ Consider: timeline urgency/bed availability, care level match, payment type, loc
           score: match.score ?? 0,
           reasoning: match.reasoning ?? "Good match",
           careTypes: home.careLevel,
-          availableBeds: home.capacity - home.currentOccupancy,
-          startingPrice: parseFloat(home.priceMin?.toString() ?? "0"),
+          // null = unverified/unknown → card shows "Availability on request", not 0.
+          availableBeds: isUnclaimed || !(home.capacity > 0) ? null : beds,
+          // null = pricing not verified → card shows "Pricing not verified", not "$0/mo".
+          startingPrice: priceMin > 0 ? priceMin : null,
           amenities: home.amenities,
-          contactEmail: home.operator?.user?.email ?? undefined,
-          contactPhone: home.operator?.user?.phone ?? undefined,
+          // Never leak the sentinel address; unclaimed leads route via CareLinkAI.
+          contactEmail: isUnclaimed ? undefined : home.operator?.user?.email ?? undefined,
+          contactPhone: isUnclaimed ? undefined : home.operator?.user?.phone ?? undefined,
+          isUnclaimed,
         };
       })
       .filter((m) => m !== null);

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -25,6 +25,8 @@ export default function LoginPage() {
   const callbackUrl = searchParams.get("callbackUrl") || "/";
   const registeredParam = searchParams.get("registered");
   const verifiedParam = searchParams.get("verified");
+  const verifyParam = searchParams.get("verify");
+  const emailParam = searchParams.get("email");
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -34,14 +36,29 @@ export default function LoginPage() {
   const [userEmail, setUserEmail] = useState<string>("");
 
   useEffect(() => {
+    // Post-registration: an account starts PENDING and CANNOT sign in until the
+    // emailed verification link is clicked. Guide the user to verify rather than
+    // (misleadingly) telling them to sign in. Surface the resend control too.
+    if (verifyParam === "1") {
+      setSuccess(
+        emailParam
+          ? `Account created. We've sent a verification link to ${emailParam} — please verify your email before signing in.`
+          : "Account created. We've sent you a verification link — please verify your email before signing in."
+      );
+      if (emailParam) setUserEmail(emailParam);
+      setShowVerificationHelp(true);
+      return;
+    }
     if (registeredParam === "true") {
-      setSuccess("Your account has been created. Please sign in below.");
+      // Legacy entry point — still gated on verification, so don't imply "just sign in".
+      setSuccess("Account created. Please verify your email before signing in — check your inbox for the verification link.");
+      setShowVerificationHelp(true);
       return;
     }
     if (verifiedParam === "true") {
       setSuccess("Your email has been verified. You can now sign in.");
     }
-  }, [registeredParam, verifiedParam]);
+  }, [registeredParam, verifiedParam, verifyParam, emailParam]);
 
   const { register, handleSubmit, formState: { errors } } = useForm<FormData>();
 

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -305,7 +305,7 @@ export default function RegisterPage() {
               router.push("/dashboard");
             }
           } else {
-            router.push("/auth/login?registered=true");
+            router.push(`/auth/login?verify=1&email=${encodeURIComponent(data.email)}`);
           }
         } catch (signInError) {
           console.error("Auto sign-in error:", signInError);

--- a/src/app/discharge-planner/search/_components/SearchResults.tsx
+++ b/src/app/discharge-planner/search/_components/SearchResults.tsx
@@ -11,11 +11,12 @@ interface SearchResult {
   score: number;
   reasoning: string;
   careTypes: string[];
-  availableBeds: number;
-  startingPrice: number;
+  availableBeds: number | null;
+  startingPrice: number | null;
   amenities: string[];
   contactEmail?: string;
   contactPhone?: string;
+  isUnclaimed?: boolean;
 }
 
 interface SearchResultsProps {
@@ -178,7 +179,9 @@ export default function SearchResults({ searchId, query, matches, totalMatches }
                   <p className="text-2xl font-bold text-neutral-900">
                     {home?.homeId && liveAvailability[home.homeId] !== undefined
                       ? liveAvailability[home.homeId]
-                      : (home?.availableBeds || 0)}
+                      : home?.availableBeds != null
+                        ? home.availableBeds
+                        : <span className="text-base font-semibold text-neutral-500">Availability on request</span>}
                   </p>
                 </div>
 
@@ -188,7 +191,11 @@ export default function SearchResults({ searchId, query, matches, totalMatches }
                     <DollarSign className="h-5 w-5 text-success-600" />
                     <span className="text-sm font-semibold text-neutral-700">Starting Price</span>
                   </div>
-                  <p className="text-2xl font-bold text-neutral-900">${(home?.startingPrice || 0)?.toLocaleString()}<span className="text-sm text-neutral-600">/mo</span></p>
+                  <p className="text-2xl font-bold text-neutral-900">
+                    {home?.startingPrice != null
+                      ? <>${home.startingPrice.toLocaleString()}<span className="text-sm text-neutral-600">/mo</span></>
+                      : <span className="text-base font-semibold text-neutral-500">Pricing not verified</span>}
+                  </p>
                 </div>
 
                 {/* Care Types */}
@@ -246,17 +253,23 @@ export default function SearchResults({ searchId, query, matches, totalMatches }
               {/* Contact Info & Action */}
               <div className="flex items-center justify-between pt-6 border-t border-neutral-200">
                 <div className="flex items-center gap-4 text-sm text-neutral-600">
-                  {home?.contactEmail && (
-                    <div className="flex items-center gap-2">
-                      <Mail className="h-4 w-4" />
-                      <span>{home.contactEmail}</span>
-                    </div>
-                  )}
-                  {home?.contactPhone && (
-                    <div className="flex items-center gap-2">
-                      <Phone className="h-4 w-4" />
-                      <span>{home.contactPhone}</span>
-                    </div>
+                  {home?.isUnclaimed ? (
+                    <span className="text-neutral-400 italic">Unclaimed — request via CareLinkAI</span>
+                  ) : (
+                    <>
+                      {home?.contactEmail && (
+                        <div className="flex items-center gap-2">
+                          <Mail className="h-4 w-4" />
+                          <span>{home.contactEmail}</span>
+                        </div>
+                      )}
+                      {home?.contactPhone && (
+                        <div className="flex items-center gap-2">
+                          <Phone className="h-4 w-4" />
+                          <span>{home.contactPhone}</span>
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
 


### PR DESCRIPTION
## A. `/discharge-planner/search` result cards

**1. Internal sentinel address leak.** Unclaimed/directory listings are owned by the sentinel operator `directory-unclaimed@carelinkai.system`, and the card rendered that as the home's contact email — a DP must never see it. The search **route** now detects unclaimed homes and strips the address + any operator contact; the **card** shows a neutral *"Unclaimed — request via CareLinkAI"* instead.

**2. Misleading "$0/mo" / "0 beds".** When pricing/occupancy is unverified the card showed a literal `$0/mo` and `0` beds (reads as broken/free, undercuts credibility). The route now sends `null` when data is unverified (`priceMin ≤ 0`, or unclaimed / no capacity), and the card shows **"Pricing not verified"** and **"Availability on request"** — matching the AI reasoning, which already says pricing is unverified.

## B. Post-registration email-verification UX

**What the app does today (investigated):** registration creates a **PENDING** user **and sends a verification email** (`sendVerificationEmailToUser`, fire-and-forget). NextAuth login **is gated** — a PENDING user hits *"Please verify your email before logging in"* (`auth.ts:133`). But the post-signup auto-sign-in always fails (they're PENDING) and dropped them on `/auth/login?registered=true` reading only *"Your account has been created. Please sign in below."* — no mention of verification, and they can't sign in yet. That's the gap.

**Decision: verification already exists → guide users to it** (no new email system needed). Registration now redirects to `/auth/login?verify=1&email=<email>`, and the login page shows *"Account created. We've sent a verification link to &lt;email&gt; — please verify your email before signing in,"* and surfaces the **existing Resend-Verification control** (reused `showVerificationHelp` + `/api/auth/resend-verification`). The legacy `registered=true` message was also corrected to point at verification instead of "just sign in" — so we never tell a user to "sign in" when they actually must verify first.

## Scope / safety
- Route response is now `startingPrice: number | null` / `availableBeds: number | null` + `isUnclaimed`; the only consumers are the DP search card (updated) and the admin concierge curate view (already guards `typeof availableBeds === 'number'`). No pricing/role changes.
- `tsc` + `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_