### PR TITLE
fix(auth): guide users to verify their email after signup (any role)

### DIFF
--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -7,7 +7,6 @@ import { useForm } from "react-hook-form";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import axios from "axios";
-import { signIn } from "next-auth/react";
 import { prefersReducedMotion } from "@/lib/animations";
 
 import {
@@ -174,6 +173,7 @@ export default function RegisterPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [registeredEmail, setRegisteredEmail] = useState("");
   const [step, setStep] = useState(1);
   const [reducedMotion, setReducedMotion] = useState(false);
 
@@ -283,35 +283,17 @@ export default function RegisterPage() {
       };
 
       await axios.post("/api/auth/register", cleanedData);
+      setRegisteredEmail(data.email);
       setSuccess(true);
 
-      setTimeout(async () => {
-        try {
-          const signInResult = await signIn("credentials", {
-            email: data.email,
-            password: data.password,
-            redirect: false,
-          });
-
-          if (signInResult?.ok) {
-            // Role-specific redirect (claim token was already redeemed by the API)
-            if (data.role === "OPERATOR") {
-              router.push("/operator/onboarding/1");
-            } else if (data.role === "FAMILY") {
-              router.push("/settings/family?onboarding=true");
-            } else if (data.role === "DISCHARGE_PLANNER") {
-              router.push("/discharge-planner");
-            } else {
-              router.push("/dashboard");
-            }
-          } else {
-            router.push(`/auth/login?verify=1&email=${encodeURIComponent(data.email)}`);
-          }
-        } catch (signInError) {
-          console.error("Auto sign-in error:", signInError);
-          router.push("/auth/login?registered=true");
-        }
-      }, 2000);
+      // A new account is created as PENDING and CANNOT sign in until the emailed
+      // verification link is clicked (enforced in auth.ts). So we do NOT attempt an
+      // auto sign-in (it always fails) and never drop the user on a bare login page.
+      // Send them to the login page's verify state, carrying their email so it shows
+      // "we've sent a verification link to <email>" + a resend control.
+      setTimeout(() => {
+        router.push(`/auth/login?verify=1&email=${encodeURIComponent(data.email)}`);
+      }, 2200);
     } catch (err: any) {
       console.error("Registration error:", err);
       setApiError(
@@ -385,12 +367,12 @@ export default function RegisterPage() {
               </div>
             </div>
             <h1 className="text-2xl font-bold text-neutral-800">
-              Registration Successful!
+              Check your email
             </h1>
             <p className="mt-2 text-neutral-600">
-              {currentRole === "FAMILY"
-                ? "Welcome! Let's set up your care profile..."
-                : "Your account has been created. Redirecting you..."}
+              Your account is created. We&apos;ve sent a verification link to{" "}
+              <strong className="text-neutral-800">{registeredEmail || "your email"}</strong> — please
+              verify your email, then sign in. Taking you to sign-in…
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Report (what the app does today, on `main`)

- **A verification email IS sent on signup** — the register API calls `sendVerificationEmailToUser` and creates the user as `status: PENDING` (`route.ts:238,452`).
- **Verification IS required to log in** — `auth.ts:133` throws *"Please verify your email before logging in"* for a `PENDING` user.

So the Education Hub's "verify your email" wording is correct — the **signup flow** just wasn't guiding it. This is the "verification exists → guide to it" case (no email was being promised that never arrives).

## Root cause

The register page attempted an **auto sign-in** after signup. But a brand-new account is `PENDING`, so it can *never* sign in — the role-redirect branch was dead, and the user fell through to a fallback redirect. PR #675 fixed one fallback (→ `?verify=1`), but the **`catch` fallback still went to `/auth/login?registered=true`** ("account created, please sign in"), with no mention of verification.

## Fix

Drop the futile auto sign-in entirely. After signup, **always** send the user to `/auth/login?verify=1&email=<email>`, which renders *"We've sent a verification link to &lt;email&gt; — please verify your email before signing in"* plus the existing **Resend** control (login page, from #675). The success splash now reads **"Check your email"** and shows the address, instead of *"Registration Successful! … Redirecting you…"*. Removed the now-unused `signIn` import.

- **Login page** — no change needed (already handles `verify=1`).
- **Register e2e specs** (`auth-register-flow`, `operator-onboarding-wizard`) — no change needed; they already `waitForURL(/…onboarding\/1|\/auth\/login/)`, so they accept the verify redirect (the codebase already anticipated it).

## Which option I implemented
**Verification email is sent → I guided users to it** (the preferred path). Nothing was removed from the how-to; the flow now matches it.

`next lint` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_