### PR TITLE
feat(concierge): notify the DP when a shortlist is sent + surface it on the dashboard

### DIFF
--- a/__tests__/concierge.notify.test.ts
+++ b/__tests__/concierge.notify.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Concierge "send to DP" notifications — when an admin sends a shortlist, the DP
+ * gets an in-app bell notification (linking to /discharge-planner/concierge) and a
+ * PHI-free email. "Mark as Matching" notifies nothing.
+ */
+
+jest.mock('@/lib/auth-utils', () => ({ requireRole: jest.fn() }));
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    placementSearch: { findUnique: jest.fn(), update: jest.fn() },
+    assistedLivingHome: { findMany: jest.fn() },
+  },
+}));
+jest.mock('@/lib/services/notifications', () => ({ createInAppNotification: jest.fn().mockResolvedValue({ success: true, id: 'n1' }) }));
+jest.mock('@/lib/email', () => ({ sendConciergeShortlistReadyEmail: jest.fn().mockResolvedValue(true) }));
+
+import { PATCH } from '@/app/api/admin/concierge/[id]/route';
+import { requireRole } from '@/lib/auth-utils';
+import { prisma } from '@/lib/prisma';
+import { createInAppNotification } from '@/lib/services/notifications';
+import { sendConciergeShortlistReadyEmail } from '@/lib/email';
+
+function makeReq(body: unknown) {
+  return { json: async () => body } as any;
+}
+const ctx = { params: { id: 'search-1' } };
+
+describe('PATCH /api/admin/concierge/[id] — DP notifications on send', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ id: 'admin-1', role: 'ADMIN' });
+    (prisma.placementSearch.findUnique as jest.Mock).mockResolvedValue({
+      id: 'search-1', isConcierge: true, userId: 'dp-1', user: { email: 'dp@example.com' },
+    });
+    (prisma.placementSearch.update as jest.Mock).mockResolvedValue({});
+    (prisma.assistedLivingHome.findMany as jest.Mock).mockResolvedValue([
+      { id: 'h1', name: 'Lakeview Memory Care', address: { street: '1 Main', city: 'Cleveland', state: 'OH', zipCode: '44114' } },
+      { id: 'h2', name: 'Maple Assisted Living', address: { street: '2 Main', city: 'Cleveland', state: 'OH', zipCode: '44114' } },
+    ]);
+  });
+
+  it('respond: bell notification (links to concierge) + PHI-free email with only a count', async () => {
+    const res = await PATCH(makeReq({
+      action: 'respond',
+      curatedHomes: [
+        { homeId: 'h1', note: 'secured dementia unit', confirmedAvailability: '2 beds' },
+        { homeId: 'h2' },
+      ],
+      conciergeNote: 'Two strong options.',
+    }), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, status: 'SHORTLIST_READY', curatedCount: 2 });
+
+    // In-app bell to the DP, deep-linking to the concierge page.
+    expect(createInAppNotification).toHaveBeenCalledTimes(1);
+    const note = (createInAppNotification as jest.Mock).mock.calls[0][0];
+    expect(note.userId).toBe('dp-1');
+    expect(note.link).toBe('/discharge-planner/concierge');
+    expect(note.title).toMatch(/shortlist/i);
+
+    // PHI-free email to the DP's own address — count only, no patient/home detail.
+    expect(sendConciergeShortlistReadyEmail).toHaveBeenCalledTimes(1);
+    const email = (sendConciergeShortlistReadyEmail as jest.Mock).mock.calls[0][0];
+    expect(email).toEqual({ toEmail: 'dp@example.com', count: 2 });
+    const blob = JSON.stringify(email).toLowerCase();
+    for (const leak of ['dementia', 'lakeview', 'maple', '1 main', 'secured']) {
+      expect(blob).not.toContain(leak);
+    }
+  });
+
+  it('matching: notifies nothing', async () => {
+    const res = await PATCH(makeReq({ action: 'matching' }), ctx);
+    expect(res.status).toBe(200);
+    expect(createInAppNotification).not.toHaveBeenCalled();
+    expect(sendConciergeShortlistReadyEmail).not.toHaveBeenCalled();
+  });
+});

