### PR TITLE
fix(dp-outreach): make DP follow-up email image-free (remove logo)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,11 +196,6 @@ LEAD_CAPTURE_TOKEN=""
 # DP_LEAD_REPLY_TO="placements@getcarelinkai.com"
 # DP_PLACEMENTS_PHONE=""   # optional — shown in the email signature block if set
 
-# Absolute https URL of the logo shown in the DP email header. Must be reachable
-# by email clients (use the PNG — Gmail strips SVG). Defaults to the public asset
-# at getcarelinkai.com/logo.png; override to point at a CDN copy if preferred.
-# EMAIL_LOGO_URL="https://getcarelinkai.com/logo.png"
-
 # ------------------------------------------------------------
 # ODH STATE INSPECTION HISTORY (OL-113) — public-records ingest
 # ------------------------------------------------------------

--- a/__tests__/dp-email-encoding.test.ts
+++ b/__tests__/dp-email-encoding.test.ts
@@ -1,9 +1,9 @@
 /**
- * fix/dp-email-encoding — acceptance test for the DP follow-up email's UTF-8
- * handling + logo header. Drives the real render path (renderDpFollowupHtml) and
- * inspects the raw HTML source, the runnable form of the handoff's acceptance
- * test ("check the raw source for <meta charset>, confirm em-dashes render, and
- * the logo loads") — a live send needs prod env (RESEND_API_KEY + flags).
+ * Acceptance test for the DP follow-up email's UTF-8 handling + image-free
+ * header. Drives the real render path (renderDpFollowupHtml) and inspects the raw
+ * HTML source: meta charset present, punctuation entity-encoded, and NO logo
+ * <img> (image-free for hospital-inbox deliverability; brand carried by the
+ * text-only "CareLinkAI Placements" signature). A live send needs prod env.
  */
 
 // renderDpFollowupHtml is a pure function, but importing @/lib/email constructs a
@@ -62,15 +62,13 @@ describe('DP email — punctuation renders as HTML entities', () => {
   });
 });
 
