### PR TITLE
fix(inspections): format-gate license writes to ^\d{4}R$ RCF licenses only (Park East follow-up)

### DIFF
--- a/__tests__/odh-roster-backfill.unit.test.ts
+++ b/__tests__/odh-roster-backfill.unit.test.ts
@@ -138,7 +138,7 @@ describe('backfillLicensesFromRoster', () => {
       prisma,
       [
         row({ odhLicense: '' }) as any,
-        row({ providerName: 'Demo Home Cleveland', odhLicense: '777R' }) as any,
+        row({ providerName: 'Demo Home Cleveland', odhLicense: '0777R' }) as any,
       ],
       { force: true },
     );

--- a/__tests__/rcf-license-format.unit.test.ts
+++ b/__tests__/rcf-license-format.unit.test.ts
@@ -1,0 +1,122 @@
+/**
+ * OL-113 follow-up (Park East incident, 2026-07-06): only well-formed Ohio RCF
+ * licenses (^\d{4}R$) may ever be WRITTEN to odhLicenseNumber. Six-digit
+ * numerics like "365810" are nursing-home CCNs — the pre-gate parser wrote one
+ * and it had to be nulled in prod. These tests pin the gate at every write
+ * site: the format validator itself, the roster backfill, and the survey
+ * ingest's learned-license path.
+ */
+
+import { jest } from '@jest/globals';
+import { isValidRcfLicense } from '@/lib/inspections/matcher';
+import { backfillLicensesFromRoster, ingestOdhRecords } from '@/lib/inspections/ingest';
+
+describe('isValidRcfLicense', () => {
+  it('accepts exactly four digits + R (case-insensitive, trims whitespace)', () => {
+    for (const ok of ['2318R', '0592R', '0592r', ' 2437R ']) {
+      expect(isValidRcfLicense(ok)).toBe(true);
+    }
+  });
+
+  it('rejects nursing-home CCNs and every other malformed token', () => {
+    for (const bad of [
+      '365810',   // the Park East 6-digit NH CCN
+      '365810R',  // 6 digits even with an R
+      '123R',     // 3 digits
+      '12345R',   // 5 digits
+      '2318',     // missing R
+      'R2318',    // wrong order
+      '2318RX',
+      '',
+      null,
+      undefined,
+    ]) {
+      expect(isValidRcfLicense(bad as any)).toBe(false);
+    }
+  });
+});
+
+// --- write-site gates with a stubbed Prisma client -------------------------
+
+function makePrisma(homes: any[]) {
+  return {
+    assistedLivingHome: {
+      findMany: jest.fn(async () => homes),
+      update: jest.fn(async () => ({})),
+    },
+    facilityInspection: {
+      upsert: jest.fn(async () => ({})),
+    },
+  } as any;
+}
+
+const home = {
+  id: 'home-1',
+  name: 'Park East Care Center',
+  description: 'Real facility',
+  odhLicenseNumber: null,
+  address: { city: 'Cleveland', state: 'OH' },
+  operator: { user: { email: 'ops@example.com' } },
+};
+
+describe('roster backfill format gate', () => {
+  it('counts a NH CCN row as invalid and never writes it', async () => {
+    const prisma = makePrisma([home]);
+    const summary = await backfillLicensesFromRoster(
+      prisma,
+      [{
+        providerName: 'Park East Care Center',
+        address: null, city: 'Cleveland', county: null, phone: null,
+        licenseStatus: 'ACTIVE',
+        odhLicense: '365810',
+      }],
+      { force: true },
+    );
+    expect(summary.invalidRows).toBe(1);
+    expect(summary.backfilled).toBe(0);
+    expect(prisma.assistedLivingHome.update).not.toHaveBeenCalled();
+  });
+
+  it('still writes a valid RCF license', async () => {
+    const prisma = makePrisma([home]);
+    const summary = await backfillLicensesFromRoster(
+      prisma,
+      [{
+        providerName: 'Park East Care Center',
+        address: null, city: 'Cleveland', county: null, phone: null,
+        licenseStatus: 'ACTIVE',
+        odhLicense: '2318R',
+      }],
+      { force: true },
+    );
+    expect(summary.backfilled).toBe(1);
+    expect(prisma.assistedLivingHome.update).toHaveBeenCalledWith({
+      where: { id: 'home-1' },
+      data: { odhLicenseNumber: '2318R' },
+    });
+  });
+});
+
+describe('survey-ingest learned-license format gate', () => {
+  it('a NAME_CITY match with a NH-CCN license never backfills the home', async () => {
+    const prisma = makePrisma([home]);
+    const summary = await ingestOdhRecords(
+      prisma,
+      [{
+        licenseNumber: '365810',
+        facilityName: 'Park East Care Center',
+        city: 'Cleveland',
+        surveyDate: '2026-03-14',
+        surveyType: 'Standard',
+        citationCount: 0,
+      }],
+      { force: true },
+    );
+    // The survey record still attaches (name+city match is confirmed)...
+    expect(summary.matchedByNameCity).toBe(1);
+    expect(summary.upserted).toBe(1);
+    // ...but the malformed license is never learned onto the home.
+    expect(summary.licenseBackfills).toBe(0);
+    expect(prisma.assistedLivingHome.update).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/ingest-odh-inspections.ts
+++ b/scripts/ingest-odh-inspections.ts
@@ -44,7 +44,7 @@ import {
   parseRosterCsv,
   backfillLicensesFromRoster,
 } from '../src/lib/inspections/ingest';
-import { isExcludedDemoHome } from '../src/lib/inspections/matcher';
+import { isExcludedDemoHome, isValidRcfLicense } from '../src/lib/inspections/matcher';
 
 const prisma = new PrismaClient();
 
@@ -106,21 +106,29 @@ async function runRosterBackfill(rosterPath: string, force: boolean): Promise<vo
 }
 
 // The metro seed wrote "(ODH license 2318R — verify against ltc.ohio.gov.)" into
-// descriptions; lift those into the structured column.
+// descriptions; lift those into the structured column. Tokens are captured
+// loosely, then FORMAT-GATED to ^\d{4}R$ before any write (Park East lesson:
+// its description carried "365810" — a 6-digit nursing-home CCN, NOT an RCF
+// license — and the pre-gate parser wrote it; founder nulled it in prod
+// 2026-07-06). Non-RCF tokens are now reported as SKIPPED, never written.
 const DESC_LICENSE_RE = /ODH license\s+([0-9]{3,6}R?)\b/i;
 
 async function backfillLicensesFromDescriptions(force: boolean): Promise<void> {
   const homes = await prisma.assistedLivingHome.findMany({
-    where: { odhLicenseNumber: null, description: { contains: 'ODH license' } },
+    // INACTIVE homes excluded — mirrors the matcher's candidate policy (the
+    // pre-gate run wrote to at least one archived row).
+    where: { odhLicenseNumber: null, description: { contains: 'ODH license' }, status: { not: 'INACTIVE' } },
     select: {
       id: true,
       name: true,
+      status: true,
       description: true,
       operator: { select: { user: { select: { email: true } } } },
     },
   });
   let set = 0;
   let skippedDemo = 0;
+  let skippedInvalid = 0;
   for (const h of homes) {
     if (isExcludedDemoHome({ name: h.name, description: h.description, operatorEmail: h.operator?.user?.email ?? null })) {
       skippedDemo++;
@@ -129,13 +137,18 @@ async function backfillLicensesFromDescriptions(force: boolean): Promise<void> {
     const m = h.description?.match(DESC_LICENSE_RE);
     if (!m) continue;
     const lic = m[1].toUpperCase();
+    if (!isValidRcfLicense(lic)) {
+      skippedInvalid++;
+      console.log(`  ⚠️  SKIPPED (not an RCF license — likely a NH CCN): ${h.name} → "${lic}" NOT written. Verify the facility's license class (see OL-113/Park East).`);
+      continue;
+    }
     console.log(`  ${force ? 'SET' : 'WOULD SET'} ${h.name} → odhLicenseNumber=${lic}`);
     if (force) {
       await prisma.assistedLivingHome.update({ where: { id: h.id }, data: { odhLicenseNumber: lic } });
     }
     set++;
   }
-  console.log(`\nLicense backfill: ${set} home(s) ${force ? 'updated' : 'would be updated'}; ${skippedDemo} demo/test skipped; ${homes.length - set - skippedDemo} had no parseable token.`);
+  console.log(`\nLicense backfill: ${set} home(s) ${force ? 'updated' : 'would be updated'}; ${skippedDemo} demo/test skipped; ${skippedInvalid} non-RCF token(s) skipped; ${homes.length - set - skippedDemo - skippedInvalid} had no parseable token.`);
   if (!force && set > 0) console.log('Re-run with --force to write.');
 }
 

--- a/src/lib/inspections/ingest.ts
+++ b/src/lib/inspections/ingest.ts
@@ -13,6 +13,7 @@ import {
   OdhCitation,
   OdhSurveyRecord,
   isExcludedDemoHome,
+  isValidRcfLicense,
   matchOdhRecord,
   normalizeLicense,
 } from './matcher';
@@ -234,7 +235,9 @@ export async function backfillLicensesFromRoster(
   const assigned = new Map<string, string>(); // homeId -> normalized license
 
   for (const row of rows) {
-    const lic = normalizeLicense(row.odhLicense);
+    // Format gate (Park East lesson): only ^\d{4}R$ RCF licenses are ever
+    // written — 6-digit NH CCNs and other identifiers count as invalid rows.
+    const lic = isValidRcfLicense(row.odhLicense) ? normalizeLicense(row.odhLicense) : null;
     if (!row.providerName?.trim() || !lic) {
       summary.invalidRows++;
       continue;
@@ -436,8 +439,9 @@ export async function ingestOdhRecords(
     if (outcome.via === 'LICENSE') summary.matchedByLicense++;
     else summary.matchedByNameCity++;
 
-    // Learn the license on a confirmed name+city match.
-    const recLic = normalizeLicense(rec.licenseNumber);
+    // Learn the license on a confirmed name+city match — but only ever WRITE
+    // well-formed RCF licenses (^\d{4}R$); NH CCNs etc. are never persisted.
+    const recLic = isValidRcfLicense(rec.licenseNumber) ? normalizeLicense(rec.licenseNumber) : null;
     const needsLicenseBackfill =
       outcome.via === 'NAME_CITY' && recLic && !normalizeLicense(outcome.home.odhLicenseNumber);
     if (needsLicenseBackfill) {

--- a/src/lib/inspections/matcher.ts
+++ b/src/lib/inspections/matcher.ts
@@ -61,6 +61,18 @@ export function normalizeLicense(lic: string | null | undefined): string | null 
   return cleaned.length >= 2 ? cleaned : null;
 }
 
+/**
+ * True iff the token is a well-formed Ohio RCF license: exactly four digits +
+ * "R" (e.g. "2318R", "0592R"). Six-digit numerics like "365810" are nursing-
+ * home CCNs, NOT RCF licenses — writing one poisons matching AND signals the
+ * facility may be NH-licensed rather than an RCF (see the Park East incident,
+ * 2026-07-06). Every code path that WRITES odhLicenseNumber must gate on this;
+ * matching/comparison still uses normalizeLicense on whatever is stored.
+ */
+export function isValidRcfLicense(lic: string | null | undefined): boolean {
+  return typeof lic === 'string' && /^\d{4}R$/i.test(lic.trim());
+}
+
 // Generic corporate/legal noise that differs between ODH's licensee name and our
 // display name without changing facility identity. Deliberately does NOT include
 // care-type words ("assisted living", "memory care") — stripping those would


### PR DESCRIPTION
## Summary

Session #3, item 1a — follow-up to today's `--backfill-licenses --force` run, where Park East's description yielded **`365810`** (a 6-digit Ohio nursing-home CCN, not an RCF license) and the parser wrote it (founder nulled it in prod).

## Root cause

`DESC_LICENSE_RE` captured any 3–6 digit token with an optional `R`. The seed data deliberately carries both kinds of identifiers — `NNNNR` RCF licenses and 6-digit CCNs on SNF-primary rows — so the parser needed a format gate, not just a capture.

## Fix

- **New `isValidRcfLicense()`** in the matcher lib: exactly `^\d{4}R$`, case-insensitive. Documented as the mandatory gate for every code path that *writes* `odhLicenseNumber` (matching/comparison of already-stored values is unchanged).
- **All three write sites gated:**
  1. Description backfill (`--backfill-licenses`) — non-RCF tokens now reported as `⚠️ SKIPPED (not an RCF license — likely a NH CCN)` with a license-class warning, never written.
  2. Roster backfill (`--roster`) — NH-CCN rows count as invalid, never written.
  3. Survey ingest's learned-license path — a confirmed name+city match still attaches the survey record, but a malformed license is never learned onto the home.
- **Description backfill also excludes INACTIVE homes** now (mirrors the matcher's candidate policy — the pre-gate run wrote to at least one archived row).

## Testing

- 5 new tests pin the exact Park East token (`365810`) at all three write sites, plus the validator matrix (`365810R`, 3-digit, 5-digit, missing-R, wrong-order all rejected; `0592R`/`2318R` accepted).
- One existing roster fixture updated (`777R` → `0777R`): the old 3-digit value was only "valid" under the pre-gate parser — the new gate correctly rejects it, which is the fix working.
- Full suite 71/71 (671 passed); `tsc` clean; lint clean. No schema change.

## Note for the re-run

After merge, re-running `--backfill-licenses` on Render is safe and idempotent: the 24 valid rows count as already-set, Park East's token now reports as SKIPPED instead of writing. The Park East *listing* itself (possible NH-license / wrong care level) is being investigated separately — report coming before any listing change.

**Hold for Chris's review — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESFkcdB481xfPn2RQ8VnW6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESFkcdB481xfPn2RQ8VnW6)_