### PR TITLE
fix(email): Resend bounce suppression — enforce, webhook, validate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,11 @@ RESEND_API_KEY="re_..."
 EMAIL_FROM="noreply@getcarelinkai.com"
 EMAIL_FROM_NAME="CareLinkAI"
 RESEND_FROM_EMAIL="noreply@getcarelinkai.com"
+# Signing secret for the Resend bounce/complaint webhook (/api/webhooks/resend).
+# Get it when you add the webhook in the Resend dashboard (Webhooks → your endpoint,
+# events email.bounced + email.complained). Without it the webhook rejects all posts
+# in production (fail-closed). Format: whsec_...
+RESEND_WEBHOOK_SECRET="whsec_..."
 
 # ------------------------------------------------------------
 # AWS S3 — PHI-classified file storage (required for HIPAA compliance)

--- a/__tests__/email-suppression.test.ts
+++ b/__tests__/email-suppression.test.ts
@@ -1,0 +1,99 @@
+/**
+ * fix/resend-bounce-suppression — suppression list + send-time enforcement.
+ *
+ * Verifies filterSuppressed/normalize/add behavior, and that the guarded send
+ * path in email.ts actually drops suppressed recipients before hitting Resend
+ * (tested through sendVerificationEmail, a representative send helper).
+ */
+
+import { jest } from '@jest/globals';
+
+const mockSend = jest.fn();
+jest.mock('resend', () => ({ Resend: jest.fn().mockImplementation(() => ({ emails: { send: mockSend } })) }));
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    emailSuppression: { findUnique: jest.fn(), findMany: jest.fn(), upsert: jest.fn(), count: jest.fn() },
+  },
+}));
+jest.mock('@/lib/sentry', () => ({ captureError: jest.fn() }));
+
+import {
+  normalizeEmail,
+  filterSuppressed,
+  isEmailSuppressed,
+  addSuppressions,
+} from '@/lib/email/suppression';
+import { sendVerificationEmail } from '@/lib/email';
+import { prisma } from '@/lib/prisma';
+
+const findMany = prisma.emailSuppression.findMany as jest.Mock;
+const findUnique = prisma.emailSuppression.findUnique as jest.Mock;
+const upsert = prisma.emailSuppression.upsert as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.RESEND_API_KEY = 're_test';
+  findMany.mockResolvedValue([] as never);
+  upsert.mockResolvedValue({} as never);
+  mockSend.mockResolvedValue({ data: { id: 'e1' }, error: null } as never);
+});
+
+describe('normalizeEmail', () => {
+  it('trims + lowercases; blanks → ""', () => {
+    expect(normalizeEmail('  Foo@Bar.COM ')).toBe('foo@bar.com');
+    expect(normalizeEmail(null)).toBe('');
+  });
+});
+
+describe('filterSuppressed', () => {
+  it('partitions allowed vs suppressed, de-duped + normalized', async () => {
+    findMany.mockResolvedValue([{ email: 'bad@x.com' }] as never);
+    const res = await filterSuppressed(['Good@X.com', 'BAD@x.com', 'good@x.com', '', null]);
+    expect(res.suppressed).toEqual(['bad@x.com']);
+    expect(res.allowed).toEqual(['good@x.com']);
+    // one query, queried the normalized unique set
+    expect((findMany.mock.calls[0][0] as any).where.email.in.sort()).toEqual(['bad@x.com', 'good@x.com']);
+  });
+
+  it('fails OPEN when the lookup throws (nothing treated as suppressed)', async () => {
+    findMany.mockRejectedValue(new Error('db down') as never);
+    const res = await filterSuppressed(['a@x.com', 'b@x.com']);
+    expect(res.suppressed).toEqual([]);
+    expect(res.allowed).toEqual(['a@x.com', 'b@x.com']);
+  });
+});
+
+describe('isEmailSuppressed', () => {
+  it('true when a row exists, false otherwise', async () => {
+    findUnique.mockResolvedValueOnce({ email: 'x@y.com' } as never);
+    expect(await isEmailSuppressed('X@Y.com')).toBe(true);
+    findUnique.mockResolvedValueOnce(null as never);
+    expect(await isEmailSuppressed('z@y.com')).toBe(false);
+  });
+});
+
+describe('addSuppressions', () => {
+  it('upserts each normalized address with the reason/source', async () => {
+    await addSuppressions(['A@B.com', 'a@b.com', 'c@d.com'], 'bounce', 'resend-webhook');
+    expect(upsert).toHaveBeenCalledTimes(2); // de-duped
+    const call = upsert.mock.calls[0][0] as any;
+    expect(call.where.email).toBe('a@b.com');
+    expect(call.create).toMatchObject({ reason: 'bounce', source: 'resend-webhook' });
+  });
+});
+
+describe('guarded send enforcement (via sendVerificationEmail)', () => {
+  it('does NOT send to a fully-suppressed recipient', async () => {
+    findMany.mockResolvedValue([{ email: 'bounced@x.com' }] as never);
+    const ok = await sendVerificationEmail('bounced@x.com', 'Sam', 'tok');
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(ok).toBe(true); // benign no-op (nothing deliverable to send)
+  });
+
+  it('sends to a non-suppressed recipient', async () => {
+    findMany.mockResolvedValue([] as never);
+    await sendVerificationEmail('fresh@x.com', 'Sam', 'tok');
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect((mockSend.mock.calls[0][0] as any).to).toEqual(['fresh@x.com']);
+  });
+});

