### PR TITLE
feat(concierge): coordinate shortlist tours — never black-hole, always tracked

### DIFF
--- a/__tests__/concierge.tour.test.ts
+++ b/__tests__/concierge.tour.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Concierge tour coordination — routing + notifications.
+ *
+ * Proves the concierge promise: a tour from a shortlist never black-holes.
+ *  - CLAIMED home   → operator email + admin (Chris) notify; no claim drip.
+ *  - UNCLAIMED home → admin (Chris) notify + claim-conversion signal; no operator email.
+ *  - Idempotent (already-requested → no duplicate notifications).
+ *  - Ownership + status guards.
+ *  - coordinateConciergeInquiry only acts for the DP who owns the search (anti-spoof).
+ *
+ * Uses the REAL persistence helper (markConciergeTourRequested) with prisma mocked.
+ */
+
+jest.mock('@/lib/auth-utils', () => ({ requireRole: jest.fn() }));
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    placementSearch: { findUnique: jest.fn(), update: jest.fn() },
+    assistedLivingHome: { findUnique: jest.fn() },
+  },
+}));
+jest.mock('@/lib/email', () => ({
+  sendConciergeTourNotification: jest.fn().mockResolvedValue(true),
+  sendNewLeadOperatorEmail: jest.fn().mockResolvedValue(true),
+}));
+jest.mock('@/lib/claim-engine/claim-drip', () => ({ startClaimDripOnLead: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('@/lib/sentry', () => ({ captureError: jest.fn() }));
+
+import { POST } from '@/app/api/discharge-planner/concierge/[id]/tour/route';
+import { coordinateConciergeInquiry } from '@/lib/concierge/tour-coordination';
+import { requireRole } from '@/lib/auth-utils';
+import { prisma } from '@/lib/prisma';
+import { sendConciergeTourNotification, sendNewLeadOperatorEmail } from '@/lib/email';
+import { startClaimDripOnLead } from '@/lib/claim-engine/claim-drip';
+
+const SENTINEL = 'directory-unclaimed@carelinkai.system';
+function req(body: unknown) { return { json: async () => body } as any; }
+const ctx = { params: { id: 'search-1' } };
+
+function seedSearch(over: any = {}) {
+  (prisma.placementSearch.findUnique as jest.Mock).mockResolvedValue({
+    id: 'search-1', userId: 'dp-1', isConcierge: true, conciergeStatus: 'SHORTLIST_READY',
+    curatedHomes: [{ homeId: 'h1', name: 'Lakeview' }],
+    user: { firstName: 'Pat', lastName: 'Planner', dischargePlannerProfile: { organization: 'County' } },
+    ...over,
+  });
+}
+function seedHome(email: string | null) {
+  (prisma.assistedLivingHome.findUnique as jest.Mock).mockResolvedValue({
+    id: 'h1', name: 'Lakeview', operator: { user: { email, firstName: 'Olivia' } },
+  });
+}
+
+describe('POST /api/discharge-planner/concierge/[id]/tour', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireRole as jest.Mock).mockResolvedValue({ id: 'dp-1', role: 'DISCHARGE_PLANNER' });
+    (prisma.placementSearch.update as jest.Mock).mockResolvedValue({});
+  });
+
+  it('CLAIMED home → operator email + admin notify, no claim drip', async () => {
+    seedSearch();
+    seedHome('operator@realhome.com');
+    const res = await POST(req({ homeId: 'h1' }), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, tourStatus: 'REQUESTED', claimed: true });
+    expect(sendConciergeTourNotification).toHaveBeenCalledTimes(1);
+    expect((sendConciergeTourNotification as jest.Mock).mock.calls[0][0]).toMatchObject({ facilityName: 'Lakeview', claimed: true });
+    expect(sendNewLeadOperatorEmail).toHaveBeenCalledTimes(1);
+    expect(startClaimDripOnLead).not.toHaveBeenCalled();
+    // status persisted
+    expect((prisma.placementSearch.update as jest.Mock).mock.calls[0][0].data.curatedHomes[0].tourStatus).toBe('REQUESTED');
+  });
+
+  it('UNCLAIMED home → admin notify + claim signal, no operator email', async () => {
+    seedSearch();
+    seedHome(SENTINEL);
+    const res = await POST(req({ homeId: 'h1' }), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, claimed: false });
+    expect(sendConciergeTourNotification).toHaveBeenCalledTimes(1);
+    expect((sendConciergeTourNotification as jest.Mock).mock.calls[0][0]).toMatchObject({ claimed: false });
+    expect(sendNewLeadOperatorEmail).not.toHaveBeenCalled();
+    expect(startClaimDripOnLead).toHaveBeenCalledWith({ homeId: 'h1', trigger: 'tour' });
+  });
+
+  it('already requested → no duplicate notifications', async () => {
+    seedSearch({ curatedHomes: [{ homeId: 'h1', name: 'Lakeview', tourStatus: 'REQUESTED' }] });
+    seedHome(SENTINEL);
+    const res = await POST(req({ homeId: 'h1' }), ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, alreadyRequested: true });
+    expect(sendConciergeTourNotification).not.toHaveBeenCalled();
+    expect(sendNewLeadOperatorEmail).not.toHaveBeenCalled();
+    expect(startClaimDripOnLead).not.toHaveBeenCalled();
+    expect(prisma.placementSearch.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects another DP (cross-tenant)', async () => {
+    seedSearch({ userId: 'other-dp' });
+    const res = await POST(req({ homeId: 'h1' }), ctx);
+    expect(res.status).toBe(403);
+    expect(prisma.placementSearch.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects when no shortlist is ready', async () => {
+    seedSearch({ conciergeStatus: 'MATCHING' });
+    const res = await POST(req({ homeId: 'h1' }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a home that is not on the shortlist', async () => {
+    seedSearch({ curatedHomes: [{ homeId: 'other' }] });
+    const res = await POST(req({ homeId: 'h1' }), ctx);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('coordinateConciergeInquiry — anti-spoof', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prisma.placementSearch.update as jest.Mock).mockResolvedValue({});
+  });
+
+  it('notifies when the requester owns the concierge search', async () => {
+    (prisma.placementSearch.findUnique as jest.Mock).mockResolvedValue({
+      id: 'search-1', userId: 'dp-1', isConcierge: true, curatedHomes: [{ homeId: 'h1' }],
+      user: { firstName: 'Pat', lastName: 'Planner', dischargePlannerProfile: { organization: 'County' } },
+    });
+    await coordinateConciergeInquiry({ searchId: 'search-1', homeId: 'h1', requesterUserId: 'dp-1', facilityName: 'Lakeview', claimed: false });
+    expect(sendConciergeTourNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the requester is not the search owner', async () => {
+    (prisma.placementSearch.findUnique as jest.Mock).mockResolvedValue({
+      id: 'search-1', userId: 'dp-1', isConcierge: true, curatedHomes: [{ homeId: 'h1' }], user: {},
+    });
+    await coordinateConciergeInquiry({ searchId: 'search-1', homeId: 'h1', requesterUserId: 'someone-else', facilityName: 'X', claimed: true });
+    expect(prisma.placementSearch.update).not.toHaveBeenCalled();
+    expect(sendConciergeTourNotification).not.toHaveBeenCalled();
+  });
+});

--- a/e2e/concierge-flow.spec.ts
+++ b/e2e/concierge-flow.spec.ts
@@ -216,15 +216,22 @@ test.describe('@critical DP concierge placement flow', () => {
     // ---------------------------------------------------------------
     // TOUR — request a tour from the shortlist → coordinated + tracked (never black-holes)
     // ---------------------------------------------------------------
-    // force: the button is present + enabled, but page chrome (cookie banner /
-    // care-advisor FAB) can overlay the bottom of the viewport in CI.
-    await dpPage.getByRole('button', { name: /request a tour/i }).first().click({ force: true });
-    await expect(dpPage.getByText(/tour requested/i).first()).toBeVisible({ timeout: 15000 });
-    // Persisted on the shortlist; the curated home is CLAIMED here (real op), so still
-    // zero operator-bound PlacementRequest rows (concierge never creates them).
+    // dispatchEvent: page chrome (cookie banner / care-advisor FAB) can overlay the
+    // viewport bottom in CI; a real click would land on the overlay. Dispatch the
+    // click directly to the button node so React's handler fires regardless.
+    await dpPage.getByRole('button', { name: /request a tour/i }).first().dispatchEvent('click');
+    // Server truth (timing-independent): the tour is recorded on the shortlist.
+    await expect.poll(
+      async () => (await (await request.get(`/api/dev/placement-search?id=${searchId}`)).json())?.curatedHomes?.[0]?.tourStatus ?? null,
+      { timeout: 20000 },
+    ).toBe('REQUESTED');
+    // The curated home is CLAIMED here (real op), so concierge still creates NO
+    // operator-bound PlacementRequest rows.
     const afterTour = await (await request.get(`/api/dev/placement-search?id=${searchId}`)).json();
-    expect(afterTour.curatedHomes?.[0]?.tourStatus).toBe('REQUESTED');
     expect(afterTour.placementRequestCount).toBe(0);
+    // UI reflects it on a fresh load.
+    await dpPage.goto('/discharge-planner/concierge', { waitUntil: 'domcontentloaded' });
+    await expect(dpPage.getByText(/tour requested/i).first()).toBeVisible({ timeout: 30000 });
 
     // ---------------------------------------------------------------
     // NOTIFY — the DP learns a shortlist is ready: dashboard count + bell + banner

--- a/e2e/concierge-flow.spec.ts
+++ b/e2e/concierge-flow.spec.ts
@@ -216,7 +216,9 @@ test.describe('@critical DP concierge placement flow', () => {
     // ---------------------------------------------------------------
     // TOUR — request a tour from the shortlist → coordinated + tracked (never black-holes)
     // ---------------------------------------------------------------
-    await dpPage.getByRole('button', { name: /request a tour/i }).first().click();
+    // force: the button is present + enabled, but page chrome (cookie banner /
+    // care-advisor FAB) can overlay the bottom of the viewport in CI.
+    await dpPage.getByRole('button', { name: /request a tour/i }).first().click({ force: true });
     await expect(dpPage.getByText(/tour requested/i).first()).toBeVisible({ timeout: 15000 });
     // Persisted on the shortlist; the curated home is CLAIMED here (real op), so still
     // zero operator-bound PlacementRequest rows (concierge never creates them).

--- a/e2e/concierge-flow.spec.ts
+++ b/e2e/concierge-flow.spec.ts
@@ -208,9 +208,21 @@ test.describe('@critical DP concierge placement flow', () => {
     await expect(dpPage.getByText(/your curated shortlist/i)).toBeVisible({ timeout: 30000 });
     await expect(dpPage.getByText(homes[0].name)).toBeVisible();
     await expect(dpPage.getByText(/2 beds, ready this week/i)).toBeVisible();
-    const tour = dpPage.getByRole('link', { name: /request a tour/i }).first();
-    await expect(tour).toBeVisible();
-    await expect(tour).toHaveAttribute('href', new RegExp(`/homes/${homes[0].id}`));
+    // "View listing" deep-links to the home carrying the concierge param.
+    const viewLink = dpPage.getByRole('link', { name: /view listing/i }).first();
+    await expect(viewLink).toBeVisible();
+    await expect(viewLink).toHaveAttribute('href', new RegExp(`/homes/${homes[0].id}\\?concierge=`));
+
+    // ---------------------------------------------------------------
+    // TOUR — request a tour from the shortlist → coordinated + tracked (never black-holes)
+    // ---------------------------------------------------------------
+    await dpPage.getByRole('button', { name: /request a tour/i }).first().click();
+    await expect(dpPage.getByText(/tour requested/i).first()).toBeVisible({ timeout: 15000 });
+    // Persisted on the shortlist; the curated home is CLAIMED here (real op), so still
+    // zero operator-bound PlacementRequest rows (concierge never creates them).
+    const afterTour = await (await request.get(`/api/dev/placement-search?id=${searchId}`)).json();
+    expect(afterTour.curatedHomes?.[0]?.tourStatus).toBe('REQUESTED');
+    expect(afterTour.placementRequestCount).toBe(0);
 
     // ---------------------------------------------------------------
     // NOTIFY — the DP learns a shortlist is ready: dashboard count + bell + banner

--- a/src/app/admin/concierge/[id]/page.tsx
+++ b/src/app/admin/concierge/[id]/page.tsx
@@ -39,7 +39,7 @@ type Detail = {
   searchResults: { matches?: Match[] } | null;
   patientInfo: PatientInfo | null;
   conciergeStatus: string | null;
-  curatedHomes: { homeId: string; note?: string; confirmedAvailability?: string }[] | null;
+  curatedHomes: { homeId: string; note?: string; confirmedAvailability?: string; tourStatus?: 'REQUESTED'; tourRequestedAt?: string }[] | null;
   conciergeNote: string | null;
   conciergeSubmittedAt: string | null;
   conciergeRespondedAt: string | null;
@@ -151,6 +151,7 @@ export default function AdminConciergeCuratePage() {
 
   const p = detail.patientInfo ?? {};
   const matches = detail.searchResults?.matches ?? [];
+  const tourRequestedHomeIds = new Set((detail.curatedHomes ?? []).filter((h) => h.tourStatus === 'REQUESTED').map((h) => h.homeId));
   const dpName = [detail.user?.firstName, detail.user?.lastName].filter(Boolean).join(' ') || detail.user?.email || 'Discharge planner';
   const selectedCount = Object.values(sel).filter((s) => s.included).length;
   const isReady = detail.conciergeStatus === 'SHORTLIST_READY';
@@ -219,6 +220,9 @@ export default function AdminConciergeCuratePage() {
                         <span className="font-semibold text-neutral-900">{m.homeName}</span>
                         {typeof m.score === 'number' && (
                           <span className="inline-flex items-center gap-1 bg-primary-100 text-primary-800 px-2 py-0.5 rounded-full text-xs font-medium"><Star className="h-3 w-3 fill-current" /> {m.score}</span>
+                        )}
+                        {tourRequestedHomeIds.has(m.homeId) && (
+                          <span className="inline-flex items-center gap-1 bg-success-100 text-success-800 px-2 py-0.5 rounded-full text-xs font-medium">🗓️ Tour requested</span>
                         )}
                         <Link href={`/homes/${m.homeId}`} target="_blank" className="text-xs text-primary-600 underline">view</Link>
                       </div>

--- a/src/app/api/discharge-planner/concierge/[id]/tour/route.ts
+++ b/src/app/api/discharge-planner/concierge/[id]/tour/route.ts
@@ -1,0 +1,106 @@
+/**
+ * POST /api/discharge-planner/concierge/[id]/tour
+ * Body: { homeId }
+ *
+ * Request a tour for one home on a concierge shortlist. The concierge promise:
+ * this never black-holes.
+ *  - CLAIMED home   → notify the operator directly + cc the care team (Chris).
+ *  - UNCLAIMED home → notify the care team (Chris) to coordinate on the family's
+ *                     behalf + fire the claim-conversion signal (claim drip →
+ *                     operator nudge + Anita's call list).
+ * Tour status is tracked on the shortlist (curatedHomes JSON) so the DP sees it.
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { requireRole } from '@/lib/auth-utils';
+import { UserRole } from '@prisma/client';
+import { sendConciergeTourNotification, sendNewLeadOperatorEmail } from '@/lib/email';
+import { startClaimDripOnLead } from '@/lib/claim-engine/claim-drip';
+import { markConciergeTourRequested, homeIsUnclaimed, CuratedHome } from '@/lib/concierge/tour-coordination';
+import { captureError } from '@/lib/sentry';
+
+const bodySchema = z.object({ homeId: z.string().min(1) });
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const user = await requireRole([UserRole.DISCHARGE_PLANNER, UserRole.ADMIN]);
+    const { homeId } = bodySchema.parse(await request.json().catch(() => ({})));
+
+    const search = await prisma.placementSearch.findUnique({
+      where: { id: params.id },
+      select: {
+        id: true, userId: true, isConcierge: true, conciergeStatus: true, curatedHomes: true,
+        user: { select: { firstName: true, lastName: true, dischargePlannerProfile: { select: { organization: true } } } },
+      },
+    });
+    if (!search || !search.isConcierge) {
+      return NextResponse.json({ error: 'Concierge request not found' }, { status: 404 });
+    }
+    if (search.userId !== user.id && user.role !== UserRole.ADMIN) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    if (search.conciergeStatus !== 'SHORTLIST_READY') {
+      return NextResponse.json({ error: 'No shortlist is ready for this request yet.' }, { status: 400 });
+    }
+    const curated = (Array.isArray(search.curatedHomes) ? search.curatedHomes : []) as unknown as CuratedHome[];
+    if (!curated.some((h) => h?.homeId === homeId)) {
+      return NextResponse.json({ error: 'That home is not on this shortlist.' }, { status: 400 });
+    }
+
+    const home = await prisma.assistedLivingHome.findUnique({
+      where: { id: homeId },
+      select: { id: true, name: true, operator: { select: { user: { select: { email: true, firstName: true } } } } },
+    });
+    if (!home) {
+      return NextResponse.json({ error: 'Home not found' }, { status: 404 });
+    }
+
+    // Persist the DP-visible status first (idempotent). If it was already
+    // requested, return success without re-sending notifications.
+    const mark = await markConciergeTourRequested(params.id, homeId, new Date().toISOString());
+    if (mark === 'not_found') {
+      return NextResponse.json({ error: 'That home is not on this shortlist.' }, { status: 400 });
+    }
+    if (mark === 'already') {
+      return NextResponse.json({ ok: true, tourStatus: 'REQUESTED', alreadyRequested: true });
+    }
+
+    const operatorEmail = home.operator?.user?.email ?? null;
+    const claimed = !homeIsUnclaimed(operatorEmail);
+    const dpName = [search.user?.firstName, search.user?.lastName].filter(Boolean).join(' ') || undefined;
+    const dpOrganization = search.user?.dischargePlannerProfile?.organization || undefined;
+
+    // Always loop in the care team (Chris) so the tour gets coordinated.
+    void sendConciergeTourNotification({ requestId: params.id, facilityName: home.name, claimed, dpName, dpOrganization });
+
+    if (claimed && operatorEmail) {
+      // Operator gets the lead directly (generic copy, no PHI).
+      const appUrl = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com').replace(/\/$/, '');
+      void sendNewLeadOperatorEmail({
+        facilityName: home.name,
+        toEmail: operatorEmail,
+        operatorFirstName: home.operator?.user?.firstName ?? undefined,
+        leadType: 'tour',
+        ctaUrl: `${appUrl}/operator/tours`,
+      });
+    } else if (!claimed) {
+      // Unclaimed: fire the claim-conversion signal (operator nudge + call-list).
+      void startClaimDripOnLead({ homeId, trigger: 'tour' });
+    }
+
+    return NextResponse.json({ ok: true, tourStatus: 'REQUESTED', claimed });
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.issues[0]?.message ?? 'Invalid request' }, { status: 400 });
+    }
+    if (error?.name === 'UnauthenticatedError') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (error?.name === 'UnauthorizedError') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    console.error('[concierge/tour] error:', error);
+    captureError(error instanceof Error ? error : new Error(String(error)), { tags: { feature: 'concierge-tour' } });
+    return NextResponse.json({ error: 'Could not request the tour. Please try again.' }, { status: 500 });
+  }
+}

--- a/src/app/api/inquiries/route.ts
+++ b/src/app/api/inquiries/route.ts
@@ -11,6 +11,7 @@ import { smsService } from '@/lib/sms/sms-service';
 import { createInquirySchema } from '@/lib/inquiries/schema';
 import { notifyUnclaimedHomeInquiry, isUnclaimedHome } from '@/lib/claim-engine/inquiry-claim-notification';
 import { sendNewLeadOperatorEmail } from '@/lib/email';
+import { coordinateConciergeInquiry } from '@/lib/concierge/tour-coordination';
 
 /**
  * POST /api/inquiries - Create a new inquiry
@@ -138,7 +139,23 @@ export async function POST(request: NextRequest) {
     // nudge the operator to claim (generic copy only — no PHI). Self-filters to
     // unclaimed homes with a known outreach email; non-blocking.
     notifyUnclaimedHomeInquiry({ homeId: inquiry.homeId, inquiryId: inquiry.id }).catch(() => {});
-    
+
+    // Concierge-aware (Option 3): if this inquiry came from a DP's concierge
+    // shortlist (the "View listing" deep link carries ?concierge=<searchId>),
+    // loop in the care team to coordinate + mark the shortlist so the DP sees a
+    // status — so a generic-page inquiry never black-holes either. Operator email
+    // / claim drip already fired above; this only adds the admin notify + status.
+    const conciergeSearchId = typeof body?.conciergeSearchId === 'string' ? body.conciergeSearchId.trim() : '';
+    if (conciergeSearchId && session?.user?.id) {
+      coordinateConciergeInquiry({
+        searchId: conciergeSearchId,
+        homeId: inquiry.homeId,
+        requesterUserId: session.user.id,
+        facilityName: inquiry.home?.name ?? 'a facility',
+        claimed: !!(operatorEmail && !isUnclaimedHome(operatorEmail)),
+      }).catch(() => {});
+    }
+
     return NextResponse.json(
       { success: true, inquiry },
       { status: 201 }

--- a/src/app/discharge-planner/concierge/page.tsx
+++ b/src/app/discharge-planner/concierge/page.tsx
@@ -13,6 +13,8 @@ type CuratedHome = {
   address?: string;
   note?: string;
   confirmedAvailability?: string;
+  tourStatus?: 'REQUESTED';
+  tourRequestedAt?: string;
 };
 
 type ConciergeRequest = {
@@ -68,6 +70,40 @@ export default function DischargePlannerConciergePage() {
   const [requests, setRequests] = useState<ConciergeRequest[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [tourBusy, setTourBusy] = useState<string | null>(null); // `${searchId}:${homeId}` in flight
+
+  // Ask CareLinkAI to coordinate a tour for one shortlist home. Routes via the
+  // concierge tour endpoint (claimed → operator + Chris; unclaimed → Chris +
+  // claim signal) and never black-holes. Optimistically reflects the status.
+  const requestTour = async (searchId: string, homeId: string) => {
+    const key = `${searchId}:${homeId}`;
+    setTourBusy(key);
+    try {
+      const res = await fetch(`/api/discharge-planner/concierge/${searchId}/tour`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ homeId }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Could not request the tour');
+      setRequests((prev) =>
+        prev.map((r) =>
+          r.id !== searchId
+            ? r
+            : {
+                ...r,
+                curatedHomes: (r.curatedHomes ?? []).map((h) =>
+                  h.homeId === homeId ? { ...h, tourStatus: 'REQUESTED' as const } : h,
+                ),
+              },
+        ),
+      );
+    } catch (e: any) {
+      setError(e?.message || 'Could not request the tour');
+    } finally {
+      setTourBusy(null);
+    }
+  };
 
   useEffect(() => {
     (async () => {
@@ -171,13 +207,34 @@ export default function DischargePlannerConciergePage() {
                                     </p>
                                   )}
                                   {h.note && <p className="text-sm text-neutral-700 mt-2">{h.note}</p>}
+                                  {h.tourStatus === 'REQUESTED' && (
+                                    <p className="text-sm text-success-700 mt-2 inline-flex items-center gap-1 font-medium">
+                                      <CheckCircle className="h-3.5 w-3.5" /> Tour requested — CareLinkAI is coordinating
+                                    </p>
+                                  )}
                                 </div>
-                                <Link
-                                  href={`/homes/${h.homeId}`}
-                                  className="shrink-0 inline-flex items-center gap-2 bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors"
-                                >
-                                  <CalendarCheck className="h-4 w-4" /> View &amp; request a tour
-                                </Link>
+                                <div className="shrink-0 flex flex-col gap-2 items-stretch">
+                                  <Link
+                                    href={`/homes/${h.homeId}?concierge=${r.id}`}
+                                    className="inline-flex items-center justify-center gap-2 border border-neutral-300 text-neutral-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-neutral-50 transition-colors"
+                                  >
+                                    <MapPin className="h-4 w-4" /> View listing
+                                  </Link>
+                                  {h.tourStatus === 'REQUESTED' ? (
+                                    <span className="inline-flex items-center justify-center gap-2 bg-success-50 text-success-700 border border-success-200 px-4 py-2 rounded-lg text-sm font-medium">
+                                      <CheckCircle className="h-4 w-4" /> Tour requested
+                                    </span>
+                                  ) : (
+                                    <button
+                                      onClick={() => requestTour(r.id, h.homeId)}
+                                      disabled={tourBusy === `${r.id}:${h.homeId}`}
+                                      className="inline-flex items-center justify-center gap-2 bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors disabled:opacity-50"
+                                    >
+                                      {tourBusy === `${r.id}:${h.homeId}` ? <Loader2 className="h-4 w-4 animate-spin" /> : <CalendarCheck className="h-4 w-4" />}
+                                      Request a tour
+                                    </button>
+                                  )}
+                                </div>
                               </div>
                             </div>
                           ))}

--- a/src/app/homes/[id]/page.tsx
+++ b/src/app/homes/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { 
@@ -274,6 +274,11 @@ export default function HomeDetailPage() {
   const router = useRouter();
   const { status: authStatus } = useSession();
   const { id } = params;
+  // Set when a discharge planner arrives from their concierge shortlist
+  // (?concierge=<searchId>): tour/inquiry actions here are coordinated by the
+  // CareLinkAI care team, not the gated family tour flow.
+  const searchParams = useSearchParams();
+  const conciergeSearchId = searchParams?.get("concierge") || null;
   
   // State for the home data
   const [home, setHome] = useState(MOCK_HOME);
@@ -502,6 +507,34 @@ export default function HomeDetailPage() {
   };
   
   // Handle tour scheduling
+  // Concierge tour: when a DP arrives via ?concierge=<searchId>, the "Schedule a
+  // Tour" CTA routes to the concierge endpoint (claimed → operator + Chris;
+  // unclaimed → Chris + claim signal) instead of the family tour modal (which a
+  // DP can't use). Non-concierge users are unaffected — they get the modal.
+  const [conciergeTourState, setConciergeTourState] = useState<'idle' | 'sending' | 'done'>('idle');
+  const handleConciergeTour = async () => {
+    if (!conciergeSearchId) return;
+    setConciergeTourState('sending');
+    try {
+      const res = await fetch(`/api/discharge-planner/concierge/${conciergeSearchId}/tour`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ homeId: String(id) }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Could not request the tour');
+      setConciergeTourState('done');
+      toast.success('Tour requested — CareLinkAI is coordinating.');
+    } catch (e: any) {
+      setConciergeTourState('idle');
+      toast.error(e?.message || 'Could not request the tour');
+    }
+  };
+  const onScheduleTour = () => {
+    if (conciergeSearchId) { void handleConciergeTour(); return; }
+    setShowTourModal(true);
+  };
+
   const handleTourSchedule = async (e: React.FormEvent) => {
     console.log('🔴🔴🔴 [TOUR DIAGNOSTIC] ========================================');
     console.log('🔴 [TOUR DIAGNOSTIC] Tour schedule handler called');
@@ -562,7 +595,12 @@ export default function HomeDetailPage() {
     // careNeeded/source:'home_detail', none of which match the API, so every
     // submission failed Zod validation with 400. moveInTimeframe has no column
     // on Inquiry, so fold it into additionalInfo rather than drop it.
-    const payload = buildInquiryPayload(String(id), inquiryForm, tourDateIso);
+    const payload = {
+      ...buildInquiryPayload(String(id), inquiryForm, tourDateIso),
+      // Concierge-aware: loops in the care team + marks the DP's shortlist so a
+      // generic-page inquiry from a concierge shortlist never black-holes either.
+      ...(conciergeSearchId ? { conciergeSearchId } : {}),
+    };
     console.log('🔴 [TOUR DIAGNOSTIC] Request payload:', JSON.stringify(payload, null, 2));
 
     try {
@@ -1135,7 +1173,7 @@ export default function HomeDetailPage() {
                     </div>
                     <div className="mt-4">
                       <button
-                        onClick={() => setShowTourModal(true)}
+                        onClick={onScheduleTour}
                         className="flex items-center rounded-md bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600"
                       >
                         <FiCalendar className="mr-2 h-4 w-4" />
@@ -1230,7 +1268,7 @@ export default function HomeDetailPage() {
                       <h3 className="mb-2 text-base font-medium text-neutral-800">Need Help?</h3>
                       <p className="mb-3 text-sm text-neutral-600">Our CareLinkAI care advisors can help you navigate your options and find the right home.</p>
                       <button
-                        onClick={() => setShowTourModal(true)}
+                        onClick={onScheduleTour}
                         className="flex items-center rounded-md bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600"
                       >
                         <MessageSquare className="mr-2 h-4 w-4" />
@@ -1248,14 +1286,22 @@ export default function HomeDetailPage() {
                     {bookingStep === 0 && (
                       <>
                         <h3 className="mb-3 text-lg font-semibold text-neutral-800">Interested in {realHome.name}?</h3>
-                        <p className="mb-4 text-sm text-neutral-600">
-                          {realHome.availability > 0
-                            ? `${realHome.availability} spot${realHome.availability > 1 ? 's' : ''} available. Schedule a tour or send an inquiry.`
-                            : 'Currently on waitlist. Send an inquiry to learn more.'}
-                        </p>
+                        {conciergeSearchId ? (
+                          <div className="mb-4 rounded-lg border border-primary-200 bg-primary-50 p-3 text-sm text-primary-800">
+                            {conciergeTourState === 'done'
+                              ? '✓ Tour requested — CareLinkAI is coordinating it on the patient’s behalf.'
+                              : 'You’re acting on a patient’s behalf via CareLinkAI Concierge — request a tour and our care team coordinates it for you.'}
+                          </div>
+                        ) : (
+                          <p className="mb-4 text-sm text-neutral-600">
+                            {realHome.availability > 0
+                              ? `${realHome.availability} spot${realHome.availability > 1 ? 's' : ''} available. Schedule a tour or send an inquiry.`
+                              : 'Currently on waitlist. Send an inquiry to learn more.'}
+                          </p>
+                        )}
                         <div className="space-y-3">
                           <button
-                            onClick={() => setShowTourModal(true)}
+                            onClick={onScheduleTour}
                             className="flex w-full items-center justify-center rounded-md bg-primary-500 px-4 py-2 font-medium text-white hover:bg-primary-600"
                           >
                             <FiCalendar className="mr-2 h-5 w-5" />
@@ -2026,7 +2072,7 @@ export default function HomeDetailPage() {
                     
                     <div className="space-y-3">
                       <button
-                        onClick={() => setShowTourModal(true)}
+                        onClick={onScheduleTour}
                         className="flex w-full items-center justify-center rounded-md bg-primary-500 px-4 py-2 font-medium text-white hover:bg-primary-600"
                       >
                         <FiCalendar className="mr-2 h-5 w-5" />
@@ -2383,7 +2429,7 @@ export default function HomeDetailPage() {
       <div className="fixed bottom-0 inset-x-0 z-20 border-t border-neutral-200 bg-white p-3 shadow-[0_-2px_8px_rgba(0,0,0,0.06)] md:hidden">
         <div className="flex gap-2 sm:flex-row flex-col">
           <button
-            onClick={() => setShowTourModal(true)}
+            onClick={onScheduleTour}
             className="flex-1 rounded-md bg-primary-500 px-4 py-2 font-medium text-white hover:bg-primary-600"
           >
             Schedule Tour

--- a/src/lib/concierge/tour-coordination.ts
+++ b/src/lib/concierge/tour-coordination.ts
@@ -1,0 +1,113 @@
+/**
+ * Concierge tour coordination — shared between the dedicated DP action
+ * (POST /api/discharge-planner/concierge/[id]/tour) and the concierge-aware
+ * generic inquiry path (POST /api/inquiries with conciergeSearchId).
+ *
+ * The promise: a tour/inquiry from a concierge shortlist NEVER silently
+ * black-holes. It always reaches the CareLinkAI concierge admin (Chris) to
+ * coordinate, and for an unclaimed home it also fires the claim-conversion
+ * signal (operator nudge + Anita's call-list via the claim drip).
+ *
+ * Tour status is tracked on the matching entry in PlacementSearch.curatedHomes
+ * (JSON) — no schema change — so the DP sees it on their Concierge tab.
+ */
+
+import { prisma } from '@/lib/prisma';
+import { sendConciergeTourNotification } from '@/lib/email';
+
+export const DIRECTORY_UNCLAIMED_EMAIL = 'directory-unclaimed@carelinkai.system';
+
+export type CuratedHome = {
+  homeId: string;
+  name?: string;
+  address?: string;
+  note?: string;
+  confirmedAvailability?: string;
+  tourStatus?: 'REQUESTED';
+  tourRequestedAt?: string;
+};
+
+/**
+ * Stamp tourStatus='REQUESTED' on the curated home entry for a concierge search.
+ * Returns:
+ *  - 'marked'         the entry was newly marked (caller should notify),
+ *  - 'already'        the entry was already requested (caller should NOT re-notify),
+ *  - 'not_found'      no such concierge search/home (caller should do nothing).
+ * Never throws.
+ */
+export async function markConciergeTourRequested(
+  searchId: string,
+  homeId: string,
+  nowIso: string,
+): Promise<'marked' | 'already' | 'not_found'> {
+  try {
+    const search = await prisma.placementSearch.findUnique({
+      where: { id: searchId },
+      select: { id: true, isConcierge: true, curatedHomes: true },
+    });
+    if (!search || !search.isConcierge || !Array.isArray(search.curatedHomes)) return 'not_found';
+
+    const homes = search.curatedHomes as unknown as CuratedHome[];
+    const idx = homes.findIndex((h) => h?.homeId === homeId);
+    if (idx < 0) return 'not_found';
+    if (homes[idx].tourStatus === 'REQUESTED') return 'already';
+
+    const next = homes.map((h, i) =>
+      i === idx ? { ...h, tourStatus: 'REQUESTED' as const, tourRequestedAt: nowIso } : h,
+    );
+    await prisma.placementSearch.update({
+      where: { id: searchId },
+      data: { curatedHomes: next as any },
+    });
+    return 'marked';
+  } catch {
+    return 'not_found';
+  }
+}
+
+/** True if the home is an unclaimed/directory listing (owned by the sentinel operator). */
+export function homeIsUnclaimed(operatorUserEmail: string | null | undefined): boolean {
+  return (operatorUserEmail ?? '').toLowerCase() === DIRECTORY_UNCLAIMED_EMAIL;
+}
+
+/**
+ * Concierge-aware generic inquiry (Option 3): when an inquiry submitted from the
+ * /homes/[id] page carries ?concierge=<searchId> (the DP came from their
+ * shortlist), loop in the care team + mark the shortlist so the DP sees a status.
+ * The /api/inquiries route already handled the operator email (claimed) and claim
+ * drip (unclaimed), so this only ADDS the admin notify + status. Validated against
+ * the requester so the param can't be spoofed to spam the admin. Never throws.
+ */
+export async function coordinateConciergeInquiry(params: {
+  searchId: string;
+  homeId: string;
+  requesterUserId: string;
+  facilityName: string;
+  claimed: boolean;
+}): Promise<void> {
+  try {
+    const search = await prisma.placementSearch.findUnique({
+      where: { id: params.searchId },
+      select: {
+        id: true, userId: true, isConcierge: true,
+        user: { select: { firstName: true, lastName: true, dischargePlannerProfile: { select: { organization: true } } } },
+      },
+    });
+    if (!search || !search.isConcierge) return;
+    if (search.userId !== params.requesterUserId) return; // not the DP's own search → ignore (anti-spoof)
+
+    const mark = await markConciergeTourRequested(params.searchId, params.homeId, new Date().toISOString());
+    if (mark !== 'marked') return; // already requested / not on this shortlist → no duplicate notify
+
+    const dpName = [search.user?.firstName, search.user?.lastName].filter(Boolean).join(' ') || undefined;
+    void sendConciergeTourNotification({
+      requestId: params.searchId,
+      facilityName: params.facilityName,
+      claimed: params.claimed,
+      dpName,
+      dpOrganization: search.user?.dischargePlannerProfile?.organization || undefined,
+    });
+  } catch {
+    /* never throws */
+  }
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -302,6 +302,72 @@ export async function sendConciergeShortlistReadyEmail(args: {
 }
 
 /**
+ * Notify the care team (admin) that a DP requested a tour from a concierge
+ * shortlist, so Chris can coordinate it on the family's behalf. The concierge
+ * promise: this NEVER black-holes — for an unclaimed home the operator is also
+ * nudged (claim drip) but only CareLinkAI can actually coordinate.
+ *
+ * HIPAA: PHI-FREE — names the facility, the DP, and whether the home is claimed,
+ * plus a deep link into the admin concierge request (where the patient's initials
+ * + callback live, auth-gated). NEVER includes patient details. Fire-and-forget.
+ *
+ * Recipient defaults to chris@getcarelinkai.com (ADMIN_NOTIFY_EMAIL).
+ */
+export async function sendConciergeTourNotification(args: {
+  /** Concierge request id (PlacementSearch id) for the admin deep link. */
+  requestId: string;
+  facilityName: string;
+  /** true = claimed (operator notified directly); false = unclaimed (Chris coordinates). */
+  claimed: boolean;
+  dpName?: string;
+  dpOrganization?: string;
+}): Promise<boolean> {
+  const to = process.env.ADMIN_NOTIFY_EMAIL || process.env.CLAIM_NOTIFY_EMAIL || 'chris@getcarelinkai.com';
+  try {
+    if (!process.env.RESEND_API_KEY) {
+      console.error('[Resend] RESEND_API_KEY not configured — skipping concierge tour notification');
+      return false;
+    }
+    const who = [args.dpName?.trim(), args.dpOrganization?.trim()].filter(Boolean).join(' · ') || 'A discharge planner';
+    const facility = args.facilityName?.trim() || 'a facility';
+    const claimLine = args.claimed
+      ? 'This home is CLAIMED — the operator was notified directly; you are cc’d to help coordinate.'
+      : 'This home is UNCLAIMED — please coordinate the tour on the family’s behalf (the operator was also nudged to claim).';
+    const appUrl = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com').replace(/\/$/, '');
+    const adminLink = `${appUrl}/admin/concierge/${args.requestId}`;
+    const { data, error } = await resend.emails.send({
+      from: `${APP_NAME} <${FROM_EMAIL}>`,
+      to: [to],
+      replyTo: OUTREACH_REPLY_TO,
+      subject: `🗓️ Concierge tour request — ${facility}`,
+      text:
+        `${who} requested a tour at ${facility} from their CareLinkAI concierge shortlist.\n\n` +
+        `${claimLine}\n\n` +
+        `Patient details are kept in-app (never emailed). Coordinate here:\n${adminLink}\n`,
+      html:
+        `<p>${escapeHtml(who)} requested a <strong>tour at ${escapeHtml(facility)}</strong> from their CareLinkAI concierge shortlist.</p>` +
+        `<p>${escapeHtml(claimLine)}</p>` +
+        `<p style="color:#6b7280;font-size:13px">Patient details are kept in-app (never emailed).</p>` +
+        `<p><a href="${escapeHtml(adminLink)}">Coordinate this tour →</a></p>`,
+    });
+    if (error) {
+      console.error('[Resend] Error sending concierge tour notification:', error);
+      captureError(error instanceof Error ? error : new Error(String((error as { message?: string })?.message ?? error)),
+        { tags: { feature: 'concierge-tour' }, extra: { requestId: args.requestId } });
+      return false;
+    }
+    console.log('[Resend] ✅ Concierge tour notification sent. Email ID:', data?.id);
+    return true;
+  } catch (error) {
+    console.error('[Resend] Exception sending concierge tour notification:', error);
+    captureError(error instanceof Error ? error : new Error(String(error)), {
+      tags: { feature: 'concierge-tour' }, extra: { requestId: args.requestId },
+    });
+    return false;
+  }
+}
+
+/**
  * Inquiry→claim "pull" engine (OL-083): when a family inquires on an UNCLAIMED
  * listing and we know the operator's outreach email, nudge them to claim their
  * free listing so they can respond. The notification IS the claim CTA.


### PR DESCRIPTION
## Current behavior (investigation — confirmed your suspicion, and it was worse)

The shortlist's "View & request a tour" just deep-linked to `/homes/[id]`. There:
- **"Schedule a Tour"** → `TourRequestModal` → `/api/family/tours/request`, which requires `TOURS_REQUEST` — **a `DISCHARGE_PLANNER` doesn't have it → 403** (and it needs a `familyId`). The tour button literally fails for a DP.
- **"Send Inquiry"** → `/api/inquiries` (works), but on an **UNCLAIMED** home (most of the directory) operator notify is skipped and it only fires the **OL-083 cold claim-drip** to the operator's outreach email. **No one at CareLinkAI is notified, nobody coordinates the tour, and the DP sees nothing** — the silent black-hole.

(The one thing that already worked on unclaimed: the claim-drip stamps `claimDripStartedAt`/`claimNudgeLastSentAt`, so the home surfaces on `report-claim-funnel.ts` — Anita's call-list signal. Reused.)

## Fix — Option 1 + Option 3 (approved), no schema change

**1. Dedicated concierge tour action.** The shortlist now shows **"View listing"** + **"Request a tour"**. The button calls `POST /api/discharge-planner/concierge/[id]/tour`:
- **CLAIMED** → operator email (`sendNewLeadOperatorEmail`) **+** PHI-safe admin notify to Chris (`sendConciergeTourNotification`, cc'd/visible).
- **UNCLAIMED** → admin notify to **Chris** (coordinate on the family's behalf) **+** `startClaimDripOnLead({trigger:'tour'})` (claim-conversion signal → operator nudge + Anita's call list). **Never black-holes.**
- Persists `tourStatus='REQUESTED'` on the `curatedHomes` entry (JSON) → the DP sees **"Tour requested — CareLinkAI is coordinating"**, and the admin detail page shows a **"Tour requested"** badge.

**2. Concierge-aware deep link (kept too).** "View listing" carries `?concierge=<searchId>`. On `/homes/[id]` in that mode, a DP's **"Schedule a Tour"** routes to the concierge endpoint (not the 403 modal), and **"Send Inquiry"** passes `conciergeSearchId` so `/api/inquiries` loops in Chris + marks the shortlist — so the generic path never black-holes either. Validated against the requester (**anti-spoof**). **Non-concierge users are completely unaffected** (identical behavior).

## PHI / safety
- The admin email (`sendConciergeTourNotification`) is **PHI-free**: facility + DP + claimed/unclaimed + a deep link to `/admin/concierge/[id]` (where the in-app initials + callback live). No patient detail.
- No schema change — tour status rides on the existing `curatedHomes` JSON.

## Tests
- **`__tests__/concierge.tour.test.ts`** — claimed → operator+admin (no drip); unclaimed → admin+claim-drip (no operator email); idempotent (already-requested → no dup notifications); ownership + status guards; `coordinateConciergeInquiry` anti-spoof.
- **`e2e/concierge-flow.spec.ts`** extended — after the shortlist is sent, click "Request a tour" and assert the tracked status badge + that no operator-bound `PlacementRequest` rows are created.
- `tsc` + `next lint` clean; **16/16** concierge jest tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_