### PR TITLE
feat(admin): OL-112 — filter demo fixtures from admin metrics (FILTER, not purge)

### DIFF
--- a/__tests__/admin-stats.demo-filter.test.ts
+++ b/__tests__/admin-stats.demo-filter.test.ts
@@ -1,0 +1,120 @@
+/**
+ * OL-112 tests: admin metrics exclude demo fixtures by default, include them
+ * when the "Show demo data" toggle is on, and the demo-account email
+ * convention classifies the retained tutorial/seed accounts correctly.
+ */
+
+import { jest } from '@jest/globals';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: { count: jest.fn() },
+    assistedLivingHome: { count: jest.fn() },
+    inquiry: { count: jest.fn() },
+    placementSearch: { count: jest.fn() },
+    operator: { findMany: jest.fn() },
+    caregiver: { count: jest.fn() },
+    provider: { count: jest.fn() },
+    family: { count: jest.fn() },
+    ride: { aggregate: jest.fn() },
+  },
+}));
+
+import { getAdminStats } from '@/lib/admin/stats';
+import { isDemoAccountEmail } from '@/lib/admin/demo-identity';
+import { prisma } from '@/lib/prisma';
+
+const p = prisma as any;
+
+beforeEach(() => {
+  p.user.count.mockResolvedValue(5);
+  p.assistedLivingHome.count.mockResolvedValue(3);
+  p.inquiry.count.mockResolvedValue(2);
+  p.placementSearch.count.mockResolvedValue(1);
+  p.operator.findMany.mockResolvedValue([{ subscriptionPlan: 'STARTER' }]);
+  p.caregiver.count.mockResolvedValue(0);
+  p.provider.count.mockResolvedValue(0);
+  p.family.count.mockResolvedValue(0);
+  p.ride.aggregate.mockResolvedValue({ _sum: { platformFee: 0 } });
+});
+afterEach(() => jest.clearAllMocks());
+
+describe('getAdminStats demo filtering (OL-112)', () => {
+  it('default (showDemo=false): every metric query excludes demo rows', async () => {
+    const stats = await getAdminStats(false);
+    expect(stats.showDemo).toBe(false);
+
+    // Direct user/home counts filter isDemo:false.
+    for (const call of p.user.count.mock.calls) {
+      expect(call[0].where.isDemo).toBe(false);
+    }
+    for (const call of p.assistedLivingHome.count.mock.calls) {
+      expect(call[0].where.isDemo).toBe(false);
+    }
+    // Relational filters: subscriptions/pro/plus via user.isDemo, inquiries via
+    // home.isDemo, placements via user.isDemo, transport via provider.user.
+    expect(p.operator.findMany.mock.calls[0][0].where.user).toEqual({ isDemo: false });
+    expect(p.caregiver.count.mock.calls[0][0].where.user).toEqual({ isDemo: false });
+    expect(p.provider.count.mock.calls[0][0].where.user).toEqual({ isDemo: false });
+    expect(p.family.count.mock.calls[0][0].where.user).toEqual({ isDemo: false });
+    expect(p.inquiry.count.mock.calls[0][0].where.home).toEqual({ isDemo: false });
+    expect(p.placementSearch.count.mock.calls[0][0].where.user).toEqual({ isDemo: false });
+    expect(p.ride.aggregate.mock.calls[0][0].where.provider).toEqual({ user: { isDemo: false } });
+  });
+
+  it('showDemo=true (tutorial toggle): no demo filters anywhere', async () => {
+    const stats = await getAdminStats(true);
+    expect(stats.showDemo).toBe(true);
+
+    const allWheres = [
+      ...p.user.count.mock.calls,
+      ...p.assistedLivingHome.count.mock.calls,
+      ...p.inquiry.count.mock.calls,
+      ...p.placementSearch.count.mock.calls,
+      ...p.operator.findMany.mock.calls,
+      ...p.caregiver.count.mock.calls,
+      ...p.provider.count.mock.calls,
+      ...p.family.count.mock.calls,
+      ...p.ride.aggregate.mock.calls,
+    ].map((c: any[]) => JSON.stringify(c[0] ?? {}));
+    for (const where of allWheres) {
+      expect(where).not.toContain('isDemo');
+    }
+  });
+
+  it('MRR math is unchanged by the filter plumbing', async () => {
+    const stats = await getAdminStats(false);
+    expect(stats.mrr.operator).toBe(99); // 1 STARTER operator
+    expect(stats.mrr.total).toBe(99);
+  });
+});
+
+describe('isDemoAccountEmail (backfill classification)', () => {
+  it('flags every retained demo/seed convention', () => {
+    for (const email of [
+      'demo.operator@carelinkai.test',
+      'demo.family@carelinkai.test',
+      'DEMO.ADMIN@CARELINKAI.TEST',
+      'op1@test.carelinkai.com',
+      'operator+seed@carelinkai.com',
+      'family.seed2@carelinkai.com',
+    ]) {
+      expect(isDemoAccountEmail(email)).toBe(true);
+    }
+  });
+
+  it('never flags real accounts', () => {
+    for (const email of [
+      'profyt7@gmail.com',
+      'chris@getcarelinkai.com',
+      'teresa@pleasantviewhealthcare.com',
+      'lfluhart@elizajen.org',
+      'seedling@example.com', // contains "seed" but not the convention
+      'family.seedman@gmail.com', // right prefix, wrong domain
+      null,
+      undefined,
+    ]) {
+      expect(isDemoAccountEmail(email as any)).toBe(false);
+    }
+  });
+});

