### PR TITLE
fix(dp-outreach): UTF-8 encoding + logo header for DP follow-up email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,6 +196,11 @@ LEAD_CAPTURE_TOKEN=""
 # DP_LEAD_REPLY_TO="placements@getcarelinkai.com"
 # DP_PLACEMENTS_PHONE=""   # optional — shown in the email signature block if set
 
+# Absolute https URL of the logo shown in the DP email header. Must be reachable
+# by email clients (use the PNG — Gmail strips SVG). Defaults to the public asset
+# at getcarelinkai.com/logo.png; override to point at a CDN copy if preferred.
+# EMAIL_LOGO_URL="https://getcarelinkai.com/logo.png"
+
 # ------------------------------------------------------------
 # ODH STATE INSPECTION HISTORY (OL-113) — public-records ingest
 # ------------------------------------------------------------

--- a/__tests__/dp-email-encoding.test.ts
+++ b/__tests__/dp-email-encoding.test.ts
@@ -1,0 +1,74 @@
+/**
+ * fix/dp-email-encoding — acceptance test for the DP follow-up email's UTF-8
+ * handling + logo header. Drives the real render path (renderDpFollowupHtml) and
+ * inspects the raw HTML source, the runnable form of the handoff's acceptance
+ * test ("check the raw source for <meta charset>, confirm em-dashes render, and
+ * the logo loads") — a live send needs prod env (RESEND_API_KEY + flags).
+ */
+
+// renderDpFollowupHtml is a pure function, but importing @/lib/email constructs a
+// Resend client at module load (throws without a key) — mock the SDK so the import
+// is side-effect-free.
+jest.mock('resend', () => ({ Resend: jest.fn().mockImplementation(() => ({ emails: { send: jest.fn() } })) }));
+
+import { renderDpFollowupHtml } from '@/lib/email';
+import { dpFollowupCopy } from '@/lib/dp-outreach/copy';
+
+const opts = {
+  unsubscribeUrl: 'https://getcarelinkai.com/api/outreach/unsubscribe?token=abc.def',
+  postalAddress: '1234 Main St, Cleveland, OH 44114',
+};
+// Touch 1 copy is the richest in non-ASCII punctuation (em-dashes + curly quotes).
+const copy = dpFollowupCopy(1, { plannerFirstName: 'Maria', videoUrl: 'https://app.heygen.com/videos/founder-x' });
+const html = renderDpFollowupHtml(copy, opts);
+
+describe('DP email — UTF-8 charset', () => {
+  it('declares <meta charset="utf-8"> inside a real <head>', () => {
+    expect(html).toContain('<meta charset="utf-8">');
+    expect(html.toLowerCase()).toContain('<head>');
+    // http-equiv belt for older clients
+    expect(html).toContain('content="text/html; charset=UTF-8"');
+  });
+
+  it('is pure 7-bit ASCII — no raw non-ASCII bytes that can mojibake', () => {
+    expect(/[^\x00-\x7F]/.test(html)).toBe(false);
+  });
+});
+
+describe('DP email — punctuation renders as HTML entities', () => {
+  it('em-dashes ship as &#8212; and never as raw —', () => {
+    expect(html).toContain('&#8212;'); // em-dash present, encoded
+    expect(html).not.toContain('—'); // no raw em-dash byte
+  });
+
+  it('curly apostrophes ship as &#8217; (e.g. "patient’s")', () => {
+    expect(html).toContain('&#8217;');
+    expect(html).not.toContain('’');
+  });
+
+  it('the footer middot ships as &#183; (not a raw ·)', () => {
+    expect(html).toContain('&#183;');
+    expect(html).not.toContain('·');
+  });
+});
+
+describe('DP email — logo header', () => {
+  it('includes the CareLinkAI logo image with an absolute https src', () => {
+    expect(html).toMatch(/<img[^>]+src="https:\/\/getcarelinkai\.com\/logo\.png"/);
+    expect(html).toMatch(/<img[^>]+alt="CareLinkAI"/);
+  });
+
+  it('honors EMAIL_LOGO_URL override via the opts logoUrl', () => {
+    const custom = renderDpFollowupHtml(copy, { ...opts, logoUrl: 'https://cdn.example.com/logo.png' });
+    expect(custom).toContain('src="https://cdn.example.com/logo.png"');
+  });
+});
+
+describe('DP email — content preserved', () => {
+  it('still linkifies the founder video URL', () => {
+    expect(html).toContain('<a href="https://app.heygen.com/videos/founder-x"');
+  });
+  it('keeps the unsubscribe link (CAN-SPAM)', () => {
+    expect(html).toContain(opts.unsubscribeUrl.replace(/&/g, '&amp;'));
+  });
+});

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -40,6 +40,10 @@ const DP_PLACEMENTS_PHONE = (process.env.DP_PLACEMENTS_PHONE || '').trim();
 // Brand-blue accent (matches the landing brand literal) — kept light so the
 // 1:1 emails still read personal, not like an operator marketing blast.
 const BRAND_BLUE = '#3978FC';