--- a/e2e/concierge-flow.spec.ts
+++ b/e2e/concierge-flow.spec.ts
@@ -211,5 +211,24 @@ test.describe('@critical DP concierge placement flow', () => {
     const tour = dpPage.getByRole('link', { name: /request a tour/i }).first();
     await expect(tour).toBeVisible();
     await expect(tour).toHaveAttribute('href', new RegExp(`/homes/${homes[0].id}`));
+
+    // ---------------------------------------------------------------
+    // NOTIFY — the DP learns a shortlist is ready: dashboard count + bell + banner
+    // ---------------------------------------------------------------
+    // (a) Main dashboard API reflects the ready shortlist (legacy counters stay 0).
+    const dash = await api(dpPage, 'GET', '/api/discharge-planner/dashboard');
+    expect(dash.status).toBe(200);
+    expect(dash.json?.stats?.conciergeShortlistReady ?? 0).toBeGreaterThanOrEqual(1);
+
+    // (b) An in-app (bell) notification was created, linking to the concierge page.
+    const notifs = await api(dpPage, 'GET', '/api/notifications');
+    expect(notifs.status).toBe(200);
+    const bell = (notifs.json?.notifications ?? []).find((n: any) => n.link === '/discharge-planner/concierge');
+    expect(bell, 'expected a concierge shortlist-ready bell notification').toBeTruthy();
+
+    // (c) The LANDING dashboard surfaces it (not just the Concierge tab).
+    await dpPage.goto('/discharge-planner', { waitUntil: 'domcontentloaded' });
+    await expect(dpPage.getByText(/curated shortlist(s)? ready/i)).toBeVisible({ timeout: 30000 });
+    await expect(dpPage.getByRole('link', { name: /view shortlists/i })).toBeVisible();
   });
 });

--- a/src/app/api/admin/concierge/[id]/route.ts
+++ b/src/app/api/admin/concierge/[id]/route.ts
@@ -18,6 +18,8 @@ import { z } from 'zod';
 import { prisma } from '@/lib/prisma';
 import { requireRole } from '@/lib/auth-utils';
 import { UserRole } from '@prisma/client';
+import { createInAppNotification } from '@/lib/services/notifications';
+import { sendConciergeShortlistReadyEmail } from '@/lib/email';
 
 function authErr(error: any): NextResponse | null {
   if (error?.name === 'UnauthenticatedError') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -85,7 +87,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
 
     const existing = await prisma.placementSearch.findUnique({
       where: { id: params.id },
-      select: { id: true, isConcierge: true },
+      select: { id: true, isConcierge: true, userId: true, user: { select: { email: true } } },
     });
     if (!existing || !existing.isConcierge) {
       return NextResponse.json({ error: 'Concierge request not found' }, { status: 404 });
@@ -135,6 +137,21 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
         conciergeRespondedAt: new Date(),
       },
     });
+
+    // Tell the DP their shortlist is ready: in-app bell badge + PHI-free email.
+    // Fire-and-forget — never block or fail the admin's send on a notify hiccup.
+    const optionWord = curated.length === 1 ? 'option' : 'options';
+    void createInAppNotification({
+      userId: existing.userId,
+      type: 'ALERT',
+      title: 'Your shortlist is ready',
+      message: `Your CareLinkAI care team curated ${curated.length} ${optionWord} for your placement request.`,
+      link: '/discharge-planner/concierge',
+      data: { kind: 'concierge_shortlist_ready', searchId: params.id, count: curated.length },
+    });
+    if (existing.user?.email) {
+      void sendConciergeShortlistReadyEmail({ toEmail: existing.user.email, count: curated.length });
+    }
 
     return NextResponse.json({ ok: true, status: 'SHORTLIST_READY', curatedCount: curated.length });
   } catch (error: any) {

--- a/src/app/api/discharge-planner/dashboard/route.ts
+++ b/src/app/api/discharge-planner/dashboard/route.ts
@@ -118,6 +118,18 @@ export async function GET(request: NextRequest) {
       }),
     };
 
