### PR TITLE
feat(claim-drip): master CLAIM_DRIP_ENABLED kill switch (default OFF) — seals touch-1 gap (OL-109)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,12 @@ CRON_SECRET="..."
 # REQUIRED before scripts/send-claim-nudges.ts will --force. e.g. "1234 Main St, Cleveland, OH 44114"
 COMPANY_POSTAL_ADDRESS=""
 
+# Master kill switch for the automated claim DRIP (event-driven touch-1 AND the
+# daily cron's touches 2-4). PAUSED unless set to a truthy value (1/true/yes/on).
+# Left UNSET on purpose (OL-109) so a redeploy can never silently resume autonomous
+# outreach. Re-enable ONLY after recipient-narrowing + bounce cleanup + copy rewrite.
+# CLAIM_DRIP_ENABLED="1"
+
 # Where "new claim" admin notifications go when an operator claims a listing.
 # Defaults to chris@getcarelinkai.com. (Legacy CLAIM_NOTIFY_EMAIL still honored as a fallback.)
 ADMIN_NOTIFY_EMAIL="chris@getcarelinkai.com"

--- a/__tests__/claim-drip-killswitch.test.ts
+++ b/__tests__/claim-drip-killswitch.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Master kill switch for the claim drip (OL-109). Paused by default so a redeploy
+ * can never silently resume autonomous outreach; re-enable is one Render env flip.
+ */
+import { claimDripEnabled } from '@/lib/claim-engine/claim-drip';
+
+describe('claimDripEnabled — paused by default', () => {
+  const orig = process.env['CLAIM_DRIP_ENABLED'];
+  afterEach(() => { process.env['CLAIM_DRIP_ENABLED'] = orig; });
+
+  it('is OFF when unset', () => {
+    delete process.env['CLAIM_DRIP_ENABLED'];
+    expect(claimDripEnabled()).toBe(false);
+  });
+
+  it('is OFF for empty / falsy values', () => {
+    for (const v of ['', '0', 'false', 'no', 'off', 'disabled']) {
+      process.env['CLAIM_DRIP_ENABLED'] = v;
+      expect(claimDripEnabled()).toBe(false);
+    }
+  });
+
+  it('is ON only for explicit truthy values', () => {
+    for (const v of ['1', 'true', 'TRUE', 'yes', 'on']) {
+      process.env['CLAIM_DRIP_ENABLED'] = v;
+      expect(claimDripEnabled()).toBe(true);
+    }
+  });
+});

--- a/src/lib/claim-engine/claim-drip.ts
+++ b/src/lib/claim-engine/claim-drip.ts
@@ -36,6 +36,15 @@ export const DRIP_OFFSETS_DAYS = [0, 3, 7, 14];
 export const MAX_DRIP_TOUCHES = DRIP_OFFSETS_DAYS.length;
 const DAY_MS = 86_400_000;
 
+/** Master kill switch — the ENTIRE drip (event-driven touch-1 AND the cron's
+ *  touches 2-4) is OFF unless CLAIM_DRIP_ENABLED is explicitly truthy. Paused by
+ *  DEFAULT so a redeploy can never silently resume autonomous outreach (OL-109).
+ *  Re-enable is a single Render env flip: CLAIM_DRIP_ENABLED=1. */
+export function claimDripEnabled(): boolean {
+  const v = (process.env['CLAIM_DRIP_ENABLED'] || '').trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
 function appUrl(): string {
   return (process.env['NEXT_PUBLIC_APP_URL'] || process.env['NEXTAUTH_URL'] || 'https://getcarelinkai.com').replace(/\/$/, '');
 }
@@ -99,6 +108,7 @@ async function sendTouch(home: DripHome, touch: number, trigger: 'inquiry' | 'to
 export async function startClaimDripOnLead(params: { homeId: string; trigger?: 'inquiry' | 'tour' }): Promise<void> {
   const { homeId, trigger = 'inquiry' } = params;
   try {
+    if (!claimDripEnabled()) return; // drip PAUSED (OL-109) — no autonomous touch-1
     const home = await prisma.assistedLivingHome.findUnique({
       where: { id: homeId },
       select: {
@@ -146,7 +156,8 @@ export async function startClaimDripOnLead(params: { homeId: string; trigger?: '
  * (claimed / suppressed / no email), sends the next escalating touch otherwise,
  * and marks 'exhausted' after the final touch.
  */
-export async function advanceClaimDrips(limit = 300): Promise<{ due: number; sent: number; stopped: number }> {
+export async function advanceClaimDrips(limit = 300): Promise<{ due: number; sent: number; stopped: number; disabled?: boolean }> {
+  if (!claimDripEnabled()) return { due: 0, sent: 0, stopped: 0, disabled: true }; // PAUSED (OL-109)
   const now = new Date();
   const due = await prisma.assistedLivingHome.findMany({
     where: {


### PR DESCRIPTION
## Why
The cron pause (#687, merged) stops touches 2–4, but **touch-1 still fires event-driven** via `startClaimDripOnLead` on inbound inquiries/tours. This adds the master gate that closes that gap.

## What
`CLAIM_DRIP_ENABLED` (default **OFF**) gates **both** entry points in `claim-drip.ts`:
- `advanceClaimDrips()` (the cron) → returns `{disabled:true}` and sends nothing.
- `startClaimDripOnLead()` (event-driven touch-1) → returns early, sends nothing.

**Sends nothing by itself** — merging this only *strengthens* the pause; it does not re-enable anything. Re-enable later = a single Render env flip (`CLAIM_DRIP_ENABLED=1`). Paused by default so a redeploy can never silently resume outreach.

Split out of the larger safeguards PR (#688) per request — the rest of #688 (exclusion script, bounce webhook, pre-send validation, copy) stays open for review.

## Tests
`jest claim-drip-killswitch` 3/3 (OFF when unset/falsy, ON only for explicit truthy). `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAEUhyPmjGsNaWdzRqhyif)_