--- a/prisma/migrations/20260705000002_is_demo_flags/migration.sql
+++ b/prisma/migrations/20260705000002_is_demo_flags/migration.sql
@@ -1,0 +1,12 @@
+-- OL-112: demo/tutorial fixture markers. Demo rows are RETAINED (tutorials
+-- depend on them) but FILTERED from admin metrics and the public directory.
+-- Backfilled by scripts/backfill-demo-flags.ts. Additive + fully idempotent.
+
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "isDemo" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "AssistedLivingHome"
+  ADD COLUMN IF NOT EXISTS "isDemo" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS "User_isDemo_idx" ON "User" ("isDemo");
+CREATE INDEX IF NOT EXISTS "AssistedLivingHome_isDemo_idx" ON "AssistedLivingHome" ("isDemo");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,10 @@ model User {
   resetPasswordTokenExpiry  DateTime?
   notificationPrefs         Json?
   preferences               Json?
+  /// OL-112: demo/tutorial account marker (demo.*@carelinkai.test etc.).
+  /// Retained for tutorials, FILTERED from admin metrics. Backfilled by
+  /// scripts/backfill-demo-flags.ts.
+  isDemo                    Boolean                  @default(false)
   timezone                  String                   @default("UTC")
   preferredContactMethod    String?                  // EMAIL, PHONE, BOTH
   createdAt                 DateTime                 @default(now())
@@ -82,6 +86,7 @@ model User {
   @@index([email])
   @@index([role])
   @@index([status])
+  @@index([isDemo])
   @@index([verificationToken])
   @@index([resetPasswordToken])
   @@index([firstName])
@@ -580,6 +585,10 @@ model AssistedLivingHome {
   // seed data / ODH directory; set by the ingest pipeline on a confirmed match.
   odhLicenseNumber        String?
   facilityInspections     FacilityInspection[]
+  /// OL-112: demo/tutorial fixture marker. Demo rows are RETAINED (tutorials
+  /// need them) but FILTERED from admin metrics + public directory. Backfilled
+  /// by scripts/backfill-demo-flags.ts from the demo-account conventions.
+  isDemo                  Boolean          @default(false)
   address                Address?
   operator               Operator         @relation(fields: [operatorId], references: [id], onDelete: Cascade)
   bookings               Booking[]
@@ -603,6 +612,7 @@ model AssistedLivingHome {
   @@index([status])
   @@index([priceMin, priceMax])
   @@index([priceSource])
+  @@index([isDemo])
   @@index([careLevel])
   @@index([claimDripNextAt])
   @@index([lastProfileGenerated])

--- a/scripts/backfill-demo-flags.ts
+++ b/scripts/backfill-demo-flags.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env npx tsx
+/**
+ * scripts/backfill-demo-flags.ts — OL-112 (FILTER, don't purge)
+ *
+ * Stamps `isDemo=true` on the RETAINED demo/tutorial fixtures so admin metrics
+ * can exclude them (and the public directory gets a structural guard) without
+ * deleting anything tutorials depend on.
+ *
+ * What gets flagged:
+ *   USERS whose email matches the demo/seed conventions:
+ *     - demo.*@carelinkai.test           (docs/DEMO_ACCOUNTS.md tutorial accounts)
+ *     - *@test.carelinkai.com            (e2e harness operators)
+ *     - *+seed@carelinkai.com            (runDemoSeed operator/caregiver accounts)
+ *     - family.seed*@carelinkai.com      (runDemoSeed families)
+ *   HOMES that are owned by a flagged demo user's operator, OR match the
+ *   pre-publish demo NAME/DESCRIPTION signature (same one the ODH ingest and
+ *   pre-publish sweep use).
+ *
+ * Flag-only and reversible (`isDemo=false` can be set back by hand); never
+ * deletes; idempotent. Dry-run by default; --force to write.
+ *
+ * Usage (Render shell):
+ *   npx tsx scripts/backfill-demo-flags.ts            # dry-run
+ *   npx tsx scripts/backfill-demo-flags.ts --force    # apply
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { isExcludedDemoHome } from '../src/lib/inspections/matcher';
+import { DEMO_EMAIL_RE } from '../src/lib/admin/demo-identity';
+
+const prisma = new PrismaClient();
+const FORCE = process.argv.includes('--force');
+
+async function main() {
+  console.log(`=== OL-112 demo-flag backfill — ${FORCE ? 'APPLY (--force)' : 'DRY-RUN'} ===\n`);
+
+  // 1. Users by email convention.
+  const users = await prisma.user.findMany({
+    where: { isDemo: false },
+    select: { id: true, email: true, role: true },
+  });
+  const demoUsers = users.filter((u) => DEMO_EMAIL_RE.test(u.email));
+  for (const u of demoUsers) console.log(`  USER  ${u.email} (${u.role})`);
+  if (FORCE && demoUsers.length > 0) {
+    await prisma.user.updateMany({
+      where: { id: { in: demoUsers.map((u) => u.id) } },
+      data: { isDemo: true },
+    });
+  }
+
+  // 2. Homes: demo-operator-owned OR matching the demo name/desc signature.
+  const homes = await prisma.assistedLivingHome.findMany({
+    where: { isDemo: false },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      status: true,
+      operator: { select: { user: { select: { email: true } } } },
+    },
+  });
+  const demoHomes = homes.filter((h) => {
+    const operatorEmail = h.operator?.user?.email ?? null;
+    return (
+      (operatorEmail && DEMO_EMAIL_RE.test(operatorEmail)) ||
+      isExcludedDemoHome({ name: h.name, description: h.description, operatorEmail })
+    );
+  });
+  for (const h of demoHomes) console.log(`  HOME  ${h.name} (${h.status}, operator ${h.operator?.user?.email ?? 'n/a'})`);
+  if (FORCE && demoHomes.length > 0) {
+    await prisma.assistedLivingHome.updateMany({
+      where: { id: { in: demoHomes.map((h) => h.id) } },
+      data: { isDemo: true },
+    });
+  }
+
+  console.log(`\n${FORCE ? 'Flagged' : 'Would flag'}: ${demoUsers.length} user(s), ${demoHomes.length} home(s). Nothing deleted.`);
+  if (!FORCE && (demoUsers.length || demoHomes.length)) console.log('Re-run with --force to write.');
+
+  // 3. Sanity: any ACTIVE home about to be flagged would have been publicly
+  // visible — call it out loudly (should be zero; demo homes stay DRAFT).
+  const activeDemo = demoHomes.filter((h) => h.status === 'ACTIVE');
+  if (activeDemo.length > 0) {
+    console.log(`\n⚠️  ${activeDemo.length} demo-flagged home(s) are ACTIVE (publicly visible until now):`);
+    for (const h of activeDemo) console.log(`   - ${h.name}`);
+    console.log('   The public search now also filters isDemo=true, so flagging fixes the leak.');
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error('Backfill failed:', err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,86 +3,26 @@ import { getServerSession } from 'next-auth';
 import authOptions from '@/lib/auth';
 import { FiUsers, FiHome, FiActivity, FiTrendingUp, FiMessageSquare, FiFileText, FiAlertCircle, FiDollarSign, FiCreditCard, FiTruck, FiShield } from 'react-icons/fi';
 import Link from 'next/link';
-import { prisma } from '@/lib/prisma';
+import { getAdminStats } from '@/lib/admin/stats';
 
 export const dynamic = 'force-dynamic';
 
-async function getAdminStats() {
-  const [
-    userCount,
-    homeCount,
-    caregiverCount,
-    inquiryCount,
-    placementCount,
-    activeUsers,
-    activeOperators,
-    proCaregiversCount,
-    activeProvidersCount,
-    familyPlusCount,
-  ] = await Promise.all([
-    prisma.user.count(),
-    prisma.assistedLivingHome.count(),
-    prisma.user.count({ where: { role: 'CAREGIVER' } }),
-    prisma.inquiry.count(),
-    prisma.placementSearch.count(),
-    prisma.user.count({
-      where: { lastLoginAt: { gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) } },
-    }),
-    prisma.operator.findMany({
-      where: { subscriptionStatus: { in: ['ACTIVE', 'TRIALING'] } },
-      select: { subscriptionPlan: true },
-    }),
-    (prisma as any).caregiver.count({ where: { proStatus: { in: ['ACTIVE', 'TRIALING'] } } }),
-    (prisma as any).provider.count({ where: { listingStatus: { in: ['ACTIVE', 'TRIALING'] } } }),
-    prisma.family.count({ where: { plusStatus: { in: ['ACTIVE', 'TRIALING'] } } }),
-  ]);
-
-  // Transport commissions: sum platformFee on COMPLETED rides this calendar month
-  const monthStart = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
-  const transportCommissions = await prisma.ride.aggregate({
-    where: { status: 'COMPLETED', createdAt: { gte: monthStart } },
-    _sum: { platformFee: true },
-  });
-  const transportCommissionMTD = Number(transportCommissions._sum?.platformFee ?? 0);
-
-  const operatorMRR = (activeOperators as any[]).reduce((sum: number, op: any) => {
-    const price = op.subscriptionPlan === 'STARTER' ? 99
-      : op.subscriptionPlan === 'PROFESSIONAL' ? 249
-      : op.subscriptionPlan === 'GROWTH' ? 499 : 0;
-    return sum + price;
-  }, 0);
-  const providerMRR = (activeProvidersCount as number) * 99;
-  const caregiverProMRR = (proCaregiversCount as number) * 19;
-  const dpMRR = 0; // Discharge planners are FREE (ratified 2026-06-27) — not a revenue line.
-  const familyPlusMRR = (familyPlusCount as number) * 19;
-  const totalMRR = operatorMRR + providerMRR + caregiverProMRR + dpMRR + familyPlusMRR;
-
-  return {
-    userCount,
-    homeCount,
-    caregiverCount,
-    inquiryCount,
-    placementCount,
-    activeUsers,
-    transportCommissionMTD,
-    mrr: { operator: operatorMRR, provider: providerMRR, caregiver: caregiverProMRR, dp: dpMRR, familyPlus: familyPlusMRR, total: totalMRR },
-    mrrCounts: {
-      operators: (activeOperators as any[]).length,
-      providers: activeProvidersCount as number,
-      proCaregiversCount: proCaregiversCount as number,
-      familyPlus: familyPlusCount as number,
-    },
-  };
-}
-
-export default async function AdminDashboard() {
+export default async function AdminDashboard({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[]>>;
+}) {
   const session = await getServerSession(authOptions);
 
   if (!session || session.user?.role !== 'ADMIN') {
     redirect('/auth/login');
   }
 
-  const stats = await getAdminStats();
+  // OL-112: metrics exclude demo/tutorial fixtures unless the admin flips the
+  // "Show demo data" toggle (?showDemo=1). Next 15: searchParams is async.
+  const sp = (await searchParams) ?? {};
+  const showDemo = sp['showDemo'] === '1';
+  const stats = await getAdminStats(showDemo);
 
   const quickActions = [
     {
@@ -167,12 +107,26 @@ export default async function AdminDashboard() {
               <h1 className="text-3xl font-bold text-neutral-900">Admin Dashboard</h1>
               <p className="mt-1 text-neutral-600">Welcome back, {session.user?.name || session.user?.email}</p>
             </div>
-            <Link
-              href="/"
-              className="text-[#3978FC] hover:text-[#3167d4] font-medium transition-colors"
-            >
-              ← Back to App
-            </Link>
+            <div className="flex items-center gap-4">
+              {/* OL-112: demo rows are retained for tutorials but filtered from
+                  metrics; this toggle restores them for tutorial recording. */}
+              <Link
+                href={showDemo ? '/admin' : '/admin?showDemo=1'}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                  showDemo
+                    ? 'border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100'
+                    : 'border-neutral-300 bg-white text-neutral-600 hover:bg-neutral-50'
+                }`}
+              >
+                {showDemo ? 'Showing demo data — click to hide' : 'Show demo data'}
+              </Link>
+              <Link
+                href="/"
+                className="text-[#3978FC] hover:text-[#3167d4] font-medium transition-colors"
+              >
+                ← Back to App
+              </Link>
+            </div>
           </div>
         </div>
       </header>

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -565,6 +565,10 @@ export async function GET(request: NextRequest) {
     // Build database query
     const whereClause: any = {
       status: 'ACTIVE', // Only active homes
+      // OL-112: demo/tutorial fixtures never surface in the public directory —
+      // structural guard on top of the DRAFT-status convention (the markers
+      // path shares this whereClause, so the map view is covered too).
+      isDemo: false,
     };
     
     // Filter by care level if specified

--- a/src/lib/admin/demo-identity.ts
+++ b/src/lib/admin/demo-identity.ts
@@ -1,0 +1,16 @@
+/**
+ * OL-112: the demo/seed ACCOUNT identity convention, in one place.
+ * Used by scripts/backfill-demo-flags.ts to stamp `isDemo` and by tests.
+ *
+ * Matches:
+ *   - demo.*@carelinkai.test        (docs/DEMO_ACCOUNTS.md tutorial accounts)
+ *   - *@test.carelinkai.com         (e2e harness operators)
+ *   - *+seed@carelinkai.com         (runDemoSeed operator/caregiver accounts)
+ *   - family.seed*@carelinkai.com   (runDemoSeed families)
+ */
+export const DEMO_EMAIL_RE =
+  /(@carelinkai\.test|@test\.carelinkai\.com|\+seed@carelinkai\.com)$|^family\.seed[^@]*@carelinkai\.com$/i;
+
+export function isDemoAccountEmail(email: string | null | undefined): boolean {
+  return !!email && DEMO_EMAIL_RE.test(email);
+}

--- a/src/lib/admin/stats.ts
+++ b/src/lib/admin/stats.ts
@@ -1,0 +1,106 @@
+/**
+ * Admin dashboard aggregates (extracted from /admin/page.tsx for OL-112).
+ *
+ * OL-112: demo/tutorial fixtures are RETAINED in the DB but FILTERED out of
+ * every metric here by default, so /admin shows real business numbers
+ * ($0 MRR / real user counts), not the demo inflation ($386 MRR, 109 users…).
+ * `showDemo: true` (the admin "Show demo data" toggle) restores the unfiltered
+ * view for tutorial recording. Filtering ONLY — demo rows are never deleted.
+ *
+ * Demo identity: `isDemo` on User + AssistedLivingHome (backfilled by
+ * scripts/backfill-demo-flags.ts); everything else filters relationally
+ * (operator/caregiver/family → user.isDemo; inquiry → home.isDemo).
+ */
+
+import { prisma } from '@/lib/prisma';
+
+export interface AdminStats {
+  userCount: number;
+  homeCount: number;
+  caregiverCount: number;
+  inquiryCount: number;
+  placementCount: number;
+  activeUsers: number;
+  transportCommissionMTD: number;
+  mrr: { operator: number; provider: number; caregiver: number; dp: number; familyPlus: number; total: number };
+  mrrCounts: { operators: number; providers: number; proCaregiversCount: number; familyPlus: number };
+  showDemo: boolean;
+}
+
+export async function getAdminStats(showDemo = false): Promise<AdminStats> {
+  // `{}` = no filtering (demo included); otherwise exclude demo rows —
+  // directly for User/Home, relationally for everything hanging off them.
+  const userDemo = showDemo ? {} : { isDemo: false };
+  const homeDemo = showDemo ? {} : { isDemo: false };
+  const viaUser = showDemo ? {} : { user: { isDemo: false } };
+  const inquiryDemo = showDemo ? {} : { home: { isDemo: false } };
+  const placementDemo = showDemo ? {} : { user: { isDemo: false } };
+  const rideDemo = showDemo ? {} : { provider: { user: { isDemo: false } } };
+
+  const [
+    userCount,
+    homeCount,
+    caregiverCount,
+    inquiryCount,
+    placementCount,
+    activeUsers,
+    activeOperators,
+    proCaregiversCount,
+    activeProvidersCount,
+    familyPlusCount,
+  ] = await Promise.all([
+    prisma.user.count({ where: { ...userDemo } }),
+    prisma.assistedLivingHome.count({ where: { ...homeDemo } }),
+    prisma.user.count({ where: { role: 'CAREGIVER', ...userDemo } }),
+    prisma.inquiry.count({ where: { ...inquiryDemo } }),
+    prisma.placementSearch.count({ where: { ...placementDemo } }),
+    prisma.user.count({
+      where: { lastLoginAt: { gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) }, ...userDemo },
+    }),
+    prisma.operator.findMany({
+      where: { subscriptionStatus: { in: ['ACTIVE', 'TRIALING'] }, ...viaUser },
+      select: { subscriptionPlan: true },
+    }),
+    (prisma as any).caregiver.count({ where: { proStatus: { in: ['ACTIVE', 'TRIALING'] }, ...viaUser } }),
+    (prisma as any).provider.count({ where: { listingStatus: { in: ['ACTIVE', 'TRIALING'] }, ...viaUser } }),
+    prisma.family.count({ where: { plusStatus: { in: ['ACTIVE', 'TRIALING'] }, ...viaUser } }),
+  ]);
+
+  // Transport commissions: sum platformFee on COMPLETED rides this calendar month
+  const monthStart = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
+  const transportCommissions = await prisma.ride.aggregate({
+    where: { status: 'COMPLETED', createdAt: { gte: monthStart }, ...rideDemo },
+    _sum: { platformFee: true },
+  });
+  const transportCommissionMTD = Number(transportCommissions._sum?.platformFee ?? 0);
+
+  const operatorMRR = (activeOperators as any[]).reduce((sum: number, op: any) => {
+    const price = op.subscriptionPlan === 'STARTER' ? 99
+      : op.subscriptionPlan === 'PROFESSIONAL' ? 249
+      : op.subscriptionPlan === 'GROWTH' ? 499 : 0;
+    return sum + price;
+  }, 0);
+  const providerMRR = (activeProvidersCount as number) * 99;
+  const caregiverProMRR = (proCaregiversCount as number) * 19;
+  const dpMRR = 0; // Discharge planners are FREE (ratified 2026-06-27) — not a revenue line.
+  const familyPlusMRR = (familyPlusCount as number) * 19;
+  const totalMRR = operatorMRR + providerMRR + caregiverProMRR + dpMRR + familyPlusMRR;
+
+  return {
+    userCount,
+    homeCount,
+    caregiverCount,
+    inquiryCount,
+    placementCount,
+    activeUsers,
+    transportCommissionMTD,
+    mrr: { operator: operatorMRR, provider: providerMRR, caregiver: caregiverProMRR, dp: dpMRR, familyPlus: familyPlusMRR, total: totalMRR },
+    mrrCounts: {
+      operators: (activeOperators as any[]).length,
+      providers: activeProvidersCount as number,
+      proCaregiversCount: proCaregiversCount as number,
+      familyPlus: familyPlusCount as number,
+    },
+    showDemo,
+  };
+}


### PR DESCRIPTION
## Summary

OL-112 (Session #2, item 2): `/admin` dashboard aggregates were counting the demo/tutorial fixtures retained under the OL-068 decision — showing **$386 MRR, 109 users, 11 placements, 57 caregivers** instead of reality (**$0 MRR, 0 claims, ~155 real ACTIVE listings**). Per the ratified decision (Chris, 2026-07-02): **FILTER, don't purge** — demo data stays for tutorials, it just stops polluting business metrics.

## What's in the PR

**(a) `isDemo` marker** — `Boolean @default(false)` on `User` and `AssistedLivingHome` (migration `20260705000002`, additive + indexed). Deliberately only on the two root models: operators/caregivers/families filter relationally via `user.isDemo`, inquiries via `home.isDemo`, placements via `user.isDemo`, transport via `provider.user.isDemo` — one flag per identity root, no per-table drift. Backfill via `scripts/backfill-demo-flags.ts` (dry-run default, `--force` to apply): stamps users matching the demo-account conventions (`demo.*@carelinkai.test`, `*@test.carelinkai.com`, `*+seed@carelinkai.com`, `family.seed*@carelinkai.com`) plus homes owned by demo operators or matching the pre-publish demo name/description signature. **Flag-only, reversible, never deletes.** It also loudly reports if any demo home is ACTIVE (publicly visible) — expected zero.

**(b) Every admin metric card filtered** — `getAdminStats` extracted from `/admin/page.tsx` into `src/lib/admin/stats.ts`; users, care homes, caregivers, inquiries, placements, active users, transport commissions, and **all revenue/MRR tiles** (operator, provider, pro-caregiver, family-plus) exclude `isDemo` by default.

**(c) "Show demo data" toggle** — a pill on the `/admin` header (`?showDemo=1`) restores the unfiltered view for tutorial recording; amber-highlighted while active so it's obvious the numbers are inflated.

**(d) Public directory verified + hardened** — demo homes were excluded from `/api/search` only by the DRAFT-status convention (they're seeded without `status`, defaulting to DRAFT). Verified that holds today, and added a structural `isDemo: false` guard to the search where-clause (the markers/map path shares it), so a demo home accidentally flipped ACTIVE can never surface publicly.

## Notes for review

- The "PR #571 marker" wasn't findable as a structured column — the durable marker in the codebase is the `@carelinkai.test` demo-account convention (docs/DEMO_ACCOUNTS.md) plus the seed-email patterns. This PR extends that convention into the structured `isDemo` flag, which I believe is the spec's intent; flagging in case #571 referenced something else.
- Founder runbook after merge: `npx tsx scripts/backfill-demo-flags.ts` on Render (dry-run, review the list), then `--force`.
- `/admin` page now reads `searchParams` via the awaited Next-15 pattern (no sync-dynamic-API regression; OL-076 unaffected elsewhere).

## Testing

- 5 new tests: **every** metric query carries the demo filter when `showDemo=false`; **no** query carries it when the toggle is on; MRR math unchanged by the plumbing; email-convention classification (all six demo/seed patterns flagged, real founder/operator emails and near-misses like `family.seedman@gmail.com` never flagged).
- Full suite 66/66 suites (647 passed, 10 pre-existing skips); `tsc` clean; lint clean; production build passes.

**Hold for Chris's review — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESFkcdB481xfPn2RQ8VnW6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESFkcdB481xfPn2RQ8VnW6)_