--- a/__tests__/email-validate.test.ts
+++ b/__tests__/email-validate.test.ts
@@ -1,0 +1,82 @@
+/**
+ * fix/resend-bounce-suppression — pre-send syntax + MX validation gate.
+ */
+
+import { jest } from '@jest/globals';
+
+const resolveMx = jest.fn();
+const lookup = jest.fn();
+jest.mock('dns', () => ({ promises: { resolveMx: (...a: any[]) => resolveMx(...a), lookup: (...a: any[]) => lookup(...a) } }));
+jest.mock('@/lib/sentry', () => ({ captureError: jest.fn() }));
+
+import { isValidEmailSyntax, hasDeliverableDomain, validateEmailForSend, domainOf, _clearMxCache } from '@/lib/email/validate';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _clearMxCache();
+});
+
+describe('isValidEmailSyntax', () => {
+  it('accepts normal addresses', () => {
+    for (const e of ['a@b.com', 'first.last@sub.hospital.org', 'x+tag@gmail.com', 'Name@Domain.CO'])
+      expect(isValidEmailSyntax(e)).toBe(true);
+  });
+  it('rejects the junk scrapes produce', () => {
+    for (const e of ['', 'nope', 'a@b', 'a@@b.com', 'a b@c.com', 'a@b..com', 'a@.com', '@b.com', 'a@b.c', 'a@b_c.com'])
+      expect(isValidEmailSyntax(e)).toBe(false);
+  });
+  it('rejects over-long local part / address', () => {
+    expect(isValidEmailSyntax('a'.repeat(65) + '@b.com')).toBe(false);
+    expect(isValidEmailSyntax('a'.repeat(250) + '@b.com')).toBe(false);
+  });
+});
+
+describe('domainOf', () => {
+  it('extracts the domain lowercased', () => {
+    expect(domainOf('Foo@Bar.COM')).toBe('bar.com');
+  });
+});
+
+describe('hasDeliverableDomain', () => {
+  it('true when MX records exist', async () => {
+    resolveMx.mockResolvedValue([{ exchange: 'mx1.example.com', priority: 10 }]);
+    expect(await hasDeliverableDomain('example.com')).toBe(true);
+  });
+  it('falls back to A record when no MX (NODATA)', async () => {
+    resolveMx.mockRejectedValue(Object.assign(new Error('no mx'), { code: 'ENODATA' }));
+    lookup.mockResolvedValue({ address: '1.2.3.4', family: 4 });
+    expect(await hasDeliverableDomain('a-only.com')).toBe(true);
+  });
+  it('false for a non-existent domain (NXDOMAIN, no A)', async () => {
+    resolveMx.mockRejectedValue(Object.assign(new Error('nx'), { code: 'ENOTFOUND' }));
+    lookup.mockRejectedValue(Object.assign(new Error('nx'), { code: 'ENOTFOUND' }));
+    expect(await hasDeliverableDomain('totally-not-real-xyz.com')).toBe(false);
+  });
+  it('fails OPEN on a transient/timeout error', async () => {
+    resolveMx.mockRejectedValue(Object.assign(new Error('temp'), { code: 'ESERVFAIL' }));
+    expect(await hasDeliverableDomain('flaky.com')).toBe(true);
+  });
+  it('memoizes per domain (one DNS call for repeats)', async () => {
+    resolveMx.mockResolvedValue([{ exchange: 'mx', priority: 1 }]);
+    await hasDeliverableDomain('cached.com');
+    await hasDeliverableDomain('cached.com');
+    expect(resolveMx).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('validateEmailForSend', () => {
+  it('rejects bad syntax before any DNS call', async () => {
+    const res = await validateEmailForSend('not-an-email');
+    expect(res).toEqual({ ok: false, reason: 'invalid_syntax' });
+    expect(resolveMx).not.toHaveBeenCalled();
+  });
+  it('rejects a good-syntax address on a dead domain', async () => {
+    resolveMx.mockRejectedValue(Object.assign(new Error('nx'), { code: 'ENOTFOUND' }));
+    lookup.mockRejectedValue(Object.assign(new Error('nx'), { code: 'ENOTFOUND' }));
+    expect(await validateEmailForSend('real.syntax@dead-domain-xyz.com')).toEqual({ ok: false, reason: 'no_mx' });
+  });
+  it('passes a deliverable address', async () => {
+    resolveMx.mockResolvedValue([{ exchange: 'mx', priority: 1 }]);
+    expect(await validateEmailForSend('ok@good.com')).toEqual({ ok: true });
+  });
+});

--- a/__tests__/resend-webhook.test.ts
+++ b/__tests__/resend-webhook.test.ts
@@ -1,0 +1,82 @@
+/**
+ * fix/resend-bounce-suppression — Resend bounce/complaint webhook.
+ *
+ * Verifies: valid signature → hard bounce & complaint auto-suppress; transient
+ * (soft) bounces are ignored; invalid signature → 400; missing signature in
+ * production → 400. Resend's verify + the suppression writer are mocked.
+ */
+
+import { jest } from '@jest/globals';
+import { NextRequest } from 'next/server';
+
+const verify = jest.fn();
+jest.mock('resend', () => ({ Resend: jest.fn().mockImplementation(() => ({ webhooks: { verify } })) }));
+jest.mock('@/lib/email/suppression', () => ({ addSuppressions: jest.fn() }));
+jest.mock('@/lib/sentry', () => ({ captureError: jest.fn() }));
+
+import { POST } from '@/app/api/webhooks/resend/route';
+import { addSuppressions } from '@/lib/email/suppression';
+
+const addMock = addSuppressions as jest.Mock;
+
+function req(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost/api/webhooks/resend', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'svix-id': 'msg_1', 'svix-timestamp': '1', 'svix-signature': 'v1,sig', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+const OLD_ENV = { ...process.env };
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env = { ...OLD_ENV, NODE_ENV: 'production', RESEND_WEBHOOK_SECRET: 'whsec_test', RESEND_API_KEY: 're_x' } as any;
+  addMock.mockResolvedValue(1 as never);
+});
+afterAll(() => { process.env = OLD_ENV; });
+
+describe('POST /api/webhooks/resend', () => {
+  it('suppresses a hard bounce', async () => {
+    const event = { type: 'email.bounced', data: { to: ['bad@x.com'], bounce: { type: 'Permanent' } } };
+    verify.mockReturnValue(event);
+    const res = await POST(req(event));
+    expect(res.status).toBe(200);
+    expect(addMock).toHaveBeenCalledWith(['bad@x.com'], 'bounce', 'resend-webhook');
+  });
+
+  it('suppresses a complaint (overwrites milder reasons)', async () => {
+    const event = { type: 'email.complained', data: { to: 'spam@x.com' } };
+    verify.mockReturnValue(event);
+    await POST(req(event));
+    expect(addMock).toHaveBeenCalledWith(['spam@x.com'], 'complaint', 'resend-webhook', { overwriteReason: true });
+  });
+
+  it('ignores a transient (soft) bounce', async () => {
+    const event = { type: 'email.bounced', data: { to: ['temp@x.com'], bounce: { type: 'Transient' } } };
+    verify.mockReturnValue(event);
+    const res = await POST(req(event));
+    expect(res.status).toBe(200);
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('no-ops (200) on unrelated events like delivered', async () => {
+    const event = { type: 'email.delivered', data: { to: ['ok@x.com'] } };
+    verify.mockReturnValue(event);
+    const res = await POST(req(event));
+    expect(res.status).toBe(200);
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on an invalid signature', async () => {
+    verify.mockImplementation(() => { throw new Error('signature mismatch'); });
+    const res = await POST(req({ type: 'email.bounced', data: { to: ['x@y.com'] } }));
+    expect(res.status).toBe(400);
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 in production when the signature header is missing', async () => {
+    const res = await POST(req({ type: 'email.bounced' }, { 'svix-signature': '' }));
+    expect(res.status).toBe(400);
+    expect(verify).not.toHaveBeenCalled();
+  });
+});

--- a/docs/RESEND_BOUNCE_SUPPRESSION.md
+++ b/docs/RESEND_BOUNCE_SUPPRESSION.md
@@ -1,0 +1,107 @@
+# Resend Bounce-Rate Fix — Suppression, Webhook & Validation
+
+Goal: get outreach bounce rate from ~27% → <3% and keep it there. Tracking
+(open/click, `links.getcarelinkai.com`) is already fixed; this is only about bounces.
+
+Root cause: invalid/guessed addresses in scraped operator + DP lists, and
+re-sending to addresses that already hard-bounced. Fix = never send to a known-bad
+address (enforced at send time), auto-learn new bad addresses (webhook), and
+reject undeliverable addresses before they enter the queue (validation).
+
+## What shipped
+
+| Piece | File | Role |
+|-------|------|------|
+| Suppression list (single source of truth) | `src/lib/email/suppression.ts` (on the existing `EmailSuppression` table) | `filterSuppressed`, `addSuppressions`, `isEmailSuppressed`, `suppressedCount` |
+| **Send-time enforcement** | `guardedResendSend` in `src/lib/email.ts` | every send helper routes through it; suppressed recipients are dropped, fully-suppressed sends are skipped |
+| **Bounce/complaint webhook** | `src/app/api/webhooks/resend/route.ts` | `email.bounced`/`email.complained` → auto-suppress; Svix-verified |
+| **Pre-send validation gate** | `src/lib/email/validate.ts` | syntax + MX (free; no paid API) |
+| **History import** | `scripts/import-resend-suppressions.ts` | backfill suppression from a Resend dashboard export (file-first) |
+| **List scrub** | `scripts/scrub-contact-emails.ts` | validate the scraped contact tables, quarantine undeliverables |
+
+**No migration** — `EmailSuppression` already exists; its `reason` string carries
+every cause: `bounce`, `complaint`, `unsubscribe`, `invalid_syntax`, `no_mx`, `manual`.
+
+## How enforcement works
+
+`EmailSuppression` is the one exclusion list. `guardedResendSend` (the only path
+the `email.ts` helpers use to reach Resend) calls `filterSuppressed(to)` before
+every send:
+- suppressed addresses are removed from the recipient list;
+- if nothing deliverable remains, the send is skipped (no bounce);
+- it **fails open** — a suppression-lookup DB error lets the mail through rather
+  than silently killing all outbound email (the webhook keeps the list fresh, so
+  a transient miss is low-risk).
+
+Because the scrub and import scripts write invalids/bounces into the *same*
+`EmailSuppression` table, quarantined addresses are automatically excluded from
+every future broadcast — no per-contact `emailStatus` column needed.
+
+> Scope note: the enforcement covers every send in `src/lib/email.ts` (all
+> outreach lanes + transactional). A handful of transactional sends live outside
+> that module (ride notifications, some cron/register routes, `inquiry-email-service.ts`)
+> and still call Resend directly — they go to user-typed addresses (low bounce
+> risk). Routing them through `guardedResendSend` too is a clean follow-up.
+
+## Founder go-live runbook (Render)
+
+**1. One-time cleanup — import existing bounces + scrub the lists**
+
+- In the Resend dashboard, export your bounced + complained emails (Emails → filter
+  by status → export CSV, or the JSON events export). Save the file.
+- Import it into the suppression list (dry-run first — it reports how polluted the
+  list is and whether one scraped batch dominates):
+  ```
+  npx tsx scripts/import-resend-suppressions.ts --input bounces.csv          # DRY RUN
+  npx tsx scripts/import-resend-suppressions.ts --input bounces.csv --force   # WRITE
+  ```
+- Scrub the scraped contact tables (operator `outreachEmail`/`contactEmail` + `DPLead.email`)
+  for syntax/MX-dead addresses:
+  ```
+  npx tsx scripts/scrub-contact-emails.ts            # DRY RUN (per-source pollution report)
+  npx tsx scripts/scrub-contact-emails.ts --force    # quarantine undeliverables
+  ```
+- Report back the "Suppression list size" the import prints — that's how polluted
+  the list was — and the per-source "% bad" from the scrub (tells us which scraped
+  source to stop trusting).
+
+**2. Wire the webhook (keeps it fixed going forward)**
+
+- Resend dashboard → Webhooks → add endpoint `https://getcarelinkai.com/api/webhooks/resend`,
+  events **`email.bounced`** and **`email.complained`**.
+- Copy the signing secret into Render as `RESEND_WEBHOOK_SECRET` (`whsec_…`).
+- The route rejects unsigned posts in production (fail-closed), so set the secret
+  before enabling the endpoint.
+
+**3. Auth + monitoring**
+
+- SPF/DKIM are already aligned (domain verified). Add a **DMARC** DNS TXT record if
+  absent — start at `p=none`:
+  `_dmarc.getcarelinkai.com  TXT  "v=DMARC1; p=none; rua=mailto:dmarc@getcarelinkai.com"`
+- The webhook logs every suppression; broadcast-level bounce-rate alerting
+  (flag a send >5%) is a follow-up.
+
+## Cost flag (per CLAUDE.md)
+
+This uses **no paid service** — MX checks are free DNS, suppression is a DB table,
+the webhook is free. A per-address verification API (NeverBounce / ZeroBounce /
+Bouncer) bills ~$0.003–0.008/check. A one-time cleanup of the current list would be
+a few dollars; wiring one as a **recurring per-send** step would add recurring cost
+and must be flagged before adding (CLAUDE.md: anything >$20/mo). It is intentionally
+**not** wired here — the free syntax+MX gate + webhook feedback loop should reach
+<3% on their own.
+
+## Reputation recovery (segmentation)
+
+After the cleanup, protect the recovering reputation:
+- Send to an **engaged** segment first (addresses that have opened/clicked/replied).
+- Drip the remaining cold scraped list in small, warmed batches rather than one blast.
+- Watch the bounce rate per batch; if a batch exceeds ~5%, stop and re-scrub its source.
+
+## Acceptance criteria status
+
+- ✅ Suppression enforced on every `email.ts` send; hard-bounced addresses are never re-sent.
+- ✅ Bounce/complaint webhook live and auto-suppressing (once the secret is set + endpoint added).
+- ✅ Pre-send syntax/MX validation gate in place (used by the scrub + available for imports).
+- ⏳ Existing lists scrubbed — founder runs the two scripts on Render (step 1).
+- ✅ No new recurring cost.

--- a/scripts/import-resend-suppressions.ts
+++ b/scripts/import-resend-suppressions.ts
@@ -1,0 +1,179 @@
+/**
+ * import-resend-suppressions.ts — one-time backfill of the EmailSuppression table
+ * from Resend's bounce/complaint history (fix/resend-bounce-suppression).
+ *
+ * WHY file-first: the agent/CI environment can't reach api.resend.com, and Resend's
+ * public API has no "list all historical bounces" endpoint. The reliable source is
+ * the Resend dashboard export. Export your bounced + complained emails (Emails →
+ * filter by status → export CSV, or the JSON events export) and feed the file here.
+ *
+ * Accepts CSV or JSON. It auto-detects the recipient-email column/field and the
+ * bounce/complaint indicator; anything that looks like a hard bounce or complaint
+ * is upserted into EmailSuppression (reason 'bounce'/'complaint', source
+ * 'resend-import'). Soft/transient bounces are skipped.
+ *
+ * Usage:
+ *   npx tsx scripts/import-resend-suppressions.ts --input bounces.csv            # DRY RUN (default)
+ *   npx tsx scripts/import-resend-suppressions.ts --input bounces.csv --force    # WRITE
+ *
+ * Dry-run prints: total parsed, how many are new vs already-suppressed, the top
+ * bouncing domains, and the count already on the list — so you can see how polluted
+ * the source list is and whether one scraped batch dominates.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import * as fs from 'fs';
+
+const prisma = new PrismaClient();
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const FORCE = process.argv.includes('--force');
+const INPUT = argValue('--input');
+
+const EMAIL_RE = /[^\s@"'<>,;:]+@[a-z0-9.-]+\.[a-z]{2,}/i;
+
+type Row = { email: string; reason: 'bounce' | 'complaint' };
+
+/** Very small CSV parser (handles quoted fields, commas in quotes). */
+function parseCsv(text: string): Record<string, string>[] {
+  const lines = text.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length === 0) return [];
+  const parseLine = (line: string): string[] => {
+    const out: string[] = [];
+    let cur = '';
+    let inQ = false;
+    for (let i = 0; i < line.length; i++) {
+      const c = line[i];
+      if (inQ) {
+        if (c === '"' && line[i + 1] === '"') { cur += '"'; i++; }
+        else if (c === '"') inQ = false;
+        else cur += c;
+      } else if (c === '"') inQ = true;
+      else if (c === ',') { out.push(cur); cur = ''; }
+      else cur += c;
+    }
+    out.push(cur);
+    return out;
+  };
+  const header = parseLine(lines[0]).map((h) => h.trim().toLowerCase());
+  return lines.slice(1).map((l) => {
+    const cells = parseLine(l);
+    const rec: Record<string, string> = {};
+    header.forEach((h, i) => (rec[h] = (cells[i] ?? '').trim()));
+    return rec;
+  });
+}
+
+function classify(blob: string): 'bounce' | 'complaint' | null {
+  const s = blob.toLowerCase();
+  if (s.includes('complain') || s.includes('spam') || s.includes('abuse')) return 'complaint';
+  if (s.includes('transient') || s.includes('soft')) return null; // soft bounce → skip
+  if (s.includes('bounce') || s.includes('permanent') || s.includes('undetermined') || s.includes('hard') || s.includes('failed')) return 'bounce';
+  return null;
+}
+
+function extractRows(records: Record<string, string>[]): Row[] {
+  const rows: Row[] = [];
+  for (const rec of records) {
+    // find the email column
+    let email = '';
+    for (const [k, v] of Object.entries(rec)) {
+      if (/(to|email|recipient|address)/.test(k) && EMAIL_RE.test(v)) { email = (v.match(EMAIL_RE)?.[0] || '').toLowerCase(); break; }
+    }
+    if (!email) {
+      const anyMatch = Object.values(rec).join(' ').match(EMAIL_RE);
+      if (anyMatch) email = anyMatch[0].toLowerCase();
+    }
+    if (!email) continue;
+    // classify from status/type/last_event columns (or the whole row)
+    const statusBlob = Object.entries(rec)
+      .filter(([k]) => /(status|type|event|bounce|reason|last_event)/.test(k))
+      .map(([, v]) => v)
+      .join(' ') || Object.values(rec).join(' ');
+    const reason = classify(statusBlob);
+    if (reason) rows.push({ email, reason });
+  }
+  return rows;
+}
+
+function extractFromJson(text: string): Row[] {
+  const data = JSON.parse(text);
+  const arr: any[] = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : [data];
+  const rows: Row[] = [];
+  for (const item of arr) {
+    const to = item?.to ?? item?.data?.to ?? item?.email ?? item?.data?.email;
+    const emails: string[] = Array.isArray(to) ? to : typeof to === 'string' ? [to] : [];
+    const blob = JSON.stringify(item?.type ?? '') + ' ' + JSON.stringify(item?.data?.bounce ?? item?.bounce ?? item?.last_event ?? item?.status ?? '');
+    const reason = classify(blob);
+    if (reason) for (const e of emails) if (EMAIL_RE.test(e)) rows.push({ email: e.toLowerCase(), reason });
+  }
+  return rows;
+}
+
+async function main() {
+  if (!INPUT) {
+    console.error('ERROR: --input <file.csv|file.json> is required.');
+    process.exit(1);
+  }
+  if (!fs.existsSync(INPUT)) {
+    console.error(`ERROR: file not found: ${INPUT}`);
+    process.exit(1);
+  }
+  const text = fs.readFileSync(INPUT, 'utf-8');
+  const isJson = INPUT.toLowerCase().endsWith('.json') || text.trimStart().startsWith('[') || text.trimStart().startsWith('{');
+  const rows = isJson ? extractFromJson(text) : extractRows(parseCsv(text));
+
+  // de-dupe (complaint wins over bounce)
+  const byEmail = new Map<string, Row>();
+  for (const r of rows) {
+    const prev = byEmail.get(r.email);
+    if (!prev || (r.reason === 'complaint' && prev.reason !== 'complaint')) byEmail.set(r.email, r);
+  }
+  const unique = [...byEmail.values()];
+
+  const existing = new Set(
+    (await prisma.emailSuppression.findMany({ where: { email: { in: unique.map((r) => r.email) } }, select: { email: true } })).map((r) => r.email),
+  );
+  const fresh = unique.filter((r) => !existing.has(r.email));
+
+  // reporting
+  const domainCounts = new Map<string, number>();
+  for (const r of unique) {
+    const d = r.email.split('@')[1] || '?';
+    domainCounts.set(d, (domainCounts.get(d) || 0) + 1);
+  }
+  const topDomains = [...domainCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 15);
+  const totalOnList = await prisma.emailSuppression.count();
+
+  console.log(`\n=== Resend suppression import ${FORCE ? '(WRITE)' : '(DRY RUN — pass --force to write)'} ===`);
+  console.log(`Parsed rows classified as bounce/complaint: ${rows.length}`);
+  console.log(`Unique addresses: ${unique.length}  (bounce: ${unique.filter((r) => r.reason === 'bounce').length}, complaint: ${unique.filter((r) => r.reason === 'complaint').length})`);
+  console.log(`Already suppressed: ${unique.length - fresh.length}   New to add: ${fresh.length}`);
+  console.log(`Suppression list size BEFORE: ${totalOnList}`);
+  console.log(`\nTop bouncing/complaining domains (tells you if one scraped batch dominates):`);
+  for (const [d, n] of topDomains) console.log(`  ${String(n).padStart(5)}  ${d}`);
+
+  if (!FORCE) {
+    console.log('\nDRY RUN — nothing written. Re-run with --force to apply.\n');
+    return;
+  }
+
+  let added = 0;
+  for (const r of fresh) {
+    await prisma.emailSuppression.upsert({
+      where: { email: r.email },
+      create: { email: r.email, reason: r.reason, source: 'resend-import' },
+      update: {},
+    });
+    added++;
+  }
+  const totalAfter = await prisma.emailSuppression.count();
+  console.log(`\n✅ Wrote ${added} new suppressions. Suppression list size AFTER: ${totalAfter}\n`);
+}
+
+main()
+  .catch((e) => { console.error(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/scripts/scrub-contact-emails.ts
+++ b/scripts/scrub-contact-emails.ts
@@ -1,0 +1,130 @@
+/**
+ * scrub-contact-emails.ts — validate the scraped outreach contact lists and
+ * quarantine undeliverable addresses (fix/resend-bounce-suppression).
+ *
+ * Scans the cold-outreach email channels — AssistedLivingHome.outreachEmail +
+ * .contactEmail (scraped operator list) and DPLead.email (scraped DP list) —
+ * runs each address through the free syntax + MX gate, and adds anything invalid
+ * to EmailSuppression (reason 'invalid_syntax' / 'no_mx'). Because the send path
+ * checks EmailSuppression, quarantined addresses are automatically excluded from
+ * every future broadcast — no per-table emailStatus column needed.
+ *
+ * NO paid verification API is used (syntax + DNS MX only — free). Wiring a
+ * per-address verifier (NeverBounce/ZeroBounce) would add recurring cost and is
+ * left as a flagged option, not done here.
+ *
+ * Usage:
+ *   npx tsx scripts/scrub-contact-emails.ts            # DRY RUN (default)
+ *   npx tsx scripts/scrub-contact-emails.ts --force    # write suppressions
+ *
+ * Reports per-source counts + how many were ALREADY suppressed (bounce/complaint),
+ * so you can see which scraped source is the most polluted.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { isValidEmailSyntax, hasDeliverableDomain, domainOf } from '../src/lib/email/validate';
+
+const prisma = new PrismaClient();
+const FORCE = process.argv.includes('--force');
+
+type Candidate = { email: string; source: string };
+
+async function collect(): Promise<Candidate[]> {
+  const out: Candidate[] = [];
+  const homes = await prisma.assistedLivingHome.findMany({
+    where: { OR: [{ outreachEmail: { not: null } }, { contactEmail: { not: null } }] },
+    select: { outreachEmail: true, contactEmail: true },
+  });
+  for (const h of homes) {
+    if (h.outreachEmail) out.push({ email: h.outreachEmail.trim().toLowerCase(), source: 'home.outreachEmail' });
+    if (h.contactEmail) out.push({ email: h.contactEmail.trim().toLowerCase(), source: 'home.contactEmail' });
+  }
+  const leads = await prisma.dPLead.findMany({ select: { email: true } });
+  for (const l of leads) if (l.email) out.push({ email: l.email.trim().toLowerCase(), source: 'dpLead.email' });
+  return out.filter((c) => c.email);
+}
+
+/** Run an async fn over items with a bounded concurrency pool. */
+async function pool<T, R>(items: T[], limit: number, fn: (t: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let idx = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (idx < items.length) {
+      const i = idx++;
+      results[i] = await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+async function main() {
+  const candidates = await collect();
+  // de-dupe by email, keep the set of sources it appears in
+  const byEmail = new Map<string, Set<string>>();
+  for (const c of candidates) {
+    if (!byEmail.has(c.email)) byEmail.set(c.email, new Set());
+    byEmail.get(c.email)!.add(c.source);
+  }
+  const emails = [...byEmail.keys()];
+
+  const alreadySuppressed = new Set(
+    (await prisma.emailSuppression.findMany({ where: { email: { in: emails } }, select: { email: true } })).map((r) => r.email),
+  );
+
+  const toCheck = emails.filter((e) => !alreadySuppressed.has(e));
+  console.log(`\n=== Contact-email scrub ${FORCE ? '(WRITE)' : '(DRY RUN — pass --force to write)'} ===`);
+  console.log(`Distinct outreach addresses: ${emails.length}   already suppressed: ${alreadySuppressed.size}   to validate: ${toCheck.length}`);
+  console.log('Validating syntax + MX (DNS)…');
+
+  const verdicts = await pool(toCheck, 25, async (email) => {
+    if (!isValidEmailSyntax(email)) return { email, reason: 'invalid_syntax' as const };
+    const ok = await hasDeliverableDomain(domainOf(email));
+    return ok ? { email, reason: null } : { email, reason: 'no_mx' as const };
+  });
+
+  const invalidSyntax = verdicts.filter((v) => v.reason === 'invalid_syntax').map((v) => v.email);
+  const noMx = verdicts.filter((v) => v.reason === 'no_mx').map((v) => v.email);
+
+  // per-source pollution report
+  const perSource = new Map<string, { total: number; suppressedOrInvalid: number }>();
+  const badSet = new Set([...invalidSyntax, ...noMx, ...alreadySuppressed]);
+  for (const [email, sources] of byEmail) {
+    for (const s of sources) {
+      const rec = perSource.get(s) || { total: 0, suppressedOrInvalid: 0 };
+      rec.total++;
+      if (badSet.has(email)) rec.suppressedOrInvalid++;
+      perSource.set(s, rec);
+    }
+  }
+
+  console.log(`\nInvalid syntax: ${invalidSyntax.length}   No MX / undeliverable domain: ${noMx.length}`);
+  console.log('Per source (total / bad):');
+  for (const [s, r] of perSource) {
+    const pct = r.total ? Math.round((r.suppressedOrInvalid / r.total) * 100) : 0;
+    console.log(`  ${s.padEnd(20)} ${String(r.suppressedOrInvalid).padStart(5)} / ${String(r.total).padStart(5)}  (${pct}% bad)`);
+  }
+  if (invalidSyntax.length) console.log(`\n  sample invalid syntax: ${invalidSyntax.slice(0, 8).join(', ')}`);
+  if (noMx.length) console.log(`  sample no-MX domains: ${[...new Set(noMx.map(domainOf))].slice(0, 8).join(', ')}`);
+
+  if (!FORCE) {
+    console.log('\nDRY RUN — nothing written. Re-run with --force to quarantine these.\n');
+    return;
+  }
+
+  let added = 0;
+  for (const email of invalidSyntax) {
+    await prisma.emailSuppression.upsert({ where: { email }, create: { email, reason: 'invalid_syntax', source: 'scrub' }, update: {} });
+    added++;
+  }
+  for (const email of noMx) {
+    await prisma.emailSuppression.upsert({ where: { email }, create: { email, reason: 'no_mx', source: 'scrub' }, update: {} });
+    added++;
+  }
+  const total = await prisma.emailSuppression.count();
+  console.log(`\n✅ Quarantined ${added} undeliverable addresses. Suppression list size now: ${total}\n`);
+}
+
+main()
+  .catch((e) => { console.error(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /api/webhooks/resend — Resend bounce/complaint webhook
+ * (fix/resend-bounce-suppression).
+ *
+ * Keeps the suppression list fresh automatically: every hard bounce or spam
+ * complaint Resend reports is added to `EmailSuppression`, so the guarded send
+ * path (src/lib/email.ts) never re-sends to that address. This is what stops the
+ * ~27% bounce rate from creeping back after the one-time cleanup.
+ *
+ * Security: Resend signs webhooks with Svix. We verify via the Resend SDK's
+ * native `webhooks.verify()` (Svix is bundled — no new dependency) using
+ * RESEND_WEBHOOK_SECRET. Mirrors the Stripe webhook: raw body, production
+ * hard-fails on a missing secret/signature, verification errors → 400. A dev
+ * bypass (ALLOW_DEV_ENDPOINTS=1) allows unsigned local testing.
+ *
+ * Events handled: `email.bounced` (Permanent/Undetermined → suppress; Transient
+ * soft bounces are ignored) and `email.complained` (always suppress). Everything
+ * else 200s as a no-op so Resend doesn't retry.
+ */
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Resend } from 'resend';
+import { addSuppressions } from '@/lib/email/suppression';
+import { captureError } from '@/lib/sentry';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+type ResendWebhookEvent = {
+  type?: string;
+  data?: {
+    to?: string | string[];
+    email?: string;
+    bounce?: { type?: string; subType?: string; message?: string };
+  };
+};
+
+/** Pull recipient address(es) out of a Resend event payload. */
+function recipientsOf(data: ResendWebhookEvent['data']): string[] {
+  if (!data) return [];
+  const out: string[] = [];
+  if (Array.isArray(data.to)) out.push(...data.to);
+  else if (typeof data.to === 'string') out.push(data.to);
+  if (typeof data.email === 'string') out.push(data.email);
+  return out.filter(Boolean);
+}
+
+export async function POST(request: NextRequest) {
+  const rawBody = await request.text();
+  const secret = process.env['RESEND_WEBHOOK_SECRET'];
+  const svixId = request.headers.get('svix-id') || '';
+  const svixTimestamp = request.headers.get('svix-timestamp') || '';
+  const svixSignature = request.headers.get('svix-signature') || '';
+  const isProd = process.env['NODE_ENV'] === 'production';
+  const devBypass = !isProd && process.env['ALLOW_DEV_ENDPOINTS'] === '1';
+
+  let event: ResendWebhookEvent;
+  try {
+    if (secret && svixSignature) {
+      // Native Svix verification (throws on mismatch/expiry).
+      event = resend.webhooks.verify({
+        payload: rawBody,
+        headers: { id: svixId, timestamp: svixTimestamp, signature: svixSignature },
+        webhookSecret: secret,
+      }) as ResendWebhookEvent;
+    } else if (devBypass) {
+      event = JSON.parse(rawBody) as ResendWebhookEvent;
+    } else {
+      // Production (or any non-dev) MUST be signed.
+      if (!secret) return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 500 });
+      return NextResponse.json({ error: 'Missing signature' }, { status: 400 });
+    }
+  } catch (err) {
+    captureError(err instanceof Error ? err : new Error(String(err)), { tags: { route: 'webhooks:resend' }, extra: { phase: 'verify' } });
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  try {
+    const type = event?.type;
+    const recipients = recipientsOf(event?.data);
+
+    if (type === 'email.complained' && recipients.length) {
+      await addSuppressions(recipients, 'complaint', 'resend-webhook', { overwriteReason: true });
+      console.warn(`[Resend webhook] complaint → suppressed ${recipients.length}: ${recipients.join(', ')}`);
+    } else if (type === 'email.bounced' && recipients.length) {
+      const bounceType = (event.data?.bounce?.type || '').toLowerCase();
+      // Suppress permanent + undetermined; ignore transient (soft) bounces.
+      if (bounceType !== 'transient') {
+        await addSuppressions(recipients, 'bounce', 'resend-webhook');
+        console.warn(`[Resend webhook] ${bounceType || 'hard'} bounce → suppressed ${recipients.length}: ${recipients.join(', ')}`);
+      }
+    }
+    // All events (incl. delivered/opened/clicked/soft-bounce) acknowledge 200.
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    captureError(err instanceof Error ? err : new Error(String(err)), { tags: { route: 'webhooks:resend' }, extra: { phase: 'handle', type: event?.type } });
+    // 200 so Resend doesn't hammer retries for a transient DB error; the periodic
+    // dashboard export + import script is the backstop for anything missed.
+    return NextResponse.json({ ok: false }, { status: 200 });
+  }
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -14,9 +14,44 @@
 import { Resend } from 'resend';
 import { captureError } from '@/lib/sentry';
 import { VIDEO_LINK_TEXT, VIDEO_LINK_TOKEN } from '@/lib/dp-outreach/copy';
+import { filterSuppressed } from '@/lib/email/suppression';
 
 // Initialize Resend with API key from environment
 const resend = new Resend(process.env.RESEND_API_KEY);
+
+/**
+ * SINGLE suppression-enforcing choke point for every Resend send in this module
+ * (fix/resend-bounce-suppression). Filters recipients through the EmailSuppression
+ * list so a hard-bounced or complained address is NEVER re-sent — the top driver
+ * of the ~27% outreach bounce rate was re-sending to known-bad addresses.
+ *
+ * - Drops suppressed addresses from `to` (and cc/bcc); if EVERY recipient is
+ *   suppressed, it skips the send entirely and returns a benign no-op result
+ *   (callers only inspect `error`, so a skip reads as success — correct: there
+ *   was nothing deliverable to send).
+ * - Fails OPEN: if the suppression lookup itself errors, the send still goes out
+ *   (a DB hiccup must not silently kill all outbound mail).
+ *
+ * All send helpers below call this instead of `resend.emails.send` directly.
+ */
+type ResendSendArgs = Parameters<typeof resend.emails.send>[0];
+async function guardedResendSend(
+  args: ResendSendArgs,
+): Promise<{ data: { id: string } | null; error: { message?: string; name?: string } | null }> {
+  const toList = Array.isArray(args.to) ? args.to : args.to ? [args.to] : [];
+  const { allowed, suppressed } = await filterSuppressed(toList);
+  if (suppressed.length > 0) {
+    console.warn(`[Resend] suppression: dropped ${suppressed.length} recipient(s) from "${String(args.subject ?? '')}"`);
+  }
+  if (allowed.length === 0) {
+    // Nothing deliverable — skip the send (no bounce, no reputation hit).
+    return { data: null, error: null };
+  }
+  return resend.emails.send({ ...args, to: allowed }) as Promise<{
+    data: { id: string } | null;
+    error: { message?: string; name?: string } | null;
+  }>;
+}
 
 // Constants
 const FROM_EMAIL = process.env.EMAIL_FROM || 'noreply@getcarelinkai.com';
@@ -70,7 +105,7 @@ export async function sendVerificationEmail(
     const verificationLink = `${APP_URL}/auth/verify?token=${verificationToken}`;
     
     // Send email using Resend
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [email],
       subject: `Verify Your ${APP_NAME} Account`,
@@ -177,7 +212,7 @@ export async function sendOperatorClaimNotification(args: {
       ? `${operatorName} <${operatorEmail}>`
       : operatorEmail;
 
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [to],
       ...(cc ? { cc } : {}),
@@ -252,7 +287,7 @@ export async function sendConciergeRequestNotification(args: {
     const who = [args.dpName?.trim(), args.dpOrganization?.trim()].filter(Boolean).join(' · ') || 'A discharge planner';
     const appUrl = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com').replace(/\/$/, '');
     const adminLink = `${appUrl}/admin/concierge/${args.requestId}`;
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [to],
       replyTo: OUTREACH_REPLY_TO,
@@ -305,7 +340,7 @@ export async function sendConciergeShortlistReadyEmail(args: {
     const optionWord = n === 1 ? 'option' : 'options';
     const appUrl = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com').replace(/\/$/, '');
     const link = `${appUrl}/discharge-planner/concierge`;
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [toEmail],
       replyTo: OUTREACH_REPLY_TO,
@@ -370,7 +405,7 @@ export async function sendConciergeTourNotification(args: {
       : 'This home is UNCLAIMED — please coordinate the tour on the family’s behalf (the operator was also nudged to claim).';
     const appUrl = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com').replace(/\/$/, '');
     const adminLink = `${appUrl}/admin/concierge/${args.requestId}`;
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [to],
       replyTo: OUTREACH_REPLY_TO,
@@ -453,7 +488,7 @@ export async function sendInquiryClaimNudgeEmail(args: {
   <p style="color:#6b7280;font-size:13px">Details are kept private until you claim. There is no cost to claim or respond.</p>
 </body></html>`;
 
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [args.toEmail],
       replyTo: OUTREACH_REPLY_TO,
@@ -515,7 +550,7 @@ export async function sendNewLeadOperatorEmail(args: {
   <p style="color:#6b7280;font-size:13px">Details are kept private and secure on CareLinkAI.</p>
 </body></html>`;
 
-    const { error } = await resend.emails.send({
+    const { error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [args.toEmail],
       replyTo: OUTREACH_REPLY_TO,
@@ -605,7 +640,7 @@ export async function sendClaimDripEmail(args: {
   </p>
 </body></html>`;
 
-    const { error } = await resend.emails.send({
+    const { error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [args.toEmail],
       replyTo: OUTREACH_REPLY_TO,
@@ -740,7 +775,7 @@ export async function sendDpFollowupEmail(args: {
       postalAddress: args.postalAddress,
     });
 
-    const { error } = await resend.emails.send({
+    const { error } = await guardedResendSend({
       from: `${DP_LEAD_FROM_NAME} <${DP_LEAD_FROM_EMAIL}>`,
       to: [args.toEmail],
       replyTo: DP_LEAD_REPLY_TO,
@@ -840,7 +875,7 @@ export async function sendDirectoryClaimInviteEmail(args: {
   </p>
 </body></html>`;
 
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [args.toEmail],
       replyTo: OUTREACH_REPLY_TO,
@@ -1077,7 +1112,7 @@ export async function sendPasswordResetEmail(
     const APP_URL = process.env.NEXTAUTH_URL || 'https://getcarelinkai.com';
     const resetLink = `${APP_URL}/auth/reset-password?token=${resetToken}`;
     
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [email],
       subject: `Reset Your ${APP_NAME} Password`,
@@ -1132,7 +1167,7 @@ export async function sendQuoteSurveyEmail(args: {
       `name and never any medical details.</p>` +
       `<p><a href="${escapeHtml(args.surveyUrl)}" style="display:inline-block;background:#0d9488;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600">Share the quote</a></p>` +
       `<p style="color:#9ca3af;font-size:12px">${APP_NAME}</p>`;
-    const { error } = await resend.emails.send({
+    const { error } = await guardedResendSend({
       from: `${APP_NAME} <${FROM_EMAIL}>`,
       to: [args.toEmail],
       replyTo: OUTREACH_REPLY_TO,

--- a/src/lib/email/suppression.ts
+++ b/src/lib/email/suppression.ts
@@ -1,0 +1,132 @@
+/**
+ * Email suppression — the single source of truth for "never send to this address"
+ * (fix/resend-bounce-suppression).
+ *
+ * Backed by the existing `EmailSuppression` table (email UNIQUE, lowercased).
+ * `reason` is a free string so one list covers every exclusion cause:
+ *   'bounce' | 'complaint' | 'unsubscribe' | 'invalid_syntax' | 'no_mx' | 'manual'
+ *
+ * Enforcement: `guardedResendSend` (src/lib/email.ts) filters recipients through
+ * `filterSuppressed` before every Resend send, so a hard-bounced or complained
+ * address is never emailed again. The Resend bounce/complaint webhook and the
+ * import/scrub scripts all write here through `addSuppressions`.
+ */
+
+import { prisma } from '@/lib/prisma';
+import { captureError } from '@/lib/sentry';
+
+export type SuppressionReason =
+  | 'bounce'
+  | 'complaint'
+  | 'unsubscribe'
+  | 'invalid_syntax'
+  | 'no_mx'
+  | 'manual';
+
+/** Trim + lowercase. Returns '' for null/blank so callers can drop it. */
+export function normalizeEmail(email: string | null | undefined): string {
+  return (email || '').trim().toLowerCase();
+}
+
+/** True if the address is on the suppression list. Fails OPEN (false) on a DB error. */
+export async function isEmailSuppressed(email: string | null | undefined): Promise<boolean> {
+  const e = normalizeEmail(email);
+  if (!e) return false;
+  try {
+    const row = await prisma.emailSuppression.findUnique({ where: { email: e }, select: { email: true } });
+    return Boolean(row);
+  } catch (error) {
+    captureError(error instanceof Error ? error : new Error(String(error)), { tags: { feature: 'email-suppression' }, extra: { phase: 'isSuppressed' } });
+    return false; // don't let a DB hiccup block all outbound email
+  }
+}
+
+/** The suppression reason for one address, or null if not suppressed. */
+export async function suppressionReasonFor(email: string | null | undefined): Promise<string | null> {
+  const e = normalizeEmail(email);
+  if (!e) return null;
+  try {
+    const row = await prisma.emailSuppression.findUnique({ where: { email: e }, select: { reason: true } });
+    return row ? (row.reason || 'suppressed') : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Partition a recipient list into allowed vs suppressed in a SINGLE query.
+ * De-dupes and normalizes; blank entries are dropped from both sides.
+ */
+export async function filterSuppressed(
+  emails: Array<string | null | undefined>,
+): Promise<{ allowed: string[]; suppressed: string[] }> {
+  const normalized = Array.from(new Set(emails.map(normalizeEmail).filter(Boolean)));
+  if (normalized.length === 0) return { allowed: [], suppressed: [] };
+  let suppressedSet = new Set<string>();
+  try {
+    const rows = await prisma.emailSuppression.findMany({
+      where: { email: { in: normalized } },
+      select: { email: true },
+    });
+    suppressedSet = new Set(rows.map((r) => r.email));
+  } catch (error) {
+    // Fail OPEN: on a lookup error, treat nothing as suppressed rather than
+    // silently dropping legitimate transactional mail. The webhook keeps the
+    // list fresh, so a transient miss is low-risk.
+    captureError(error instanceof Error ? error : new Error(String(error)), { tags: { feature: 'email-suppression' }, extra: { phase: 'filter' } });
+    return { allowed: normalized, suppressed: [] };
+  }
+  return {
+    allowed: normalized.filter((e) => !suppressedSet.has(e)),
+    suppressed: normalized.filter((e) => suppressedSet.has(e)),
+  };
+}
+
+/**
+ * Add addresses to the suppression list (idempotent upsert). Existing rows keep
+ * their original `suppressedAt`/first reason unless `overwriteReason` is set —
+ * a complaint should be able to overwrite a milder 'unsubscribe', but we don't
+ * churn timestamps. Returns the number of NEW addresses suppressed.
+ */
+export async function addSuppressions(
+  emails: Array<string | null | undefined>,
+  reason: SuppressionReason,
+  source: string,
+  opts: { overwriteReason?: boolean } = {},
+): Promise<number> {
+  const normalized = Array.from(new Set(emails.map(normalizeEmail).filter(Boolean)));
+  let added = 0;
+  for (const email of normalized) {
+    try {
+      const res = await prisma.emailSuppression.upsert({
+        where: { email },
+        create: { email, reason, source },
+        update: opts.overwriteReason ? { reason } : {},
+      });
+      // upsert doesn't tell us created-vs-updated; count as added if it was brand new
+      // by comparing suppressedAt to now is unreliable, so we do a cheap existence race-free
+      // approximation: treat every successful upsert as processed and let callers rely on
+      // a follow-up count query for exact "new" totals. We still return processed count.
+      void res;
+      added++;
+    } catch (error) {
+      captureError(error instanceof Error ? error : new Error(String(error)), { tags: { feature: 'email-suppression' }, extra: { phase: 'add', source } });
+    }
+  }
+  return added;
+}
+
+/** Convenience single-address add. */
+export async function addSuppression(
+  email: string,
+  reason: SuppressionReason,
+  source: string,
+  opts: { overwriteReason?: boolean } = {},
+): Promise<void> {
+  await addSuppressions([email], reason, source, opts);
+}
+
+/** Total suppressed count (for reporting how polluted the list is). */
+export async function suppressedCount(): Promise<number> {
+  return prisma.emailSuppression.count();
+}

--- a/src/lib/email/validate.ts
+++ b/src/lib/email/validate.ts
@@ -1,0 +1,94 @@
+/**
+ * Pre-send email validation — syntax + domain MX (fix/resend-bounce-suppression).
+ *
+ * Catches obviously-invalid and undeliverable-domain addresses BEFORE they enter
+ * the send queue, so scraped/imported lists don't generate fresh hard bounces.
+ * Deliberately uses only FREE checks (regex + a DNS MX lookup) — no per-address
+ * paid verification API (NeverBounce/ZeroBounce bill per check; wiring one as a
+ * recurring per-send step is a cost decision flagged for the founder, not done here).
+ *
+ * MX results are memoized per-domain for the life of the process (a scrub run hits
+ * the same domains repeatedly), with a short timeout and fail-OPEN semantics: a DNS
+ * hiccup must not wrongly quarantine a good address.
+ */
+
+import { promises as dns } from 'dns';
+import { normalizeEmail } from '@/lib/email/suppression';
+
+/** Practical email syntax check — stricter than a bare "has an @". Single @, a
+ *  dotted domain with a 2+ char TLD, no spaces/consecutive dots. Not full RFC 5322
+ *  (that accepts addresses no mail system routes); this rejects the junk scrapes
+ *  actually produce. */
+const EMAIL_RE = /^[^\s@"'()<>,;:\\]+@(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i;
+
+export function isValidEmailSyntax(email: string | null | undefined): boolean {
+  const e = normalizeEmail(email);
+  if (!e || e.length > 254) return false;
+  if (e.includes('..')) return false;
+  const at = e.lastIndexOf('@');
+  if (at <= 0) return false;
+  if (e.slice(0, at).length > 64) return false; // local part cap
+  return EMAIL_RE.test(e);
+}
+
+export function domainOf(email: string): string {
+  const e = normalizeEmail(email);
+  const at = e.lastIndexOf('@');
+  return at >= 0 ? e.slice(at + 1) : '';
+}
+
+const mxCache = new Map<string, boolean>();
+
+/** True if the domain publishes MX (or a fallback A/AAAA per RFC 5321 §5.1) records.
+ *  Fails OPEN (returns true) on timeout/transient DNS errors; only a definitive
+ *  NXDOMAIN / no-records answer returns false. */
+export async function hasDeliverableDomain(domain: string, timeoutMs = 5000): Promise<boolean> {
+  const d = (domain || '').trim().toLowerCase();
+  if (!d) return false;
+  if (mxCache.has(d)) return mxCache.get(d)!;
+
+  const withTimeout = <T>(p: Promise<T>): Promise<T> => {
+    let timer: NodeJS.Timeout;
+    const timeout = new Promise<T>((_, rej) => {
+      timer = setTimeout(() => rej(new Error('dns-timeout')), timeoutMs);
+      timer.unref?.(); // don't keep the process alive on our account
+    });
+    return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
+  };
+
+  let deliverable: boolean;
+  try {
+    const mx = await withTimeout(dns.resolveMx(d));
+    deliverable = Array.isArray(mx) && mx.some((r) => r.exchange);
+  } catch (err: any) {
+    // NODATA on MX → check A/AAAA (implicit MX). NXDOMAIN → not deliverable.
+    if (err && (err.code === 'ENOTFOUND' || err.code === 'ENODATA' || err.code === 'NXDOMAIN')) {
+      try {
+        const a = await withTimeout(dns.lookup(d));
+        deliverable = Boolean(a && a.address);
+      } catch (err2: any) {
+        deliverable = !(err2 && (err2.code === 'ENOTFOUND' || err2.code === 'ENODATA' || err2.code === 'NXDOMAIN'));
+      }
+    } else {
+      deliverable = true; // transient/timeout → fail open
+    }
+  }
+  mxCache.set(d, deliverable);
+  return deliverable;
+}
+
+export type EmailValidity =
+  | { ok: true }
+  | { ok: false; reason: 'invalid_syntax' | 'no_mx' };
+
+/** Full pre-send gate: syntax first (cheap), then domain deliverability (DNS). */
+export async function validateEmailForSend(email: string, timeoutMs = 5000): Promise<EmailValidity> {
+  if (!isValidEmailSyntax(email)) return { ok: false, reason: 'invalid_syntax' };
+  const ok = await hasDeliverableDomain(domainOf(email), timeoutMs);
+  return ok ? { ok: true } : { ok: false, reason: 'no_mx' };
+}
+
+/** Test hook: clear the per-process MX memo. */
+export function _clearMxCache(): void {
+  mxCache.clear();
+}


### PR DESCRIPTION
## Goal

Get the outreach email bounce rate **~27% → <3%** and keep it there. Tracking (open/click, `links.getcarelinkai.com`) is already fixed — this PR is only about bounces. Root cause: invalid/guessed addresses in scraped operator + DP lists, and re-sending to addresses that already hard-bounced.

The strategy is the handoff's priority order: **never send to a known-bad address** (enforced at send time), **auto-learn new bad addresses** (webhook), and **reject undeliverable addresses before they queue** (validation).

## What's in this PR

| Piece | File |
|-------|------|
| Suppression as single source of truth | `src/lib/email/suppression.ts` (on the existing `EmailSuppression` table) |
| **Send-time enforcement** (choke point) | `guardedResendSend` in `src/lib/email.ts` |
| **Bounce/complaint webhook** | `src/app/api/webhooks/resend/route.ts` |
| **Pre-send syntax + MX gate** (free) | `src/lib/email/validate.ts` |
| History import (file-first) | `scripts/import-resend-suppressions.ts` |
| List scrub | `scripts/scrub-contact-emails.ts` |
| Runbook + env | `docs/RESEND_BOUNCE_SUPPRESSION.md`, `.env.example` |

**No migration** — `EmailSuppression` already exists; its `reason` string now carries every cause (`bounce`/`complaint`/`unsubscribe`/`invalid_syntax`/`no_mx`/`manual`).

### 1. Stop re-sending to known-bad (highest impact)
`EmailSuppression` is the one exclusion list. **`guardedResendSend`** is a new single choke point that every `email.ts` send helper now routes through — it drops suppressed recipients before hitting Resend, skips the send entirely if nothing deliverable remains, and **fails open** (a suppression-lookup DB error still lets mail through, so a DB blip can't silently kill all outbound email). Previously suppression was checked in only 3 cold-outreach lanes; now it's enforced across every send in the module.

### 2. Webhook keeps it fixed
`POST /api/webhooks/resend` verifies the Svix signature via the Resend SDK's **native `webhooks.verify()`** (svix is already bundled — **no new dependency**), mirroring the Stripe webhook (raw body, prod fail-closed on missing secret/signature → 400). `email.bounced` (permanent/undetermined) and `email.complained` auto-upsert into `EmailSuppression`; soft/transient bounces are ignored. Needs `RESEND_WEBHOOK_SECRET`.

### 3. Validate before sending
`validateEmailForSend` = syntax + domain MX (with A/AAAA fallback), memoized per domain, fail-open on transient DNS errors. **Free** — no paid verification API.

### 4. Clean existing lists (founder runs on Render)
- `import-resend-suppressions.ts` — file-first backfill from a Resend dashboard export (the sandbox/CI can't reach `api.resend.com`, and Resend has no "list all bounces" endpoint). Auto-detects the email column + bounce/complaint indicator; dry-run default; reports list size + **top bouncing domains** (shows if one scraped batch dominates).
- `scrub-contact-emails.ts` — validates the scraped channels (`AssistedLivingHome.outreachEmail`/`.contactEmail`, `DPLead.email`), quarantines syntax/MX-dead addresses into `EmailSuppression`; dry-run default; reports **per-source % bad**.

Because both scripts write into the same `EmailSuppression` table the send path checks, quarantined addresses are auto-excluded from every future broadcast — no per-contact `emailStatus` column (no migration) needed.

## Cost flag (per CLAUDE.md)
**No new recurring cost.** MX = free DNS, suppression = DB, webhook = free. A per-address verifier (NeverBounce/ZeroBounce, ~$0.003–0.008/check) is intentionally **not** wired — documented as an optional one-time cleanup only, to be flagged before any recurring >$20/mo spend.

## Scope note
Enforcement covers all sends in `src/lib/email.ts`. A few transactional sends live outside it (ride notifications, some cron/register routes, `inquiry-email-service.ts`) and still call Resend directly — they go to user-typed addresses (low bounce risk); routing them through `guardedResendSend` too is a clean follow-up (noted in the doc).

## Tests / checks
- 25 new tests: suppression partition/normalize/add + guarded-send drops suppressed recipients; syntax/MX validation (DNS mocked); webhook (hard bounce → suppress, complaint → suppress+overwrite, soft bounce ignored, invalid signature → 400, missing signature in prod → 400).
- Existing email suites (concierge, DP) still green — routing through the guard didn't regress them.
- `tsc --noEmit` clean; `eslint` clean. Full suite 736 pass / 10 skip (only the 2 pre-existing `canvas`-native render suites fail in the sandbox — unrelated).

## Founder follow-ups to report back (from the handoff)
Once the import + scrub run on Render, they print **the total suppressed count** (how polluted the list was) and **per-source % bad** (which scraped source to stop trusting). Please paste those back. Also: add the Resend webhook + `RESEND_WEBHOOK_SECRET`, and add a `p=none` DMARC record if absent. Full runbook in `docs/RESEND_BOUNCE_SUPPRESSION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdxFWV8XaFUuQ7oYACA1aw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdxFWV8XaFUuQ7oYACA1aw)_