### PR TITLE
feat(dp-leads): admin Delete action + scoped test-lead cleanup script

### DIFF
--- a/__tests__/dp-lead-api.test.ts
+++ b/__tests__/dp-lead-api.test.ts
@@ -16,6 +16,7 @@ jest.mock('@/lib/prisma', () => ({
       findUnique: jest.fn(),
       findMany: jest.fn(),
       update: jest.fn(),
+      delete: jest.fn(),
     },
   },
 }));
@@ -29,7 +30,7 @@ jest.mock('@/lib/auth-utils', () => ({ requireRole: jest.fn() }));
 jest.mock('@/lib/sentry', () => ({ captureError: jest.fn() }));
 
 import { POST as leadPost } from '@/app/api/lead/dp/route';
-import { PATCH as adminPatch } from '@/app/api/admin/dp-leads/[id]/route';
+import { PATCH as adminPatch, DELETE as adminDelete } from '@/app/api/admin/dp-leads/[id]/route';
 import { GET as adminGet } from '@/app/api/admin/dp-leads/route';
 import { prisma } from '@/lib/prisma';
 import { startDpSequenceOnLead } from '@/lib/dp-outreach/dp-followup';
@@ -39,6 +40,7 @@ const create = prisma.dPLead.create as jest.Mock;
 const findUnique = prisma.dPLead.findUnique as jest.Mock;
 const update = prisma.dPLead.update as jest.Mock;
 const findMany = prisma.dPLead.findMany as jest.Mock;
+const deleteMock = prisma.dPLead.delete as jest.Mock;
 const startSeq = startDpSequenceOnLead as jest.Mock;
 const roleMock = requireRole as jest.Mock;
 
@@ -69,6 +71,7 @@ beforeEach(() => {
   process.env.ALLOW_DEV_ENDPOINTS = '1'; // bypass rate limit in tests
   create.mockResolvedValue({ id: 'lead-1' } as never);
   update.mockResolvedValue({ id: 'lead-1', status: 'replied' } as never);
+  deleteMock.mockResolvedValue({ id: 'lead-1' } as never);
   startSeq.mockResolvedValue(undefined as never);
   roleMock.mockResolvedValue({ id: 'admin', role: 'ADMIN' } as never);
 });
@@ -167,5 +170,34 @@ describe('GET /api/admin/dp-leads', () => {
     roleMock.mockRejectedValue(err);
     const res = await adminGet(new NextRequest('http://localhost/api/admin/dp-leads'));
     expect(res.status).toBe(401);
+  });
+});
+
+// ------------------------------------------------- DELETE /api/admin/dp-leads/[id]
+describe('DELETE /api/admin/dp-leads/[id]', () => {
+  const delReq = () => new NextRequest('http://localhost/api/admin/dp-leads/lead-1', { method: 'DELETE' });
+
+  it('deletes an existing lead for an admin', async () => {
+    findUnique.mockResolvedValue({ id: 'lead-1' } as never);
+    const res = await adminDelete(delReq(), { params: { id: 'lead-1' } });
+    expect(res.status).toBe(200);
+    expect(deleteMock).toHaveBeenCalledWith({ where: { id: 'lead-1' } });
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, deleted: 'lead-1' });
+  });
+
+  it('returns 404 for a missing lead (and deletes nothing)', async () => {
+    findUnique.mockResolvedValue(null as never);
+    const res = await adminDelete(delReq(), { params: { id: 'nope' } });
+    expect(res.status).toBe(404);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for a non-admin (and deletes nothing)', async () => {
+    const err: any = new Error('Forbidden'); err.name = 'UnauthorizedError';
+    roleMock.mockRejectedValue(err);
+    const res = await adminDelete(delReq(), { params: { id: 'lead-1' } });
+    expect(res.status).toBe(403);
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 });

