### PR TITLE
feat(seo): add Google Search Console verification meta tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -74,6 +74,13 @@ export const metadata: Metadata = {
   metadataBase: new URL(
     process.env["NEXT_PUBLIC_APP_URL"] || "http://localhost:5000"
   ),
+  // Google Search Console domain verification. Renders
+  // <meta name="google-site-verification" content="..."> into <head> on every
+  // page for anonymous crawlers. KEEP PERMANENTLY — removing it un-verifies the
+  // property in GSC.
+  verification: {
+    google: "9TWGIJuY4DL4n9q2pL__KZGEO-aBxevmDY209yV_o3E",
+  },
   alternates: {
     canonical: "/",
   },


### PR DESCRIPTION
## Why
Verify the `getcarelinkai.com` property in Google Search Console so we can submit the sitemap (shipped in #680) and monitor indexing.

## What
Added the GSC verification token to the **root layout** metadata (`src/app/layout.tsx`) via the Next.js Metadata `verification.google` field. This renders the exact required tag into `<head>` **on every page**:

```html
<meta name="google-site-verification" content="9TWGIJuY4DL4n9q2pL__KZGEO-aBxevmDY209yV_o3E"/>
```

Used the Metadata API (not a raw `<meta>`) to match how the rest of this file declares head tags; the served HTML is identical.

## Verification (done locally against the dev server)
`curl -s http://localhost:3111/ | grep google-site-verification` → tag present in the served HTML `<head>` for an **unauthenticated** request (GSC crawls anonymously). `tsc --noEmit` clean.

## After deploy
Confirm on prod:
```
curl -s https://getcarelinkai.com/ | grep google-site-verification
```
Then complete verification in GSC and submit `https://getcarelinkai.com/sitemap.xml`.

⚠️ **Keep permanently** — removing this tag un-verifies the property. (Noted in a code comment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_