### PR TITLE
fix(security): stop logging cookie values in admin home-detail route (OL-118)

### DIFF
--- a/src/app/api/admin/homes/[id]/route.ts
+++ b/src/app/api/admin/homes/[id]/route.ts
@@ -30,27 +30,12 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    console.log('[Admin Home Detail API] GET request for id:', id);
-    
-    // Debug: Check cookies being received
-    const cookies = request.cookies.getAll();
-    console.log('[Admin Home Detail API] Cookies received:', cookies.map(c => `${c.name}=${c.value.substring(0, 20)}...`));
-    
-    // Try getServerSession first
+
+    // OL-118: NEVER log cookie/header values here (this route used to dump
+    // every cookie incl. the NextAuth session token prefix into Render logs).
+    // Auth material and PII stay out of log output; log role/booleans only.
     const session = await getServerSession(authOptions);
-    console.log('[Admin Home Detail API] Session from getServerSession:', session ? {
-      email: session.user?.email,
-      role: session.user?.role,
-      id: session.user?.id
-    } : 'No session');
-    
-    // Also try getToken as fallback/debug
     const token = await getToken({ req: request });
-    console.log('[Admin Home Detail API] Token from getToken:', token ? {
-      email: token.email,
-      role: token.role,
-      id: token.id
-    } : 'No token');
 
     // Use session if available, otherwise try token
     const userRole = session?.user?.role || (token?.role as string);
@@ -60,17 +45,8 @@ export async function GET(
     // Check if user is admin
     if (!userRole || userRole !== 'ADMIN') {
       console.log('[Admin Home Detail API] Unauthorized - session:', !!session, 'token:', !!token, 'role:', userRole);
-      return NextResponse.json({ 
-        error: 'Unauthorized',
-        debug: {
-          hasSession: !!session,
-          hasToken: !!token,
-          role: userRole || null,
-          expectedRole: 'ADMIN',
-          cookieCount: cookies.length,
-          cookieNames: cookies.map(c => c.name)
-        }
-      }, { status: 403 });
+      // No cookie names/values in the response body either (OL-118).
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
     }
 
     const home = await prisma.assistedLivingHome.findUnique({


### PR DESCRIPTION
## Summary

Session #3, priority 1 (security): kills the source of the `__Secure-next-auth.session-token=...` lines in Render logs.

## Root cause

`GET /api/admin/homes/[id]` had a leftover debug block that dumped **every request cookie** (`name=first-20-chars...`) to stdout on every call, plus session/token debug logs carrying the admin's email. That's the exact log line you saw from 7/2 — including the literal `...` (it's the code's own truncation).

## Actual exposure assessment (good news)

The logged value is `value.substring(0, 20)` — for the NextAuth session token that's only the **JWE header prefix**, which is identical constant boilerplate on every token (`eyJhbGciOiJkaXIiLCJ...`). It is **not a usable credential** — nobody can hijack a session from those log lines. The problem is hygiene/optics (auth material in logs, cookie names + admin email enumerable), not an active compromise. `NEXTAUTH_SECRET` rotation is therefore optional; cheap reassurance if you want it, but not indicated by this exposure.

## Fix

- Removed the cookie dump and the email-bearing session/token debug logs (kept role/boolean logging for authz diagnostics).
- Removed cookie names/count from the 403 response body (was also enumerating them to the client).

## Sweep results (repo-wide)

This was the **only** cookie/header-value logger in `src/`:
- The operator-resident pages read `cookies().toString()` but only to **forward** them on internal fetches — never logged.
- `mockMode.ts` reads the cookie header, logs only errors.
- NextAuth `debug` is `NODE_ENV === 'development'` only.
- All `authorization`-header reads (cron routes) compare, never log.

OL-118 will be filed in the open-loops file via this session's final context-docs PR (avoids the multi-PR conflict on shared context files), with a founder note: Render log retention will age out the 7/2 lines on its own; no rotation required.

## Testing

Removal-only change: full suite green (70/70), `tsc` clean, lint clean.

**Hold for Chris's review — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESFkcdB481xfPn2RQ8VnW6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESFkcdB481xfPn2RQ8VnW6)_