+    // Concierge requests are tracked on PlacementSearch (not PlacementRequest), so
+    // the legacy placement counters above stay 0 for them — surface them explicitly
+    // so a ready shortlist shows on the landing dashboard, not just the Concierge tab.
+    const conciergeStats = {
+      conciergeShortlistReady: await prisma.placementSearch.count({
+        where: { userId: user.id, isConcierge: true, conciergeStatus: 'SHORTLIST_READY' },
+      }),
+      conciergeActive: await prisma.placementSearch.count({
+        where: { userId: user.id, isConcierge: true, conciergeStatus: { in: ['SUBMITTED', 'MATCHING'] } },
+      }),
+    };
+
     console.log("📊 [DP-DASHBOARD] ✅ Dashboard data fetched");
 
     return NextResponse?.json?.(
@@ -127,6 +139,7 @@ export async function GET(request: NextRequest) {
         stats: {
           ...stats,
           ...recentStats,
+          ...conciergeStats,
         },
       },
       { status: 200 }

--- a/src/app/discharge-planner/_components/DischargePlannerDashboard.tsx
+++ b/src/app/discharge-planner/_components/DischargePlannerDashboard.tsx
@@ -25,6 +25,8 @@ type DashboardData = {
     pendingResponses: number;
     searchesLast30Days: number;
     placementsLast30Days: number;
+    conciergeShortlistReady?: number;
+    conciergeActive?: number;
   };
 };
 