--- a/scripts/delete-test-dp-leads.ts
+++ b/scripts/delete-test-dp-leads.ts
@@ -1,0 +1,69 @@
+/**
+ * delete-test-dp-leads.ts — remove the seeded TEST rows from the DPLead table.
+ *
+ * TIGHTLY scoped so no real lead is ever touched: matches ONLY rows where the
+ * planner name starts with "TEST" AND hospital is exactly "TEST Hospital"
+ * (the signature of the manual test submissions — e.g. "TEST", "TEST 2", …,
+ * hospital "TEST Hospital", profyt7@gmail.com). A real lead like "Karen Lockman"
+ * at a real hospital can't match either clause.
+ *
+ * Dry-run by default: it prints the exact rows that WOULD be deleted so you can
+ * eyeball them first. Pass --force to actually delete. A safety cap (--max,
+ * default 25) refuses to delete if the match set is unexpectedly large.
+ *
+ * Usage (Render shell, on the deployed code):
+ *   npx tsx scripts/delete-test-dp-leads.ts            # DRY RUN — show matches
+ *   npx tsx scripts/delete-test-dp-leads.ts --force    # DELETE the matched rows
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const FORCE = process.argv.includes('--force');
+const MAX = Number(argValue('--max') ?? 25);
+
+// The ONLY match criteria — both must hold.
+const WHERE = { name: { startsWith: 'TEST' }, hospital: 'TEST Hospital' } as const;
+
+async function main() {
+  const matches = await prisma.dPLead.findMany({
+    where: WHERE,
+    select: { id: true, name: true, email: true, hospital: true, status: true, createdAt: true },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  console.log(`\n=== delete-test-dp-leads ${FORCE ? '(DELETE)' : '(DRY RUN — pass --force to delete)'} ===`);
+  console.log(`Match criteria: name starts with "TEST" AND hospital = "TEST Hospital"`);
+  console.log(`Matched rows: ${matches.length}\n`);
+
+  if (matches.length === 0) {
+    console.log('Nothing to delete — no rows match. (Already cleaned up?)\n');
+    return;
+  }
+
+  for (const m of matches) {
+    console.log(`  • ${m.name.padEnd(10)} | ${m.hospital} | ${m.email} | status=${m.status} | ${m.createdAt.toISOString().slice(0, 10)} | id=${m.id}`);
+  }
+
+  if (!FORCE) {
+    console.log(`\nDRY RUN — nothing deleted. Verify the ${matches.length} row(s) above, then re-run with --force.\n`);
+    return;
+  }
+
+  if (matches.length > MAX) {
+    console.error(`\n⛔ ABORT: ${matches.length} matches exceeds the safety cap (--max ${MAX}). That's more TEST rows than expected — inspect before deleting, or raise --max deliberately.\n`);
+    process.exit(1);
+  }
+
+  const result = await prisma.dPLead.deleteMany({ where: WHERE });
+  console.log(`\n✅ Deleted ${result.count} test lead(s).\n`);
+}
+
+main()
+  .catch((e) => { console.error(e); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/src/app/admin/dp-leads/page.tsx
+++ b/src/app/admin/dp-leads/page.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Loader2, CheckCircle, MessageSquare, Send, Ban, Stethoscope } from 'lucide-react';
+import { Loader2, CheckCircle, MessageSquare, Send, Ban, Stethoscope, Trash2 } from 'lucide-react';
 
 type Lead = {
   id: string;
@@ -104,6 +104,24 @@ export default function AdminDpLeadsPage() {
       await load();
     } catch (e: any) {
       setError(e?.message || 'Action failed');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function del(lead: Lead) {
+    if (!window.confirm(`Permanently delete this lead?\n\n${lead.name} — ${lead.hospital}\n${lead.email}\n\nThis cannot be undone.`)) return;
+    setBusyId(lead.id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/dp-leads/${lead.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        throw new Error(d?.error || 'Delete failed');
+      }
+      await load();
+    } catch (e: any) {
+      setError(e?.message || 'Delete failed');
     } finally {
       setBusyId(null);
     }
@@ -206,6 +224,10 @@ export default function AdminDpLeadsPage() {
                           <CheckCircle className="h-3 w-3" /> Reactivate
                         </button>
                       )}
+                      <button onClick={() => del(lead)} disabled={busyId === lead.id} title="Delete this lead permanently"
+                        className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium bg-red-50 text-red-700 hover:bg-red-100 disabled:opacity-50">
+                        <Trash2 className="h-3 w-3" /> Delete
+                      </button>
                       {busyId === lead.id && <Loader2 className="h-3 w-3 animate-spin text-neutral-400" />}
                     </div>
                   </td>

--- a/src/app/api/admin/dp-leads/[id]/route.ts
+++ b/src/app/api/admin/dp-leads/[id]/route.ts
@@ -72,3 +72,23 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     return NextResponse.json({ error: 'Failed to update' }, { status: 500 });
   }
 }
+
+/**
+ * DELETE /api/admin/dp-leads/[id] — permanently remove a single DP lead.
+ * Admin-only, one row by id (so cleanup can't over-delete). Idempotent-ish:
+ * a missing id returns 404. DPLead has NO PHI and no FKs, so a hard delete is safe.
+ */
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await requireRole([UserRole.ADMIN]);
+    const lead = await prisma.dPLead.findUnique({ where: { id: params.id }, select: { id: true } });
+    if (!lead) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    await prisma.dPLead.delete({ where: { id: lead.id } });
+    return NextResponse.json({ ok: true, deleted: lead.id });
+  } catch (error: any) {
+    if (error?.name === 'UnauthenticatedError') return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (error?.name === 'UnauthorizedError') return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    console.error('[admin/dp-leads] delete error:', error);
+    return NextResponse.json({ error: 'Failed to delete' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## What

Two things so DP leads can be cleaned up — one for right now, one for going forward.

### 1. Admin Delete action (self-service, going forward)
- **`DELETE /api/admin/dp-leads/[id]`** — ADMIN-only, hard-deletes one lead by id. Returns 404 for a missing id. Safe as a hard delete: `DPLead` holds **no PHI** and has no foreign keys.
- **Admin UI** (`/admin/dp-leads`): a red **Delete** button in the Actions column (always shown, alongside the existing Reactivate/Stop), wired to the endpoint. It pops a `window.confirm` showing the lead's name / hospital / email before deleting, then refreshes the list.

### 2. Scoped test-lead cleanup script (for the 4 TEST rows now)
`scripts/delete-test-dp-leads.ts` — removes the seeded test rows, **tightly scoped** so no real lead is touched: it matches **only** rows where `name` starts with `"TEST"` **AND** `hospital` is exactly `"TEST Hospital"` (the signature of the manual test submits — `TEST`/`TEST 2`/`TEST 3`/`TEST 4`, `profyt7@gmail.com`). A real lead like *Karen Lockman* can't match either clause.
- **Dry-run by default** — prints the exact rows that would be deleted so you eyeball them first; `--force` to delete.
- Safety cap (`--max`, default 25) aborts if the match set is unexpectedly large.

```
npx tsx scripts/delete-test-dp-leads.ts            # DRY RUN — show matches
npx tsx scripts/delete-test-dp-leads.ts --force    # delete the matched rows
```

## Deleting the 4 TEST rows — two options once this deploys
- **Script:** run the dry-run on Render, confirm the 4 rows, then `--force` (bulk, with the preview you asked for).
- **Or the new button:** just click **Delete** on each TEST row in `/admin/dp-leads`.

> Heads-up (as before): I can't run the delete against prod from here — this env has no prod `DATABASE_URL` and the proxy blocks external hosts. The script is the dry-run-first tool for you to run on Render.

## Tests / checks
- 3 new endpoint tests: admin delete → 200 (+ `prisma.dPLead.delete` called with the right id), missing lead → 404 (deletes nothing), non-admin → 403 (deletes nothing).
- `tsc --noEmit` clean; `eslint` clean; 14 tests in the DP-lead API suite green.

No migration; no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdxFWV8XaFUuQ7oYACA1aw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdxFWV8XaFUuQ7oYACA1aw)_