### PR TITLE
fix(seo): serve robots.txt + sitemap.xml publicly; enumerate the SEO surface

### DIFF
--- a/__tests__/sitemap-robots.test.ts
+++ b/__tests__/sitemap-robots.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Crawler surface guards: the sitemap must enumerate the public SEO routes
+ * (Education Hub + every Senior Care Guide + Cleveland landing pages + search),
+ * and robots must allow public crawling + point at the sitemap. Also keeps the
+ * sitemap in sync as guides are added.
+ */
+
+import sitemap from '@/app/sitemap';
+import robots from '@/app/robots';
+import { GUIDES } from '@/app/learn/guides/content';
+
+const SITE = 'https://getcarelinkai.com';
+
+describe('sitemap', () => {
+  const entries = sitemap();
+  const urls = entries.map((e) => e.url);
+
+  it('includes the homepage, the Education Hub, public search, and Cleveland landing pages', () => {
+    for (const path of ['/', '/learn', '/search', '/cleveland', '/cleveland/assisted-living', '/cleveland/memory-care']) {
+      expect(urls).toContain(`${SITE}${path}`);
+    }
+  });
+
+  it('lists every Senior Care Guide', () => {
+    expect(GUIDES.length).toBeGreaterThanOrEqual(15);
+    for (const g of GUIDES) {
+      expect(urls).toContain(`${SITE}/learn/guides/${g.slug}`);
+    }
+  });
+
+  it('uses absolute https URLs with no duplicates', () => {
+    expect(urls.every((u) => u.startsWith('https://'))).toBe(true);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+});
+
+describe('robots', () => {
+  const r = robots();
+  const rule = Array.isArray(r.rules) ? r.rules[0] : r.rules;
+
+  it('allows crawling and points at the sitemap', () => {
+    expect(rule?.allow).toBe('/');
+    expect(r.sitemap).toBe(`${SITE}/sitemap.xml`);
+  });
+
+  it('keeps private/app areas out of the index but NOT the public SEO routes', () => {
+    const disallow = ([] as string[]).concat((rule?.disallow as any) ?? []);
+    for (const p of ['/admin/', '/api/', '/auth/']) expect(disallow).toContain(p);
+    // Public SEO routes must not be disallowed.
+    for (const pub of ['/learn', '/cleveland', '/search']) {
+      expect(disallow.some((d) => pub === d || pub.startsWith(d))).toBe(false);
+    }
+  });
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from 'next';
+import { GUIDES } from '@/app/learn/guides/content';
 
 const SITE_URL = 'https://getcarelinkai.com';
 
@@ -48,7 +49,22 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'daily',
       priority: 0.7,
     },
+    // Education Hub landing — the SEO entry point for the Senior Care Guides.
+    {
+      url: `${SITE_URL}/learn`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
   ];
 
-  return staticPages;
+  // The 15 Senior Care Guides — the bulk of the organic-search surface.
+  const guidePages: MetadataRoute.Sitemap = GUIDES.map((g) => ({
+    url: `${SITE_URL}/learn/guides/${g.slug}`,
+    lastModified,
+    changeFrequency: 'monthly',
+    priority: 0.7,
+  }));
+
+  return [...staticPages, ...guidePages];
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,12 +28,17 @@ const PUBLIC_PATHS = [
   '/sw.js',            // Service worker
   '/manifest.json',    // PWA manifest
   '/offline.html',     // PWA offline page
+  '/robots.txt',       // Crawler directives — MUST be publicly readable by search engines
+  '/sitemap.xml',      // Sitemap — MUST be publicly readable by search engines
 ];
 
 /**
  * Check if a path should bypass all authentication
  */
 function shouldBypassAuth(pathname: string): boolean {
+  // Search-engine crawler files must never redirect to login. Cover split
+  // sitemaps (/sitemap-0.xml, /sitemap/0.xml) too.
+  if (pathname === '/robots.txt' || /^\/sitemap.*\.xml$/.test(pathname)) return true;
   return PUBLIC_PATHS.some(path => {
     if (path.endsWith('/')) {
       return pathname.startsWith(path);
@@ -235,7 +240,7 @@ export const config = {
      * 4. /auth/ (auth pages)
      * 5. Common assets (favicon, manifest, etc.)
      */
-    '/((?!_next/|api/|static/|public/|images/|uploads/|favicon\\.ico|auth/|sw\\.js|manifest\\.json|offline\\.html).*)',
+    '/((?!_next/|api/|static/|public/|images/|uploads/|favicon\\.ico|robots\\.txt|sitemap.*\\.xml|auth/|sw\\.js|manifest\\.json|offline\\.html).*)',
   ],
 };
 


### PR DESCRIPTION
## Problem

`getcarelinkai.com/robots.txt` and `/sitemap.xml` 302-redirected to `/auth/login`. Root cause: the auth middleware (`src/middleware.ts`) matched them — they were **not** in the matcher's exclusion list **nor** in the `authorized` public-path list (`/`, `/help`, `/search`, `/homes`, `/privacy`, `/terms`, `/learn`) — so the `authorized` callback fell through to `!!token` → no token → redirect. Googlebot can't authenticate, so it couldn't read the sitemap or robots directives.

## Fix (per item)

**1. Crawler files are public again.** `src/middleware.ts`:
- Added `robots\.txt` and `sitemap.*\.xml` to the matcher's negative-lookahead exclusion → middleware never runs on them.
- Defensive `shouldBypassAuth` guard (`/robots.txt` or `^/sitemap.*\.xml$`) covers split sitemaps (`/sitemap-0.xml`) + added both to `PUBLIC_PATHS`.
- Next.js then serves the metadata routes directly with the correct content-type.

**2. Sitemap enumerates the SEO surface.** `src/app/sitemap.ts` now adds **`/learn`** (Education Hub) and **all 15 Senior Care Guides** (`/learn/guides/<slug>`, sourced from `GUIDES` so it stays in sync), alongside the existing Cleveland landing pages + `/search`. **23 URLs total.**

**3. robots.txt** already allowed public routes and pointed at `/sitemap.xml` — left as-is and **pinned by a new test** so it can't regress.

## Verification (#4)

Ran the dev server locally and curled both:
```
/robots.txt   → HTTP 200, content-type: text/plain
/sitemap.xml  → HTTP 200, content-type: application/xml   (no auth redirect)
```
The sitemap lists `/learn` + all 15 guide slugs + Cleveland pages + search. New unit test `__tests__/sitemap-robots.test.ts` (5 tests) asserts the sitemap enumerates every guide and that robots allows public crawling + points at the sitemap. `tsc` + `next lint` clean.

> After deploy, please confirm on prod: `curl -I https://getcarelinkai.com/robots.txt` and `/sitemap.xml` return `200` + the content-types above (unauthenticated). Then you can submit the sitemap in Google Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_