+// Publicly reachable absolute logo URL for the email header. Must be an https
+// URL an email client can fetch (Gmail strips SVG, so use the PNG). Overridable
+// via EMAIL_LOGO_URL; defaults to the public asset served at getcarelinkai.com.
+const EMAIL_LOGO_URL = (process.env.EMAIL_LOGO_URL || 'https://getcarelinkai.com/logo.png').trim();
 
 /**
  * Send a verification email to a new user
@@ -105,6 +109,23 @@ function escapeHtml(s: string): string {
 /** Turn bare http(s) URLs in ALREADY-ESCAPED text into clickable anchors. */
 function linkify(escaped: string): string {
   return escaped.replace(/(https?:\/\/[^\s<]+)/g, (url) => `<a href="${url}" style="color:#3978FC">${url}</a>`);
+}
+
+/**
+ * Replace every non-ASCII character with a numeric HTML entity (e.g. em-dash →
+ * `&#8212;`, curly quote → `&#8217;`, middot → `&#183;`). Applied to the FULL
+ * assembled HTML so the payload is pure 7-bit ASCII and renders identically no
+ * matter how the receiving client guesses the charset — the belt to the meta
+ * charset's suspenders. Safe to run over markup: all tags/attributes/URLs are
+ * already ASCII, so only human-readable text is affected. Astral-plane chars
+ * (emoji, surrogate pairs) are encoded per code point. */
+function encodeNonAscii(html: string): string {
+  let out = '';
+  for (const ch of html) {
+    const cp = ch.codePointAt(0)!;
+    out += cp > 127 ? `&#${cp};` : ch;
+  }
+  return out;
 }
 
 /**
@@ -614,6 +635,54 @@ export async function sendClaimDripEmail(args: {
 }
 
 /**
+ * Build the full HTML for a DP follow-up email — exported so the raw source is
+ * unit-testable (acceptance test checks the meta charset, entity-encoded
+ * em-dashes, and the logo). Emits a real `<head>` with `<meta charset="utf-8">`
+ * so clients render UTF-8, prepends the CareLinkAI logo header, then runs the
+ * whole document through `encodeNonAscii` so every em-dash / curly quote / middot
+ * ships as a numeric HTML entity (charset-independent, no mojibake).
+ */
+export function renderDpFollowupHtml(
+  copy: { subject: string; paragraphs: string[] },
+  opts: { unsubscribeUrl: string; postalAddress: string; logoUrl?: string },
+): string {
+  const logoUrl = (opts.logoUrl || EMAIL_LOGO_URL);
+  const bodyHtml = copy.paragraphs
+    .map((p) => `<p style="margin:0 0 14px">${linkify(escapeHtml(p))}</p>`)
+    .join('\n');
+  const sigHtml = `
+  <table role="presentation" cellpadding="0" cellspacing="0" style="margin-top:8px">
+    <tr><td style="border-left:3px solid ${BRAND_BLUE};padding:2px 0 2px 10px;color:#374151;font-size:14px;line-height:1.5">
+      <strong style="color:#111827">Chris Tolliver</strong><br/>
+      <span style="color:${BRAND_BLUE};font-weight:600">CareLinkAI Placements</span><br/>
+      ${DP_PLACEMENTS_PHONE ? `${escapeHtml(DP_PLACEMENTS_PHONE)}<br/>` : ''}
+      <a href="https://getcarelinkai.com" style="color:#6b7280;text-decoration:none">getcarelinkai.com</a>
+    </td></tr>
+  </table>`;
+  const rawHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0;padding:0;font-family:Arial,Helvetica,sans-serif;color:#1f2937;line-height:1.55;font-size:15px">
+  <div style="margin:0 0 20px">
+    <img src="${escapeHtml(logoUrl)}" alt="CareLinkAI" width="170" style="display:block;border:0;outline:none;text-decoration:none;height:auto;width:170px;max-width:170px"/>
+  </div>
+  ${bodyHtml}
+  ${sigHtml}
+  <hr style="border:none;border-top:1px solid #e5e7eb;margin:18px 0"/>
+  <p style="color:#9ca3af;font-size:12px;line-height:1.5">
+    ${APP_NAME} · ${escapeHtml(opts.postalAddress)}<br/>
+    <a href="${escapeHtml(opts.unsubscribeUrl)}" style="color:#9ca3af">Unsubscribe</a> — you won't receive these emails again.
+  </p>
+</body></html>`;
+  // Pure-ASCII payload: renders identically regardless of the client's charset guess.
+  return encodeNonAscii(rawHtml);
+}
+
+/**
  * DP FOLLOW-UP touch (feat/dp-lead-capture).
  *
  * A single 1:1, personal-style email in the discharge-planner nurture sequence.
@@ -654,6 +723,9 @@ export async function sendDpFollowupEmail(args: {
       'getcarelinkai.com',
     ].filter(Boolean) as string[];
 
+    // Plain-text alternative keeps literal Unicode punctuation (correct for
+    // text/plain, which Resend sends as UTF-8). Only the HTML part needs the
+    // charset/entity treatment (that's where the mojibake showed up).
     const text =
       copy.paragraphs.join('\n\n') +
       '\n\n' +
@@ -662,29 +734,10 @@ export async function sendDpFollowupEmail(args: {
       `${APP_NAME} · ${args.postalAddress}\n` +
       `Prefer not to receive these? Unsubscribe: ${args.unsubscribeUrl}`;
 
-    const bodyHtml = copy.paragraphs
-      .map((p) => `<p style="margin:0 0 14px">${linkify(escapeHtml(p))}</p>`)
-      .join('\n');
-    const sigHtml = `
-  <table role="presentation" cellpadding="0" cellspacing="0" style="margin-top:8px">
-    <tr><td style="border-left:3px solid ${BRAND_BLUE};padding:2px 0 2px 10px;color:#374151;font-size:14px;line-height:1.5">
-      <strong style="color:#111827">Chris Tolliver</strong><br/>
-      <span style="color:${BRAND_BLUE};font-weight:600">CareLinkAI Placements</span><br/>
-      ${DP_PLACEMENTS_PHONE ? `${escapeHtml(DP_PLACEMENTS_PHONE)}<br/>` : ''}
-      <a href="https://getcarelinkai.com" style="color:#6b7280;text-decoration:none">getcarelinkai.com</a>
-    </td></tr>
-  </table>`;
-    const html = `
-<!DOCTYPE html>
-<html><body style="font-family:Arial,Helvetica,sans-serif;color:#1f2937;line-height:1.55;font-size:15px">
-  ${bodyHtml}
-  ${sigHtml}
-  <hr style="border:none;border-top:1px solid #e5e7eb;margin:18px 0"/>
-  <p style="color:#9ca3af;font-size:12px;line-height:1.5">
-    ${APP_NAME} · ${escapeHtml(args.postalAddress)}<br/>
-    <a href="${escapeHtml(args.unsubscribeUrl)}" style="color:#9ca3af">Unsubscribe</a> — you won't receive these emails again.
-  </p>
-</body></html>`;
+    const html = renderDpFollowupHtml(copy, {
+      unsubscribeUrl: args.unsubscribeUrl,
+      postalAddress: args.postalAddress,
+    });
 
     const { error } = await resend.emails.send({
       from: `${DP_LEAD_FROM_NAME} <${DP_LEAD_FROM_EMAIL}>`,


### PR DESCRIPTION
## Problem

The DP follow-up email (`sendDpFollowupEmail`, shipped in #704) rendered its em-dashes, curly apostrophes, and the footer middot as **mojibake** in some clients, and had **no logo** in the header. Root cause: the HTML had no `<head>`/charset declaration, so clients were left to guess the encoding of the raw UTF-8 bytes.

## Fix (belt + suspenders)

1. **`<meta charset="utf-8">`** — the HTML now emits a real `<head>` with `<meta charset="utf-8">` plus an `http-equiv` `Content-Type` fallback for older clients. This is the charset declaration Resend/the client render the HTML part from.
2. **HTML-entity encoding** — the fully-assembled HTML is run through a new `encodeNonAscii()` so **every** non-ASCII character ships as a numeric entity (em-dash → `&#8212;`, curly quote → `&#8217;`, middot → `&#183;`). The payload is now **pure 7-bit ASCII**, so it renders identically no matter how a client guesses the charset — charset-independent. The **plain-text** alternative keeps literal Unicode (correct for `text/plain`, which Resend sends as UTF-8).
3. **Logo header** — the CareLinkAI logo (`public/logo.png`, 912×214 PNG) is added to the top of the email as an absolute-https `<img>` (Gmail strips SVG, so PNG). Overridable via the new **`EMAIL_LOGO_URL`** env var; defaults to `https://getcarelinkai.com/logo.png`.
4. Extracted **`renderDpFollowupHtml()`** (exported) so the raw email source is directly unit-testable.

No behavior change to the sequence engine, sending logic, CAN-SPAM footer, or the copy itself — only how the HTML part is encoded and that a logo is prepended.

## Acceptance test

The handoff's acceptance test ("submit a lead → check the raw source for `<meta charset="utf-8">`, confirm em-dashes render and the logo loads") is encoded as a runnable unit test that drives the real render path — a live send needs prod env (`RESEND_API_KEY` + the DP flags). `__tests__/dp-email-encoding.test.ts` (9 tests) asserts:

- `<meta charset="utf-8">` present inside a real `<head>` (+ the `http-equiv` fallback)
- **zero** raw non-ASCII bytes in the HTML
- em-dash → `&#8212;`, curly apostrophe → `&#8217;`, middot → `&#183;` (and none present as raw bytes)
- the logo `<img>` with an absolute https `src` + `alt="CareLinkAI"`, and `EMAIL_LOGO_URL` override honored
- the founder video URL still linkified; the unsubscribe link preserved

Verified raw source of a rendered Touch-1 email:
```html
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
<meta name="viewport" content="width=device-width, initial-scale=1.0">
</head>
<body ...>
  <div style="margin:0 0 20px">
    ``&lt;img src="https://getcarelinkai.com/logo.png" alt="CareLinkAI" width="170" .../&gt;``
  </div>
  <p ...>Thanks for taking my colleague&#39;s call. I&#39;m Chris Tolliver, the founder of CareLinkAI &#8212; a free tool ...</p>
```
Raw non-ASCII byte count: **0**. The logo resolves to the public asset in production (this CI/sandbox can't fetch `getcarelinkai.com`, so visual logo-load is confirmed against the committed `public/logo.png` + the correct absolute `src`).

## Checks
- `tsc --noEmit` clean; `eslint` clean on changed files.
- 44 tests pass across the DP + email suites (9 new + existing `dp-followup`, `dp-lead-api`, `concierge.email`).

Scoped to the DP follow-up email only. No migration, no schema change; feature remains dormant behind `DP_FOLLOWUP_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdxFWV8XaFUuQ7oYACA1aw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdxFWV8XaFUuQ7oYACA1aw)_