-describe('DP email — logo header', () => {
-  it('includes the CareLinkAI logo image with an absolute https src', () => {
-    expect(html).toMatch(/<img[^>]+src="https:\/\/getcarelinkai\.com\/logo\.png"/);
-    expect(html).toMatch(/<img[^>]+alt="CareLinkAI"/);
+describe('DP email — image-free header', () => {
+  it('contains no logo <img> (image-free for deliverability)', () => {
+    expect(html).not.toContain('<img');
   });
 
-  it('honors EMAIL_LOGO_URL override via the opts logoUrl', () => {
-    const custom = renderDpFollowupHtml(copy, { ...opts, logoUrl: 'https://cdn.example.com/logo.png' });
-    expect(custom).toContain('src="https://cdn.example.com/logo.png"');
+  it('keeps the text-only "CareLinkAI Placements" signature branding', () => {
+    expect(html).toContain('CareLinkAI Placements');
   });
 });
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -41,10 +41,6 @@ const DP_PLACEMENTS_PHONE = (process.env.DP_PLACEMENTS_PHONE || '').trim();
 // Brand-blue accent (matches the landing brand literal) — kept light so the
 // 1:1 emails still read personal, not like an operator marketing blast.
 const BRAND_BLUE = '#3978FC';
-// Publicly reachable absolute logo URL for the email header. Must be an https
-// URL an email client can fetch (Gmail strips SVG, so use the PNG). Overridable
-// via EMAIL_LOGO_URL; defaults to the public asset served at getcarelinkai.com.
-const EMAIL_LOGO_URL = (process.env.EMAIL_LOGO_URL || 'https://getcarelinkai.com/logo.png').trim();
 
 /**
  * Send a verification email to a new user
@@ -637,17 +633,20 @@ export async function sendClaimDripEmail(args: {
 
 /**
  * Build the full HTML for a DP follow-up email — exported so the raw source is
- * unit-testable (acceptance test checks the meta charset, entity-encoded
- * em-dashes, and the logo). Emits a real `<head>` with `<meta charset="utf-8">`
- * so clients render UTF-8, prepends the CareLinkAI logo header, then runs the
- * whole document through `encodeNonAscii` so every em-dash / curly quote / middot
- * ships as a numeric HTML entity (charset-independent, no mojibake).
+ * unit-testable (acceptance test checks the meta charset + entity-encoded
+ * punctuation). Emits a real `<head>` with `<meta charset="utf-8">` so clients
+ * render UTF-8, then runs the whole document through `encodeNonAscii` so every
+ * em-dash / curly quote / middot ships as a numeric HTML entity
+ * (charset-independent, no mojibake).
+ *
+ * IMAGE-FREE by design: no logo `<img>` in the header. These are 1:1 emails to
+ * hospital inboxes where image-heavy mail hurts deliverability; the brand is
+ * carried by the text-only "CareLinkAI Placements" signature block instead.
  */
 export function renderDpFollowupHtml(
   copy: { subject: string; paragraphs: string[]; videoUrl: string },
-  opts: { unsubscribeUrl: string; postalAddress: string; logoUrl?: string },
+  opts: { unsubscribeUrl: string; postalAddress: string },
 ): string {
-  const logoUrl = (opts.logoUrl || EMAIL_LOGO_URL);
   // Friendly-text anchor for the founder video (href unchanged; only the visible
   // link text is friendly instead of the raw URL).
   const videoAnchor = `<a href="${escapeHtml(copy.videoUrl)}" style="color:#3978FC">${VIDEO_LINK_TEXT}</a>`;
@@ -671,9 +670,6 @@ export function renderDpFollowupHtml(
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body style="margin:0;padding:0;font-family:Arial,Helvetica,sans-serif;color:#1f2937;line-height:1.55;font-size:15px">
-  <div style="margin:0 0 20px">
-    <img src="${escapeHtml(logoUrl)}" alt="CareLinkAI" width="170" style="display:block;border:0;outline:none;text-decoration:none;height:auto;width:170px;max-width:170px"/>
-  </div>
   ${bodyHtml}
   ${sigHtml}
   <hr style="border:none;border-top:1px solid #e5e7eb;margin:18px 0"/>


### PR DESCRIPTION
## What

Removes the logo `<img>` from the DP follow-up email header (`renderDpFollowupHtml` in `src/lib/email.ts`). Going **image-free** for better deliverability to hospital inboxes, where image-heavy mail is more likely to be filtered or clipped.

Everything else is unchanged — including the **text-only "CareLinkAI Placements" signature block**, which now carries the branding on its own.

## Changes
- `src/lib/email.ts`:
  - Drop the `<div><img …/></div>` logo header from the DP email body.
  - Remove the now-unused `EMAIL_LOGO_URL` constant and the `logoUrl?` render option (dead config once the image is gone).
  - Doc comment updated to state the email is image-free by design.
- `.env.example`: remove the `EMAIL_LOGO_URL` entry.
- `__tests__/dp-email-encoding.test.ts`: the former "logo header" assertions now assert the logo `<img>` is **absent** and that the "CareLinkAI Placements" text signature is present.

No change to the copy, the UTF-8/charset handling, the friendly video link, the CAN-SPAM footer, or the sending logic.

## Verification
Rendered a Touch-1 email through the real path:
- `has <img?` → **false**
- `has "CareLinkAI Placements"?` → **true**
- `has <meta charset="utf-8">?` → **true**
- body now starts directly at the greeting (no logo block)

`tsc --noEmit` clean; `eslint` clean; 44 tests pass across the DP + email suites.

No behavior change beyond the header; no migration; feature stays dormant behind `DP_FOLLOWUP_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdxFWV8XaFUuQ7oYACA1aw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdxFWV8XaFUuQ7oYACA1aw)_