### PR TITLE
chore(ops): PAUSE autonomous claim-drip cron (urgent — OL-109)

### DIFF
--- a/.github/workflows/claim-drip.yml
+++ b/.github/workflows/claim-drip.yml
@@ -1,10 +1,18 @@
 name: Claim Drip
 
 on:
-  # Once daily — advance due claim-drip touches (email-only). ~14:00 UTC ≈ 9-10am ET.
-  schedule:
-    - cron: '0 14 * * *'
-  # Allow manual trigger
+  # ⏸️ PAUSED 2026-07-01 (OL-109) — the autonomous daily drip was colliding with
+  # human outreach (VA calls + personal 1:1 emails) and hitting a ~40% bounce rate,
+  # burning sender reputation. The scheduled trigger is intentionally disabled.
+  # Code is preserved; DO NOT delete. Re-enable ONLY after the recipient-narrowing +
+  # bounce-cleanup + copy-rewrite fixes land — see OL-109.
+  #
+  # TO RE-ENABLE: uncomment the two `schedule` lines below, PR to main.
+  # schedule:
+  #   - cron: '0 14 * * *'   # daily ~14:00 UTC ≈ 9-10am ET
+  #
+  # Manual trigger stays available (e.g. a controlled, narrowed re-run) but never
+  # fires on its own.
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Urgent — stop autonomous claim outreach

The daily claim-drip cron (`.github/workflows/claim-drip.yml`, `0 14 * * *` → `GET /api/cron/claim-drip` → `advanceClaimDrips()`) was autonomously emailing directory facilities (~40% bounce), **colliding with human outreach** (VA phone calls + personal 1:1 claim emails to warm leads) and burning getcarelinkai.com sender reputation.

## What this does
- **Removes only the `schedule:` trigger** from `claim-drip.yml`. GitHub reads cron schedules from the **default branch**, so once this lands on `main` the daily job **stops firing on its own**.
- **Keeps `workflow_dispatch`** (manual-only; never self-fires) and **all code intact** — the drip engine (`src/lib/claim-engine/claim-drip.ts`), the cron endpoint, and `send-claim-nudges.ts` are untouched. This is a pause, not a teardown.
- Unrelated crons are **not** touched. Verified `process-followups.yml` (`/api/follow-ups/process`) does **not** send any claim emails.

## Timing (from workflow run history)
- **Last run:** 2026-06-30 14:51 UTC.
- **Next scheduled fire (if not paused):** ~2026-07-01 14:00 UTC (~13h out — not imminent).
- Cadence 0/3/7/14 days, 4 touches max → up to **2 touches remain** per active facility before auto-"exhausted".

## Re-enable (one step)
Uncomment the two `schedule` lines in `claim-drip.yml` and PR to `main`. (Do this only after the recipient-narrowing + bounce-cleanup + copy-rewrite fixes land — tracked in **OL-109**.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_