### PR TITLE
feat(billing): Stripe go-live prep — FOUNDER_20, AGENCY tier, webhook fix, flip checklist (S2-1)

### DIFF
--- a/__tests__/stripe-founder-code.test.ts
+++ b/__tests__/stripe-founder-code.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the FOUNDER_20 founder-code flow (feat/stripe-golive-prep):
+ * resolveFounderPromo validation + the subscribe route's checkout shaping
+ * (valid code → 180-day trial + discount; invalid code → clean 400 before any
+ * checkout; no code → standard 14-day trial, promo codes stay disabled).
+ */
+
+import { jest } from '@jest/globals';
+import { NextRequest } from 'next/server';
+
+const mockStripe = {
+  promotionCodes: { list: jest.fn() },
+  customers: { create: jest.fn() },
+  checkout: { sessions: { create: jest.fn() } },
+};
+
+jest.mock('@/lib/stripe', () => ({ stripe: mockStripe }));
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/auth', () => ({ authOptions: {} }));
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+    operator: { findUnique: jest.fn(), update: jest.fn() },
+  },
+}));
+
+import Stripe from 'stripe';
+import { getServerSession } from 'next-auth';
+import { FOUNDER_COUPON_ID, FOUNDER_TRIAL_DAYS, resolveFounderPromo } from '@/lib/billing/founder-code';
+import { POST as postSubscribe } from '@/app/api/operator/billing/subscribe/route';
+import { prisma } from '@/lib/prisma';
+
+const mockedSession = getServerSession as jest.Mock;
+const mockedList = mockStripe.promotionCodes.list as jest.Mock;
+const mockedCheckout = mockStripe.checkout.sessions.create as jest.Mock;
+
+const founderPromo = {
+  id: 'promo_123',
+  code: 'FOUNDER20',
+  active: true,
+  coupon: { id: FOUNDER_COUPON_ID },
+};
+
+beforeEach(() => {
+  process.env.STRIPE_PRICE_STARTER = 'price_starter_test';
+  mockedSession.mockResolvedValue({ user: { email: 'op@example.com' } } as never);
+  (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+    id: 'user-1', email: 'op@example.com', role: 'OPERATOR', firstName: 'Op', lastName: 'Erator',
+  } as never);
+  (prisma.operator.findUnique as jest.Mock).mockResolvedValue({
+    id: 'op-1', userId: 'user-1', companyName: 'Acme Care', stripeCustomerId: 'cus_existing',
+  } as never);
+  mockedCheckout.mockResolvedValue({ url: 'https://checkout.stripe.com/x' } as never);
+  mockedList.mockResolvedValue({ data: [founderPromo] } as never);
+});
+afterEach(() => {
+  jest.clearAllMocks();
+  delete process.env.STRIPE_PRICE_STARTER;
+});
+
+describe('resolveFounderPromo', () => {
+  const s = mockStripe as unknown as Stripe;
+
+  it('resolves an active code on the FOUNDER_20 coupon (case/whitespace-insensitive)', async () => {
+    const res = await resolveFounderPromo(s, '  founder20 ');
+    expect(res).toEqual({ promotionCodeId: 'promo_123', code: 'FOUNDER20' });
+    expect(mockedList).toHaveBeenCalledWith({ code: 'FOUNDER20', active: true, limit: 1 });
+  });
+
+  it('rejects codes belonging to a different coupon (e.g. legacy FOUNDERS49)', async () => {
+    mockedList.mockResolvedValue({
+      data: [{ id: 'promo_old', code: 'FOUNDERS49', active: true, coupon: { id: 'carelinkai_founders_rate' } }],
+    } as never);
+    expect(await resolveFounderPromo(s, 'FOUNDERS49')).toBeNull();
+  });
+
+  it('rejects unknown/exhausted codes (active filter returns nothing)', async () => {
+    mockedList.mockResolvedValue({ data: [] } as never);
+    expect(await resolveFounderPromo(s, 'NOPE123')).toBeNull();
+  });
+
+  it('rejects non-string, empty, and absurdly long input without calling Stripe', async () => {
+    for (const bad of [null, undefined, 42, {}, '', 'X'.repeat(41)]) {
+      expect(await resolveFounderPromo(s, bad)).toBeNull();
+    }
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/operator/billing/subscribe — founder-code checkout shaping', () => {
+  const req = (body: unknown) =>
+    new NextRequest('http://localhost/api/operator/billing/subscribe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+  it('valid founder code → 180-day trial + discount, promo-code entry disabled', async () => {
+    const res = await postSubscribe(req({ plan: 'STARTER', founderCode: 'FOUNDER20' }));
+    expect(res.status).toBe(200);
+    const params = mockedCheckout.mock.calls[0][0] as any;
+    expect(params.subscription_data.trial_period_days).toBe(FOUNDER_TRIAL_DAYS);
+    expect(params.discounts).toEqual([{ promotion_code: 'promo_123' }]);
+    expect(params.allow_promotion_codes).toBeUndefined(); // mutually exclusive with discounts
+    expect(params.subscription_data.metadata.founderCode).toBe('FOUNDER20');
+  });
+
+  it('invalid founder code → 400 BEFORE any checkout session is created', async () => {
+    mockedList.mockResolvedValue({ data: [] } as never);
+    const res = await postSubscribe(req({ plan: 'STARTER', founderCode: 'TYPO99' }));
+    expect(res.status).toBe(400);
+    expect(mockedCheckout).not.toHaveBeenCalled();
+  });
+
+  it('no founder code → standard 14-day trial, promo codes disabled', async () => {
+    const res = await postSubscribe(req({ plan: 'STARTER' }));
+    expect(res.status).toBe(200);
+    const params = mockedCheckout.mock.calls[0][0] as any;
+    expect(params.subscription_data.trial_period_days).toBe(14);
+    expect(params.allow_promotion_codes).toBe(false);
+    expect(params.discounts).toBeUndefined();
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+
+  it('empty-string founder code is treated as no code (no validation round-trip)', async () => {
+    const res = await postSubscribe(req({ plan: 'STARTER', founderCode: '' }));
+    expect(res.status).toBe(200);
+    expect(mockedList).not.toHaveBeenCalled();
+    expect((mockedCheckout.mock.calls[0][0] as any).subscription_data.trial_period_days).toBe(14);
+  });
+});

--- a/context/STRIPE_SETUP_RUNBOOK.md
+++ b/context/STRIPE_SETUP_RUNBOOK.md
@@ -2,6 +2,16 @@
 _Run this any time a new Stripe account is connected to CareLinkAI._
 _Designed for CoWork browser automation + Render env var updates._
 
+> ⚠️ **SUPERSEDED for setup + go-live (2026-07-05, feat/stripe-golive-prep):**
+> use `npx tsx scripts/stripe-golive-setup.ts` (idempotent, dry-run default,
+> adds the AGENCY tier + the missing `checkout.session.completed` webhook
+> event) and follow `docs/STRIPE_GOLIVE_CHECKLIST.md` for the test→live flip.
+> **FOUNDERS49 is DEPRECATED** — replaced by the ratified FOUNDER_20 framework
+> (6 months free + 20% off forever; single coupon `carelinkai_founder_20`;
+> phase-1 code `FOUNDER20`, Cleveland Ops-50, max 50). Existing FOUNDERS49
+> redemptions are grandfathered. The manual dashboard steps below remain as
+> reference only.
+
 ---
 
 ## Overview

--- a/docs/STRIPE_GOLIVE_CHECKLIST.md
+++ b/docs/STRIPE_GOLIVE_CHECKLIST.md
@@ -1,0 +1,114 @@
+# Stripe Go-Live Checklist (S2-1, feat/stripe-golive-prep)
+
+_The complete test→live flip. **Chris flips the keys** — nothing in code or CI
+switches modes. Every step is reversible until Step 5._
+
+## Current state (audited 2026-07-05)
+
+| Piece | State |
+|---|---|
+| Keys in Render | TEST-mode (`sk_test_…`); app code is env-var-only, zero code changes to flip |
+| Products/prices | 3 tiers created by old `stripe-setup.js`; **AGENCY missing** → new script adds it |
+| Webhook endpoint | Registered, but the old event list **omitted `checkout.session.completed`** (the handler consumes it — plan changes/one-time flows could be missed) → new script fixes |
+| Coupon | Legacy FOUNDERS49 ($50 off forever, max 50) — **deprecated by this PR** (see below) |
+| Checkout | 14-day trial default; promo codes were disabled entirely (`allow_promotion_codes: false`) — FOUNDERS49 was never actually redeemable at checkout |
+| Portal | Configured per old runbook |
+
+## FOUNDERS49 → FOUNDER_20 migration
+
+- **FOUNDER_20 (ratified 2026-06-02):** 6 months free + 20% off forever, ONE
+  coupon (`carelinkai_founder_20`), first cohort per paid role per metro.
+  Phase 1 = **Cleveland Ops-50**: promotion code `FOUNDER20`, max 50
+  redemptions. Later cohorts = new promo codes on the same coupon.
+- **Mechanics:** coupon carries the 20%-forever; the 6 free months are a
+  180-day trial applied server-side by `/api/operator/billing/subscribe` when
+  a valid founder code is submitted (validated against Stripe before checkout
+  is created — a typo'd code 400s, never a silent full-price session).
+- **FOUNDERS49 (legacy):** the setup script deactivates its promotion code —
+  no new redemptions. Any subscription that already carries the FOUNDERS49
+  discount keeps it forever (Stripe never strips an applied coupon) —
+  **grandfathered, no action needed**. If zero redemptions exist in the live
+  account (likely — promo codes were disabled at checkout), this is a no-op.
+
+## Step-by-step flip (run top to bottom)
+
+### 1. Verify in TEST mode first
+```bash
+# Render shell (test keys still set):
+npx tsx scripts/stripe-golive-setup.ts            # dry-run audit
+npx tsx scripts/stripe-golive-setup.ts --force    # apply to TEST account
+```
+Then run the webhook verification matrix below against the test account.
+
+### 2. Create the LIVE account objects
+```bash
+# With the LIVE secret key exported (not yet in Render):
+STRIPE_SECRET_KEY=sk_live_... npx tsx scripts/stripe-golive-setup.ts --force --live
+```
+Copy the printed Price IDs + webhook signing secret.
+
+### 3. Flip Render env vars (the only real "switch")
+| Var | Change |
+|---|---|
+| `STRIPE_SECRET_KEY` | `sk_test_…` → `sk_live_…` |
+| `STRIPE_PUBLISHABLE_KEY` | `pk_test_…` → `pk_live_…` |
+| `STRIPE_WEBHOOK_SECRET` | test `whsec_…` → the live one printed in Step 2 |
+| `STRIPE_PRICE_STARTER` | live `price_…` from Step 2 |
+| `STRIPE_PRICE_PROFESSIONAL` | live `price_…` from Step 2 |
+| `STRIPE_PRICE_GROWTH` | live `price_…` from Step 2 |
+| `STRIPE_PRICE_AGENCY` | live `price_…` from Step 2 (tier auto-hides if unset — safe) |
+
+Unchanged: `PLACEMENT_FEE_CENTS`, `WALLET_FEE_PCT`, and the
+provider/caregiver/family price vars until those streams go live (their tiers
+auto-hide while unset in live mode).
+
+### 4. Clear test-mode Stripe customer IDs (Known Issue #1)
+Demo/test operators carry `stripeCustomerId` values from the TEST account;
+live-mode API calls with them would 404. In the Render shell:
+```bash
+npx tsx -e "
+const { PrismaClient } = require('@prisma/client');
+const p = new PrismaClient();
+p.operator.updateMany({ where: { stripeCustomerId: { startsWith: 'cus_' } }, data: { stripeCustomerId: null, stripeSubscriptionId: null } })
+ .then(r => console.log('cleared', r.count, 'operators')).finally(() => p.\$disconnect());
+"
+```
+⚠️ Run this ONLY at the moment of the flip (it clears test subscriptions), and
+only if no real live customers exist yet — true today.
+
+### 5. Redeploy + smoke test with a real card
+1. Redeploy (env var change triggers it on Render).
+2. Register/log in as a real operator account → `/operator/billing`.
+3. Subscribe to Starter **with the `FOUNDER20` code** → confirm checkout shows
+   *20% off forever* + *6-month trial*, complete with a real card.
+4. Confirm the webhook fired: operator row gains `stripeSubscriptionId`,
+   status TRIALING; admin MRR tile updates.
+5. Cancel via the Customer Portal → confirm status syncs to CANCELED at period end.
+6. (Optional) refund/void anything created during the smoke test from the
+   Stripe dashboard.
+
+## Webhook verification matrix (test events)
+
+With the **Stripe CLI** against the test account
+(`stripe listen --forward-to localhost:3000/api/webhooks/stripe` locally, or
+`--forward-to https://carelinkai.onrender.com/api/webhooks/stripe`):
+
+| Trigger | Expected handler behavior (`src/app/api/webhooks/stripe/route.ts`) |
+|---|---|
+| `stripe trigger customer.subscription.created` | Operator row: `stripeSubscriptionId` + plan + status persisted |
+| `stripe trigger customer.subscription.updated` | Status/plan/period-end synced |
+| `stripe trigger customer.subscription.deleted` | Status → CANCELED; feature gate closes |
+| `stripe trigger invoice.payment_succeeded` | Payment recorded; placement-fee invoice items marked COMPLETED |
+| `stripe trigger invoice.payment_failed` | Status → PAST_DUE; operator SMS/email alert path |
+| `stripe trigger checkout.session.completed` | Session metadata routed (ride payments, kit purchases) |
+| `stripe trigger payment_intent.succeeded` | Payment record path (wallet/rides) |
+| Bad signature (curl with wrong `Stripe-Signature`) | 400, nothing persisted |
+
+All handlers return 200 on ignored/irrelevant events (Stripe stops retrying).
+
+## Explicitly NOT in this PR
+- No live-mode switch (Chris flips keys per this checklist).
+- No changes to placement-fee, wallet, provider/caregiver/family billing.
+- Founder code entry is wired on `/operator/billing` (SubscriptionManager);
+  the onboarding wizard Step 4 still uses the standard checkout — add the code
+  input there when the Ops-50 outreach actually sends wizard links (follow-up).

--- a/scripts/stripe-golive-setup.ts
+++ b/scripts/stripe-golive-setup.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env npx tsx
+/**
+ * scripts/stripe-golive-setup.ts — Stripe go-live preparation (S2-1)
+ *
+ * Idempotent audit + setup of everything CareLinkAI needs in a Stripe account
+ * (test OR live — run once per account/mode). Supersedes scripts/stripe-setup.js
+ * (kept for reference; this adds AGENCY, FOUNDER_20, the missing
+ * checkout.session.completed webhook event, and FOUNDERS49 deprecation).
+ *
+ * What it manages:
+ *   1. Products + recurring monthly Prices for ALL FOUR operator tiers
+ *      (Starter $99 / Professional $249 / Growth $499 / Agency $799)
+ *   2. Webhook endpoint with the full event set the handler actually consumes
+ *      (incl. checkout.session.completed — missing from the old script/runbook)
+ *   3. Customer Portal configuration
+ *   4. FOUNDER_20 framework (ratified 2026-06-02): ONE coupon
+ *      `carelinkai_founder_20` (20% off forever) + phase-1 promotion code
+ *      FOUNDER20 (max 50 redemptions, metadata cohort=CLE-OPS-50). The 6 free
+ *      months are a 180-day trial applied by the subscribe route when a valid
+ *      code is redeemed. Later cohorts = new promo codes on the SAME coupon.
+ *   5. FOUNDERS49 deprecation: deactivates the legacy promotion code so no NEW
+ *      redemptions happen; existing subscriptions keep their discount
+ *      (grandfathered — Stripe never strips applied coupons).
+ *
+ * Safety:
+ *   - DRY-RUN by default: reports what exists vs. what would be created/changed.
+ *   - --force applies changes.
+ *   - Refuses to touch a LIVE-mode key (sk_live_...) unless --live is ALSO
+ *     passed — accidental live mutation is impossible with a copy-pasted cmd.
+ *
+ * Usage (Render shell or locally with STRIPE_SECRET_KEY set):
+ *   npx tsx scripts/stripe-golive-setup.ts                # dry-run audit
+ *   npx tsx scripts/stripe-golive-setup.ts --force        # apply (test mode)
+ *   npx tsx scripts/stripe-golive-setup.ts --force --live # apply (live mode)
+ *
+ * After a live run, copy the printed Price IDs + webhook secret into Render —
+ * see docs/STRIPE_GOLIVE_CHECKLIST.md for the full flip sequence.
+ */
+
+import Stripe from 'stripe';
+import {
+  FOUNDER_COUPON_ID,
+  FOUNDER_PHASE1_PROMO_CODE,
+} from '../src/lib/billing/founder-code';
+
+const key = process.env.STRIPE_SECRET_KEY;
+if (!key || key.includes('dummy')) {
+  console.error('\n❌  STRIPE_SECRET_KEY is not set (or is the dummy build key). Set it and re-run.\n');
+  process.exit(1);
+}
+
+const FORCE = process.argv.includes('--force');
+const LIVE_ACK = process.argv.includes('--live');
+const isLiveKey = key.startsWith('sk_live_') || key.startsWith('rk_live_');
+
+if (isLiveKey && !LIVE_ACK) {
+  console.error('\n🛑  LIVE-mode key detected but --live was not passed.');
+  console.error('    Re-run with BOTH --force and --live to modify the live account.\n');
+  process.exit(1);
+}
+
+const stripe = new Stripe(key, { apiVersion: '2023-10-16' });
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://getcarelinkai.com';
+
+const PLANS = [
+  { key: 'starter',      name: 'CareLinkAI Starter',      amount: 9900,  env: 'STRIPE_PRICE_STARTER',      lookup: 'carelinkai_starter_monthly',      description: 'Inquiry pipeline, resident management, 1 home, email support' },
+  { key: 'professional', name: 'CareLinkAI Professional', amount: 24900, env: 'STRIPE_PRICE_PROFESSIONAL', lookup: 'carelinkai_professional_monthly', description: 'Everything in Starter + AI responses, caregiver management, tour scheduling, analytics, up to 3 homes' },
+  { key: 'growth',       name: 'CareLinkAI Growth',       amount: 49900, env: 'STRIPE_PRICE_GROWTH',       lookup: 'carelinkai_growth_monthly',       description: 'Everything in Professional + discharge planner integration, advanced analytics, priority support, up to 10 homes' },
+  { key: 'agency',       name: 'CareLinkAI Agency',       amount: 79900, env: 'STRIPE_PRICE_AGENCY',       lookup: 'carelinkai_agency_monthly',       description: 'Everything in Growth + unlimited homes, white-label options, dedicated support' },
+] as const;
+
+// The full set the handler at src/app/api/webhooks/stripe/route.ts consumes.
+const WEBHOOK_EVENTS: Stripe.WebhookEndpointCreateParams.EnabledEvent[] = [
+  'customer.subscription.created',
+  'customer.subscription.updated',
+  'customer.subscription.deleted',
+  'invoice.payment_succeeded',
+  'invoice.payment_failed',
+  'checkout.session.completed',
+  'payment_intent.succeeded',
+  'transfer.paid',
+  'transfer.failed',
+];
+
+const act = (msg: string) => console.log(`  ${FORCE ? '▶' : '[dry-run] would'} ${msg}`);
+
+async function ensurePlans(): Promise<Record<string, string>> {
+  console.log('\n1️⃣  Products & prices (4 operator tiers)');
+  const envLines: Record<string, string> = {};
+  for (const plan of PLANS) {
+    const existing = await stripe.prices.list({ lookup_keys: [plan.lookup], limit: 1 });
+    if (existing.data.length > 0) {
+      console.log(`  ✓ ${plan.name}: price exists (${existing.data[0].id})`);
+      envLines[plan.env] = existing.data[0].id;
+      continue;
+    }
+    act(`create product+price ${plan.name} @ $${plan.amount / 100}/mo (lookup ${plan.lookup})`);
+    if (FORCE) {
+      const product = await stripe.products.create({
+        name: plan.name,
+        description: plan.description,
+        metadata: { plan_key: plan.key },
+      });
+      const price = await stripe.prices.create({
+        product: product.id,
+        unit_amount: plan.amount,
+        currency: 'usd',
+        recurring: { interval: 'month' },
+        lookup_key: plan.lookup,
+        metadata: { plan_key: plan.key },
+      });
+      envLines[plan.env] = price.id;
+    }
+  }
+  return envLines;
+}
+
+async function ensureWebhook(): Promise<string | null> {
+  console.log('\n2️⃣  Webhook endpoint');
+  const webhookUrl = `${APP_URL}/api/webhooks/stripe`;
+  const existing = await stripe.webhookEndpoints.list({ limit: 20 });
+  const match = existing.data.find((w) => w.url === webhookUrl);
+  if (match) {
+    const missing = WEBHOOK_EVENTS.filter((e) => !match.enabled_events.includes(e) && !match.enabled_events.includes('*'));
+    if (missing.length === 0) {
+      console.log(`  ✓ Webhook registered with all ${WEBHOOK_EVENTS.length} required events`);
+    } else {
+      act(`update webhook ${match.id}: add missing events ${missing.join(', ')}`);
+      if (FORCE) {
+        const merged = Array.from(new Set([...match.enabled_events, ...missing])) as Stripe.WebhookEndpointUpdateParams.EnabledEvent[];
+        await stripe.webhookEndpoints.update(match.id, { enabled_events: merged });
+      }
+    }
+    console.log('    (signing secret unchanged — Render STRIPE_WEBHOOK_SECRET stays valid)');
+    return null;
+  }
+  act(`register webhook ${webhookUrl} with ${WEBHOOK_EVENTS.length} events`);
+  if (FORCE) {
+    const webhook = await stripe.webhookEndpoints.create({
+      url: webhookUrl,
+      enabled_events: WEBHOOK_EVENTS,
+      description: 'CareLinkAI main webhook — subscription lifecycle + payments',
+    });
+    return webhook.secret ?? null;
+  }
+  return null;
+}
+
+async function ensurePortal(): Promise<void> {
+  console.log('\n3️⃣  Customer Portal');
+  const configs = await stripe.billingPortal.configurations.list({ limit: 5 });
+  if (configs.data.some((c) => c.active)) {
+    console.log('  ✓ An active portal configuration exists');
+    return;
+  }
+  act('create portal configuration (cancel + payment-method + invoice history)');
+  if (FORCE) {
+    await stripe.billingPortal.configurations.create({
+      business_profile: { headline: 'CareLinkAI — manage your subscription' },
+      features: {
+        customer_update: { enabled: true, allowed_updates: ['email', 'address'] },
+        invoice_history: { enabled: true },
+        payment_method_update: { enabled: true },
+        subscription_cancel: { enabled: true, mode: 'at_period_end' },
+      },
+    });
+  }
+}
+
+async function ensureFounder20(): Promise<void> {
+  console.log('\n4️⃣  FOUNDER_20 (ratified 2026-06-02: 6 mo free + 20% off forever, single coupon)');
+  let couponExists = false;
+  try {
+    const c = await stripe.coupons.retrieve(FOUNDER_COUPON_ID);
+    couponExists = Boolean(c && c.valid !== false);
+    console.log(`  ✓ Coupon ${FOUNDER_COUPON_ID} exists (${c.percent_off}% off, duration=${c.duration})`);
+  } catch {
+    act(`create coupon ${FOUNDER_COUPON_ID}: 20% off, duration=forever`);
+    if (FORCE) {
+      await stripe.coupons.create({
+        id: FOUNDER_COUPON_ID,
+        percent_off: 20,
+        duration: 'forever',
+        name: 'CareLinkAI Founder — 20% off forever',
+      });
+      couponExists = true;
+    }
+  }
+
+  const codes = await stripe.promotionCodes.list({ code: FOUNDER_PHASE1_PROMO_CODE, limit: 1 });
+  if (codes.data.length > 0) {
+    console.log(`  ✓ Phase-1 promo code ${FOUNDER_PHASE1_PROMO_CODE} exists (active=${codes.data[0].active}, redeemed ${codes.data[0].times_redeemed}/${codes.data[0].max_redemptions ?? '∞'})`);
+  } else {
+    act(`create promotion code ${FOUNDER_PHASE1_PROMO_CODE} (max 50 — Cleveland Ops-50, phase 1)`);
+    if (FORCE && couponExists) {
+      await stripe.promotionCodes.create({
+        coupon: FOUNDER_COUPON_ID,
+        code: FOUNDER_PHASE1_PROMO_CODE,
+        max_redemptions: 50,
+        metadata: { cohort: 'CLE-OPS-50', phase: '1', framework: 'FOUNDER_20' },
+      });
+    } else if (FORCE) {
+      console.log('  ⚠️  Coupon missing — re-run to create the promo code after the coupon exists.');
+    }
+  }
+  console.log('  ℹ️  The 6 free months are a 180-day trial applied by /api/operator/billing/subscribe when a valid code is entered.');
+}
+
+async function deprecateFounders49(): Promise<void> {
+  console.log('\n5️⃣  FOUNDERS49 deprecation (legacy — grandfather existing, stop new redemptions)');
+  const codes = await stripe.promotionCodes.list({ code: 'FOUNDERS49', limit: 1 });
+  const promo = codes.data[0];
+  if (!promo) {
+    console.log('  ✓ No FOUNDERS49 promotion code in this account — nothing to deprecate.');
+    return;
+  }
+  if (!promo.active) {
+    console.log(`  ✓ FOUNDERS49 already deactivated (was redeemed ${promo.times_redeemed}×; existing discounts remain grandfathered).`);
+    return;
+  }
+  act(`deactivate promotion code FOUNDERS49 (${promo.id}; redeemed ${promo.times_redeemed}×). Existing subscription discounts are NOT affected.`);
+  if (FORCE) {
+    await stripe.promotionCodes.update(promo.id, { active: false });
+  }
+}
+
+async function main() {
+  console.log('=== CareLinkAI Stripe go-live setup ===');
+  console.log(`Mode: ${isLiveKey ? '🔴 LIVE' : '🧪 TEST'} account · ${FORCE ? 'APPLY (--force)' : 'DRY-RUN (default)'}\n`);
+
+  const envLines = await ensurePlans();
+  const webhookSecret = await ensureWebhook();
+  await ensurePortal();
+  await ensureFounder20();
+  await deprecateFounders49();
+
+  console.log('\n--- Render env vars ---');
+  for (const [k, v] of Object.entries(envLines)) console.log(`${k}=${v}`);
+  if (webhookSecret) console.log(`STRIPE_WEBHOOK_SECRET=${webhookSecret}   ← shown ONCE, copy now`);
+  console.log('\nNext: docs/STRIPE_GOLIVE_CHECKLIST.md for the full test→live flip sequence.');
+  if (!FORCE) console.log('Dry-run complete. Re-run with --force to apply.');
+}
+
+main().catch((err) => {
+  console.error('\nSetup failed:', err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/src/app/api/operator/billing/subscribe/route.ts
+++ b/src/app/api/operator/billing/subscribe/route.ts
@@ -7,12 +7,17 @@ import { prisma } from '@/lib/prisma';
 import { stripe } from '@/lib/stripe';
 import { UserRole } from '@prisma/client';
 import { priceIdForPlan, planLabel } from '@/lib/operator-plans';
+import { FOUNDER_TRIAL_DAYS, resolveFounderPromo } from '@/lib/billing/founder-code';
 
 const SUPPORT_EMAIL = 'hello@getcarelinkai.com';
 
 /**
  * POST /api/operator/billing/subscribe
- * Body: { plan: 'STARTER' | 'PROFESSIONAL' | 'GROWTH' }
+ * Body: { plan: 'STARTER' | 'PROFESSIONAL' | 'GROWTH' | 'AGENCY', founderCode?: string }
+ *
+ * founderCode (FOUNDER_20 framework): a valid, active founder promotion code
+ * applies 6 months free (180-day trial) + 20% off forever. Invalid codes get a
+ * clean 400 BEFORE checkout is created — never a silently full-price session.
  *
  * Creates (or reuses) a Stripe Customer for the operator, then creates a
  * Stripe Checkout Session in subscription mode and returns the session URL.
@@ -82,18 +87,36 @@ export async function POST(request: NextRequest) {
       });
     }
 
+    // FOUNDER_20 flow: validate the founder code up front so a typo'd code
+    // fails loudly here instead of producing a full-price checkout session.
+    let founderPromo = null;
+    if (body.founderCode !== undefined && body.founderCode !== null && body.founderCode !== '') {
+      founderPromo = await resolveFounderPromo(stripe, body.founderCode);
+      if (!founderPromo) {
+        return NextResponse.json(
+          { error: `That founder code isn't valid or has been fully redeemed. Double-check the code, or email ${SUPPORT_EMAIL}.` },
+          { status: 400 }
+        );
+      }
+    }
+
     const checkoutSession = await stripe.checkout.sessions.create({
       customer: stripeCustomerId,
       mode: 'subscription',
       line_items: [{ price: priceId, quantity: 1 }],
       subscription_data: {
-        trial_period_days: 14,
-        metadata: { operatorId: operator.id, plan },
+        // Founder cohort: 6 months free; standard self-serve: 14-day trial.
+        trial_period_days: founderPromo ? FOUNDER_TRIAL_DAYS : 14,
+        metadata: { operatorId: operator.id, plan, ...(founderPromo ? { founderCode: founderPromo.code } : {}) },
       },
+      // `discounts` and `allow_promotion_codes` are mutually exclusive in
+      // Stripe Checkout — the founder code is the single controlled promo path.
+      ...(founderPromo
+        ? { discounts: [{ promotion_code: founderPromo.promotionCodeId }] }
+        : { allow_promotion_codes: false }),
       success_url: `${appUrl}/operator/billing?subscription=success`,
       cancel_url: `${appUrl}/operator/billing?subscription=canceled`,
       metadata: { operatorId: operator.id, plan },
-      allow_promotion_codes: false,
     });
 
     if (!checkoutSession.url) {

--- a/src/components/operator/billing/SubscriptionManager.tsx
+++ b/src/components/operator/billing/SubscriptionManager.tsx
@@ -82,6 +82,8 @@ export default function SubscriptionManager() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [showPlanChange, setShowPlanChange] = useState(false);
+  // FOUNDER_20 founder-cohort code — optional; validated server-side before checkout.
+  const [founderCode, setFounderCode] = useState('');
   // Tiers with a configured Stripe price. null = not loaded; until then we hide
   // AGENCY so a tier that would dead-end at checkout never appears as buyable.
   const [availablePlans, setAvailablePlans] = useState<string[] | null>(null);
@@ -111,7 +113,7 @@ export default function SubscriptionManager() {
       const res = await fetch('/api/operator/billing/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ plan }),
+        body: JSON.stringify({ plan, ...(founderCode.trim() ? { founderCode: founderCode.trim() } : {}) }),
       });
       const data = await res.json();
       if (!res.ok) { setError(data.error || 'Failed to start checkout.'); return; }
@@ -365,6 +367,24 @@ export default function SubscriptionManager() {
           <div className="text-sm font-medium text-neutral-700 mb-3 flex items-center gap-2">
             <Zap className="w-4 h-4 text-amber-500" />
             Choose a plan — 14-day free trial, no credit card required at signup
+          </div>
+          {/* FOUNDER_20 cohort code: 6 months free + 20% off forever. Validated
+              server-side; an invalid code fails before checkout, never silently. */}
+          <div className="mb-4 max-w-sm">
+            <label htmlFor="founder-code" className="block text-xs font-semibold text-neutral-500 uppercase tracking-wide mb-1">
+              Founder code (optional)
+            </label>
+            <input
+              id="founder-code"
+              type="text"
+              value={founderCode}
+              onChange={(e) => setFounderCode(e.target.value)}
+              placeholder="e.g. FOUNDER20"
+              className="form-input w-full rounded-md border-neutral-300 text-sm shadow-sm focus:border-primary-500 focus:ring-primary-500"
+            />
+            <p className="mt-1 text-xs text-neutral-500">
+              Founding-cohort operators: enter your code for 6 months free + 20% off forever.
+            </p>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             {visiblePlans.map((plan) => {

--- a/src/lib/billing/founder-code.ts
+++ b/src/lib/billing/founder-code.ts
@@ -1,0 +1,60 @@
+/**
+ * FOUNDER_20 founder-cohort promo (feat/stripe-golive-prep).
+ *
+ * Ratified framework (decision 2026-06-02): 6 months free + 20% off forever,
+ * ONE coupon, first cohort per paid role per metro. Phase 1 = Cleveland Ops-50.
+ *
+ * Stripe mechanics: a single coupon (`carelinkai_founder_20`, 20% off forever)
+ * carries the discount; the 6 free months are a 180-day trial applied
+ * server-side when a valid founder code is redeemed at checkout. Cohort caps
+ * live on PROMOTION CODES attached to the coupon (phase 1: code FOUNDER20,
+ * max_redemptions 50) — later cohorts get new codes on the SAME coupon, so
+ * "single coupon" stays true while each cohort is independently capped.
+ *
+ * FOUNDERS49 ($50-off, legacy) is deprecated: its promotion code is
+ * deactivated by scripts/stripe-golive-setup.ts so no NEW redemptions are
+ * possible, while existing subscriptions keep their discount (Stripe never
+ * strips an applied coupon when a promo code is deactivated) — grandfathered.
+ */
+
+import type Stripe from 'stripe';
+
+/** The single founder coupon id in Stripe (created by scripts/stripe-golive-setup.ts). */
+export const FOUNDER_COUPON_ID = 'carelinkai_founder_20';
+
+/** 6 months free, applied as a trial alongside the coupon. */
+export const FOUNDER_TRIAL_DAYS = 180;
+
+/** Phase-1 customer-facing code (Cleveland Ops-50 cohort). */
+export const FOUNDER_PHASE1_PROMO_CODE = 'FOUNDER20';
+
+export interface FounderPromoResolution {
+  promotionCodeId: string;
+  code: string;
+}
+
+/**
+ * Validate a customer-entered founder code: it must be an ACTIVE Stripe
+ * promotion code attached to the FOUNDER_20 coupon (cohort caps and expiry are
+ * enforced by Stripe via the promotion code's own state). Returns null for
+ * anything else — unknown codes, inactive/exhausted codes, or codes that
+ * belong to a different coupon (e.g. legacy FOUNDERS49).
+ */
+export async function resolveFounderPromo(
+  stripe: Stripe,
+  rawCode: unknown,
+): Promise<FounderPromoResolution | null> {
+  if (typeof rawCode !== 'string') return null;
+  const code = rawCode.trim().toUpperCase();
+  if (!code || code.length > 40) return null;
+
+  const found = await stripe.promotionCodes.list({ code, active: true, limit: 1 });
+  const promo = found.data[0];
+  if (!promo) return null;
+
+  const coupon = promo.coupon;
+  const couponId = typeof coupon === 'string' ? coupon : coupon?.id;
+  if (couponId !== FOUNDER_COUPON_ID) return null;
+
+  return { promotionCodeId: promo.id, code };
+}


### PR DESCRIPTION
## Summary

Stripe go-live preparation (Session #2, item 1). **Prep + checklist only — no live-mode switch anywhere in this PR; Chris flips the keys** per `docs/STRIPE_GOLIVE_CHECKLIST.md`.

## Audit findings (what was wrong/missing)

1. **AGENCY tier missing from setup** — `operator-plans.ts` supports 4 tiers, but the old `stripe-setup.js` only created 3 products; `STRIPE_PRICE_AGENCY` had nothing to point at.
2. **Webhook under-registered** — the handler consumes `checkout.session.completed` (ride payments, kit purchases), but the old script/runbook never registered that event.
3. **FOUNDERS49 was never actually redeemable** — checkout has always had `allow_promotion_codes: false`, so the legacy $50-off coupon existed in Stripe but no operator could enter it. Deprecating it costs nothing.

## FOUNDERS49 → FOUNDER_20 migration

- **FOUNDER_20 (ratified 2026-06-02)**: 6 months free + 20% off forever, **single coupon** (`carelinkai_founder_20`), first cohort per paid role per metro. Phase 1 = Cleveland Ops-50: promotion code `FOUNDER20`, max 50 redemptions. Later cohorts = new promo codes on the same coupon (each independently capped).
- **Mechanics**: the coupon carries the 20%-forever; the 6 free months are a **180-day trial** applied server-side by `/api/operator/billing/subscribe` when a valid founder code is submitted. Codes are validated against Stripe **before** checkout is created — an invalid/exhausted code returns a clean 400, never a silent full-price session. `discounts` and `allow_promotion_codes` are mutually exclusive in Stripe Checkout, so the founder code is the single controlled promo path.
- **FOUNDERS49 (legacy)**: the setup script deactivates its promotion code — no new redemptions possible. Any existing subscription carrying the discount keeps it forever (Stripe never strips applied coupons) — **grandfathered, zero action needed**. Given promo codes were disabled at checkout, live redemptions are almost certainly zero, making this a clean no-op.

## What's in the PR

- **`scripts/stripe-golive-setup.ts`** (supersedes `stripe-setup.js`): idempotent; dry-run by default, `--force` to apply, **refuses `sk_live_` keys unless `--live` is also passed**. Creates/verifies the 4 products+prices (lookup-key idempotent), the webhook endpoint with the full 9-event set, portal config, the FOUNDER_20 coupon + FOUNDER20 promo code, and deactivates FOUNDERS49. Prints the Render env-var lines at the end.
- **Subscribe route**: optional `founderCode` in the body → validated via `resolveFounderPromo` (`src/lib/billing/founder-code.ts`) → valid: 180-day trial + coupon discount + `founderCode` stamped in subscription metadata; invalid: 400 before any Stripe session exists.
- **`/operator/billing` UI**: optional "Founder code" input above the plan cards ("6 months free + 20% off forever" helper copy).
- **`docs/STRIPE_GOLIVE_CHECKLIST.md`**: the full test→live flip — verify in test mode, create live objects, the exact 7 Render env-var swaps, test-mode `stripeCustomerId` cleanup (Known Issue #1), real-card smoke test with the FOUNDER20 code, and a webhook verification matrix (`stripe trigger` event ↔ expected handler behavior).
- **Runbook**: `context/STRIPE_SETUP_RUNBOOK.md` gets a supersession banner (manual steps kept as reference).

## Testing

- 8 new tests: founder-code resolution (active FOUNDER_20 code accepted case-insensitively; wrong-coupon codes like FOUNDERS49 rejected; exhausted/unknown/garbage rejected without a Stripe call) and checkout shaping (valid code → 180-day trial + discount + no promo-code field; invalid → 400 with zero checkout calls; no code → standard 14-day trial).
- Full suite 69/69 (650 passed, 10 pre-existing skips); `tsc` clean; lint clean; production build passes.

## Follow-ups (flagged, not in this PR)

- Onboarding wizard Step 4 still uses standard checkout — add the founder-code input there when Ops-50 outreach sends wizard links.
- Context-doc updates for all of Session #2 (including the OL-116 log for the pre-existing DP direct-mode `homeId`/`homeIds` bug) land once in the S2-3 PR to avoid three-way conflicts on the shared context files.

**Hold for Chris's review — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESFkcdB481xfPn2RQ8VnW6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESFkcdB481xfPn2RQ8VnW6)_