@@ -114,6 +116,51 @@ export default function DischargePlannerDashboard() {
           Start New Search
         </button>
       </motion.div>
+
+      {/* Concierge surfacing — a curated shortlist (tracked on PlacementSearch) does
+          not move the legacy placement counters, so make it visible on the landing page. */}
+      {(stats?.conciergeShortlistReady ?? 0) > 0 ? (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="bg-gradient-to-r from-success-50 to-secondary-50 border-2 border-success-300 rounded-lg p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+        >
+          <div className="flex items-center gap-3">
+            <div className="p-2.5 bg-success-100 rounded-full">
+              <FiCheckCircle className="text-success-600" size={22} />
+            </div>
+            <div>
+              <p className="font-bold text-neutral-900">
+                {stats.conciergeShortlistReady} curated shortlist{stats.conciergeShortlistReady === 1 ? "" : "s"} ready
+              </p>
+              <p className="text-sm text-neutral-600">
+                Your CareLinkAI care team matched options with confirmed availability.
+              </p>
+            </div>
+          </div>
+          <Link
+            href="/discharge-planner/concierge"
+            className="bg-success-600 hover:bg-success-700 text-white px-5 py-2.5 rounded-lg font-medium whitespace-nowrap text-center transition-colors"
+          >
+            View shortlists →
+          </Link>
+        </motion.div>
+      ) : (stats?.conciergeActive ?? 0) > 0 ? (
+        <div className="bg-primary-50 border border-primary-200 rounded-lg p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div className="flex items-center gap-3 text-sm text-primary-800">
+            <FiClock className="text-primary-500 flex-shrink-0" />
+            <span>
+              {stats.conciergeActive} concierge request{stats.conciergeActive === 1 ? "" : "s"} in progress — our care team is curating your shortlist.
+            </span>
+          </div>
+          <Link
+            href="/discharge-planner/concierge"
+            className="text-sm font-medium text-primary-700 hover:text-primary-800 whitespace-nowrap"
+          >
+            View →
+          </Link>
+        </div>
+      ) : null}
 
       {/* Stats Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -248,6 +248,60 @@ export async function sendConciergeRequestNotification(args: {
 }
 
 /**
+ * Tell a discharge planner their concierge shortlist is ready (sent when an admin
+ * curates + "Send to DP"). Goes to the DP's OWN account email.
+ *
+ * HIPAA: PHI-FREE by construction — names only the option count and links into the
+ * app where the (auth-gated) shortlist lives. NEVER includes patient details or
+ * the facility names/notes. Fire-and-forget: logged + Sentry on failure, never thrown.
+ */
+export async function sendConciergeShortlistReadyEmail(args: {
+  toEmail: string;
+  count: number;
+}): Promise<boolean> {
+  const toEmail = args.toEmail?.trim();
+  if (!toEmail) return false;
+  try {
+    if (!process.env.RESEND_API_KEY) {
+      console.error('[Resend] RESEND_API_KEY not configured — skipping concierge shortlist-ready email');
+      return false;
+    }
+    const n = args.count > 0 ? args.count : 1;
+    const optionWord = n === 1 ? 'option' : 'options';
+    const appUrl = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com').replace(/\/$/, '');
+    const link = `${appUrl}/discharge-planner/concierge`;
+    const { data, error } = await resend.emails.send({
+      from: `${APP_NAME} <${FROM_EMAIL}>`,
+      to: [toEmail],
+      replyTo: OUTREACH_REPLY_TO,
+      subject: `Your CareLinkAI shortlist is ready — ${n} ${optionWord}`,
+      text:
+        `Your CareLinkAI care team has curated ${n} ${optionWord} for your placement request.\n\n` +
+        `View your shortlist (with confirmed availability) in the app:\n${link}\n\n` +
+        `Details are kept private and secure in CareLinkAI.`,
+      html:
+        `<p>Your CareLinkAI care team has curated <strong>${n} ${optionWord}</strong> for your placement request.</p>` +
+        `<p><a href="${escapeHtml(link)}" style="display:inline-block;background:#0d9488;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600">View your shortlist</a></p>` +
+        `<p style="color:#6b7280;font-size:13px">Details are kept private and secure in CareLinkAI.</p>`,
+    });
+    if (error) {
+      console.error('[Resend] Error sending concierge shortlist-ready email:', error);
+      captureError(error instanceof Error ? error : new Error(String((error as { message?: string })?.message ?? error)),
+        { tags: { feature: 'concierge-shortlist-ready' }, extra: { count: n } });
+      return false;
+    }
+    console.log('[Resend] ✅ Concierge shortlist-ready email sent. Email ID:', data?.id);
+    return true;
+  } catch (error) {
+    console.error('[Resend] Exception sending concierge shortlist-ready email:', error);
+    captureError(error instanceof Error ? error : new Error(String(error)), {
+      tags: { feature: 'concierge-shortlist-ready' },
+    });
+    return false;
+  }
+}
+
+/**
  * Inquiry→claim "pull" engine (OL-083): when a family inquires on an UNCLAIMED
  * listing and we know the operator's outreach email, nudge them to claim their
  * free listing so they can respond. The notification IS the claim CTA.


### PR DESCRIPTION
## Why

The concierge loop works end-to-end, but the **DP side was silent when an admin sends a shortlist** — so the DP can't tell anything happened (the founder hit exactly this in testing). Two fixes.

## 1. Notify the DP on send

When an admin clicks **"Send shortlist to DP"** (→ `SHORTLIST_READY`), the admin respond handler now fires (fire-and-forget, never blocks the send):
- **(a) In-app bell notification** — `createInAppNotification` (type `ALERT`) for the DP, linking to `/discharge-planner/concierge`. Shows on the bell badge.
- **(b) PHI-safe email** to the DP's own account address — `sendConciergeShortlistReadyEmail`: *"Your CareLinkAI shortlist is ready — N options, view in the app."* **Count + link only**; no patient or facility detail in the body. Reply-To is the monitored inbox.

## 2. Surface concierge on the main DP dashboard

Concierge requests are tracked on `PlacementSearch`, so the legacy placement counters stayed `0` and `/discharge-planner` read *"no pending requests / all placements up to date"* even with a shortlist waiting. Now:
- Dashboard API returns `conciergeShortlistReady` / `conciergeActive`.
- `/discharge-planner` shows a **"N curated shortlist(s) ready → View shortlists"** banner when one is ready (or a subtler "in progress" note), so the DP sees concierge activity on the landing page without opening the Concierge tab.

## Verification

- **`__tests__/concierge.notify.test.ts`** (new) — `respond` fires the bell notification (links to the concierge page) **and** the PHI-free email (`{toEmail, count}` only — asserts no patient/home strings leak); `matching` fires nothing.
- **`e2e/concierge-flow.spec.ts`** (extended) — after the admin sends the shortlist, asserts: dashboard API `conciergeShortlistReady ≥ 1`, `/api/notifications` contains a bell notification linking to `/discharge-planner/concierge`, and the landing dashboard shows the "curated shortlist ready / View shortlists" banner.
- 8/8 concierge jest tests pass; `tsc` + `next lint` clean. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_