### PR TITLE
fix(sentry): stop CI e2e noise from dev-tagged handled errors

### DIFF
--- a/.github/workflows/e2e-family.yml
+++ b/.github/workflows/e2e-family.yml
@@ -18,6 +18,17 @@ concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
+# Sentry is production-only. Blank BOTH DSNs for every job (build + runtime) so
+# CI e2e never initializes Sentry and never reports handled errors — e.g. Resend
+# 401s from the committed placeholder key — as dev-tagged noise
+# (CARELINK-AI-16/-17). An empty value stays set, so Next.js will NOT override it
+# with the committed .env value. Backstop to the enabled:production gate in the
+# sentry.*.config.ts files. Both are blanked because the config falls back to
+# NEXT_PUBLIC_SENTRY_DSN when SENTRY_DSN is empty.
+env:
+  SENTRY_DSN: ""
+  NEXT_PUBLIC_SENTRY_DSN: ""
+
 jobs:
   e2e-residents:
     runs-on: ubuntu-latest

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -13,6 +13,11 @@ if (SENTRY_DSN) {
   Sentry.init({
     dsn: SENTRY_DSN,
 
+    // Report ONLY from production. CI/e2e runs (NODE_ENV=development on
+    // localhost) were the source of dev-tagged noise (CARELINK-AI-16/-17). The
+    // beforeSend guard below is the backstop to this flag.
+    enabled: process.env.NODE_ENV === 'production',
+
     // Enable Logs feature
     enableLogs: true,
 
@@ -32,6 +37,11 @@ if (SENTRY_DSN) {
     sendDefaultPii: false,
 
     beforeSend(event) {
+      // Backstop to `enabled` above: drop every non-production event so CI/e2e
+      // noise never reaches Sentry, even if a DSN leaks into a dev environment.
+      if (process.env.NODE_ENV !== 'production') {
+        return null;
+      }
       if (event.request?.data) {
         event.request.data = scrubPhi(event.request.data);
       }

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -15,6 +15,12 @@ if (SENTRY_DSN) {
   Sentry.init({
     dsn: SENTRY_DSN,
 
+    // Report ONLY from production. CI/e2e runs execute on localhost with
+    // NODE_ENV=development and were the source of ~637 dev-tagged handled errors
+    // (CARELINK-AI-16/-17, Resend 401s on the placeholder key). The beforeSend
+    // guard below is the backstop to this flag.
+    enabled: process.env.NODE_ENV === 'production',
+
     // Enable Logs feature
     enableLogs: true,
 
@@ -40,6 +46,11 @@ if (SENTRY_DSN) {
     sendDefaultPii: false,
 
     beforeSend(event) {
+      // Backstop to `enabled` above: drop every non-production event so CI/e2e
+      // noise never reaches Sentry, even if a DSN leaks into a dev environment.
+      if (process.env.NODE_ENV !== 'production') {
+        return null;
+      }
       if (event.request?.data) {
         event.request.data = scrubPhi(event.request.data);
       }

--- a/src/app/api/admin/concierge/[id]/route.ts
+++ b/src/app/api/admin/concierge/[id]/route.ts
@@ -27,11 +27,12 @@ function authErr(error: any): NextResponse | null {
   return null;
 }
 
-export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    const { id } = await params;
     await requireRole([UserRole.ADMIN]);
     const row = await prisma.placementSearch.findUnique({
-      where: { id: params.id },
+      where: { id },
       select: {
         id: true,
         queryText: true,
@@ -80,14 +81,15 @@ const patchSchema = z.discriminatedUnion('action', [
   }),
 ]);
 
-export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    const { id } = await params;
     await requireRole([UserRole.ADMIN]);
     const body = await request.json().catch(() => ({}));
     const parsed = patchSchema.parse(body);
 
     const existing = await prisma.placementSearch.findUnique({
-      where: { id: params.id },
+      where: { id },
       select: { id: true, isConcierge: true, userId: true, user: { select: { email: true } } },
     });
     if (!existing || !existing.isConcierge) {
@@ -96,7 +98,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
 
     if (parsed.action === 'matching') {
       await prisma.placementSearch.update({
-        where: { id: params.id },
+        where: { id },
         data: { conciergeStatus: 'MATCHING' },
       });
       return NextResponse.json({ ok: true, status: 'MATCHING' });
@@ -130,7 +132,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     }
 
     await prisma.placementSearch.update({
-      where: { id: params.id },
+      where: { id },
       data: {
         curatedHomes: curated,
         conciergeNote: parsed.conciergeNote?.trim() || null,
@@ -148,7 +150,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       title: 'Your shortlist is ready',
       message: `Your CareLinkAI care team curated ${curated.length} ${optionWord} for your placement request.`,
       link: '/discharge-planner/concierge',
-      data: { kind: 'concierge_shortlist_ready', searchId: params.id, count: curated.length },
+      data: { kind: 'concierge_shortlist_ready', searchId: id, count: curated.length },
     });
     if (existing.user?.email) {
       void sendConciergeShortlistReadyEmail({ toEmail: existing.user.email, count: curated.length });

--- a/src/app/api/discharge-planner/concierge/[id]/tour/route.ts
+++ b/src/app/api/discharge-planner/concierge/[id]/tour/route.ts
@@ -25,13 +25,14 @@ import { captureError } from '@/lib/sentry';
 
 const bodySchema = z.object({ homeId: z.string().min(1) });
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    const { id } = await params;
     const user = await requireRole([UserRole.DISCHARGE_PLANNER, UserRole.ADMIN]);
     const { homeId } = bodySchema.parse(await request.json().catch(() => ({})));
 
     const search = await prisma.placementSearch.findUnique({
-      where: { id: params.id },
+      where: { id },
       select: {
         id: true, userId: true, isConcierge: true, conciergeStatus: true, curatedHomes: true,
         user: { select: { firstName: true, lastName: true, dischargePlannerProfile: { select: { organization: true } } } },
@@ -61,7 +62,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
 
     // Persist the DP-visible status first (idempotent). If it was already
     // requested, return success without re-sending notifications.
-    const mark = await markConciergeTourRequested(params.id, homeId, new Date().toISOString());
+    const mark = await markConciergeTourRequested(id, homeId, new Date().toISOString());
     if (mark === 'not_found') {
       return NextResponse.json({ error: 'That home is not on this shortlist.' }, { status: 400 });
     }
@@ -75,7 +76,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
     const dpOrganization = search.user?.dischargePlannerProfile?.organization || undefined;
 
     // Always loop in the care team (Chris) so the tour gets coordinated.
-    void sendConciergeTourNotification({ requestId: params.id, facilityName: home.name, claimed, dpName, dpOrganization });
+    void sendConciergeTourNotification({ requestId: id, facilityName: home.name, claimed, dpName, dpOrganization });
 
     if (claimed && operatorEmail) {
       // Operator gets the lead directly (generic copy, no PHI).

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -16,6 +16,11 @@ if (SENTRY_DSN) {
   Sentry.init({
     dsn: SENTRY_DSN,
 
+    // Report ONLY from production. CI/e2e runs (NODE_ENV=development on
+    // localhost) were the source of dev-tagged noise (CARELINK-AI-16/-17). The
+    // beforeSend guard below is the backstop to this flag.
+    enabled: process.env.NODE_ENV === 'production',
+
     // Performance Monitoring - capture 10% of transactions in production
     tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
 
@@ -61,6 +66,11 @@ if (SENTRY_DSN) {
     ],
 
     beforeSend(event) {
+      // Backstop to `enabled` above: drop every non-production event so CI/e2e
+      // noise never reaches Sentry, even if a DSN leaks into a dev environment.
+      if (process.env.NODE_ENV !== 'production') {
+        return null;
+      }
       // Filter noisy ResizeObserver errors
       if (event.exception?.values?.[0]?.value?.includes('ResizeObserver')) {
         return null;

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -53,6 +53,38 @@ async function guardedResendSend(
   }>;
 }
 
+/**
+ * Guard every send helper consults before touching Resend. Returns true when
+ * outbound email must be short-circuited (skip the send, return false, NEVER
+ * captureError). Two cases:
+ *
+ *  - RESEND_API_KEY is missing — no way to send in any environment.
+ *  - NON-PRODUCTION with a placeholder key. The committed `.env` ships
+ *    `RESEND_API_KEY=re_placeholder_key_set_on_render`, so CI e2e (and local
+ *    dev) would otherwise attempt a send, get a 401 from Resend, and report
+ *    that HANDLED error to Sentry from CI — the source of ~637 dev-tagged
+ *    issues (CARELINK-AI-16/-17). Skipping the send there means no network
+ *    call and no captureError.
+ *
+ * Production is unaffected: a real key is always present, so this returns false
+ * and sends proceed normally. Logs the disabled state ONCE per process to avoid
+ * per-send log spam.
+ */
+let warnedEmailUnavailable = false;
+function emailSendingUnavailable(): boolean {
+  const key = process.env.RESEND_API_KEY;
+  const missing = !key;
+  const placeholder = process.env.NODE_ENV !== 'production' && !!key && key.includes('placeholder');
+  const unavailable = missing || placeholder;
+  if (unavailable && !warnedEmailUnavailable) {
+    warnedEmailUnavailable = true;
+    console.warn(
+      `[Resend] Email sending unavailable (${missing ? 'RESEND_API_KEY not configured' : 'placeholder key in non-production'}) — skipping outbound sends.`,
+    );
+  }
+  return unavailable;
+}
+
 // Constants
 const FROM_EMAIL = process.env.EMAIL_FROM || 'noreply@getcarelinkai.com';
 const APP_NAME = 'CareLinkAI';
@@ -93,12 +125,8 @@ export async function sendVerificationEmail(
   try {
     console.log(`[Resend] Sending verification email to ${email}`);
     
-    // Check if Resend API key is configured
-    if (!process.env.RESEND_API_KEY) {
-      console.error('[Resend] RESEND_API_KEY is not configured in environment variables');
-      console.error('[Resend] Please set RESEND_API_KEY on Render dashboard');
-      return false;
-    }
+    // Check if Resend API key is configured (and real — see emailSendingUnavailable)
+    if (emailSendingUnavailable()) return false;
     
     // Generate verification link
     const APP_URL = process.env.NEXTAUTH_URL || 'https://getcarelinkai.com';
@@ -189,10 +217,7 @@ export async function sendOperatorClaimNotification(args: {
   const ccRaw = (process.env.CLAIM_NOTIFY_CC ?? '').trim();
   const cc = ccRaw && ccRaw.toLowerCase() !== to.toLowerCase() ? [ccRaw] : undefined;
   try {
-    if (!process.env.RESEND_API_KEY) {
-      console.error('[Resend] RESEND_API_KEY not configured — skipping operator claim notification');
-      return false;
-    }
+    if (emailSendingUnavailable()) return false;
     const facilityName = args.facilityName || '(unnamed facility)';
     const operatorEmail = args.operatorEmail || '(unknown operator)';
     const operatorName = args.operatorName?.trim();
@@ -280,10 +305,7 @@ export async function sendConciergeRequestNotification(args: {
 }): Promise<boolean> {
   const to = process.env.ADMIN_NOTIFY_EMAIL || process.env.CLAIM_NOTIFY_EMAIL || 'chris@getcarelinkai.com';
   try {
-    if (!process.env.RESEND_API_KEY) {
-      console.error('[Resend] RESEND_API_KEY not configured — skipping concierge request notification');
-      return false;
-    }
+    if (emailSendingUnavailable()) return false;
     const who = [args.dpName?.trim(), args.dpOrganization?.trim()].filter(Boolean).join(' · ') || 'A discharge planner';
     const appUrl = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com').replace(/\/$/, '');
     const adminLink = `${appUrl}/admin/concierge/${args.requestId}`;
@@ -332,10 +354,7 @@ export async function sendConciergeShortlistReadyEmail(args: {
   const toEmail = args.toEmail?.trim();
   if (!toEmail) return false;
   try {
-    if (!process.env.RESEND_API_KEY) {
-      console.error('[Resend] RESEND_API_KEY not configured — skipping concierge shortlist-ready email');
-      return false;
-    }
+    if (emailSendingUnavailable()) return false;
     const n = args.count > 0 ? args.count : 1;
     const optionWord = n === 1 ? 'option' : 'options';
     const appUrl = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://getcarelinkai.com').replace(/\/$/, '');
@@ -394,10 +413,7 @@ export async function sendConciergeTourNotification(args: {
 }): Promise<boolean> {
   const to = process.env.ADMIN_NOTIFY_EMAIL || process.env.CLAIM_NOTIFY_EMAIL || 'chris@getcarelinkai.com';
   try {
-    if (!process.env.RESEND_API_KEY) {
-      console.error('[Resend] RESEND_API_KEY not configured — skipping concierge tour notification');
-      return false;
-    }
+    if (emailSendingUnavailable()) return false;
     const who = [args.dpName?.trim(), args.dpOrganization?.trim()].filter(Boolean).join(' · ') || 'A discharge planner';
     const facility = args.facilityName?.trim() || 'a facility';
     const claimLine = args.claimed
@@ -464,10 +480,7 @@ export async function sendInquiryClaimNudgeEmail(args: {
     ? `${count} families are trying to reach`
     : `A family is trying to reach`;
   try {
-    if (!process.env.RESEND_API_KEY) {
-      console.error('[Resend] RESEND_API_KEY not configured — skipping inquiry claim nudge');
-      return false;
-    }
+    if (emailSendingUnavailable()) return false;
     const safeFacility = escapeHtml(facilityName);
     const subject = isTour
       ? `A family wants to tour ${facilityName} — claim to confirm the visit`
@@ -531,7 +544,7 @@ export async function sendNewLeadOperatorEmail(args: {
   ctaUrl: string;
 }): Promise<boolean> {
   try {
-    if (!process.env.RESEND_API_KEY) return false;
+    if (emailSendingUnavailable()) return false;
     const facility = escapeHtml(args.facilityName?.trim() || 'your community');
     const hi = args.operatorFirstName ? `Hi ${escapeHtml(args.operatorFirstName)}, ` : '';
     const lead = args.leadType === 'tour' ? 'tour request' : 'inquiry';
@@ -590,7 +603,7 @@ export async function sendClaimDripEmail(args: {
   trigger?: 'inquiry' | 'tour';
 }): Promise<boolean> {
   try {
-    if (!process.env.RESEND_API_KEY) return false;
+    if (emailSendingUnavailable()) return false;
     const facility = args.facilityName?.trim() || 'your community';
     const n = Math.max(1, args.waitingCount || 1);
     const fam = n === 1 ? 'family' : 'families';
@@ -743,7 +756,7 @@ export async function sendDpFollowupEmail(args: {
   postalAddress: string;
 }): Promise<boolean> {
   try {
-    if (!process.env.RESEND_API_KEY) return false;
+    if (emailSendingUnavailable()) return false;
     const { dpFollowupCopy } = await import('@/lib/dp-outreach/copy');
     const copy = dpFollowupCopy(args.touch, {
       plannerFirstName: args.plannerFirstName,
@@ -829,10 +842,7 @@ export async function sendDirectoryClaimInviteEmail(args: {
   if (communities.length === 0) return false;
   const multi = communities.length > 1;
   try {
-    if (!process.env.RESEND_API_KEY) {
-      console.error('[Resend] RESEND_API_KEY not configured — skipping directory claim invite');
-      return false;
-    }
+    if (emailSendingUnavailable()) return false;
     const subject = multi
       ? `Claim your ${communities.length} free ${APP_NAME} listings`
       : `Claim your free ${APP_NAME} listing for ${communities[0].name}`;
@@ -1104,10 +1114,7 @@ export async function sendPasswordResetEmail(
   try {
     console.log(`[Resend] Sending password reset email to ${email}`);
     
-    if (!process.env.RESEND_API_KEY) {
-      console.error('[Resend] RESEND_API_KEY is not configured');
-      return false;
-    }
+    if (emailSendingUnavailable()) return false;
     
     const APP_URL = process.env.NEXTAUTH_URL || 'https://getcarelinkai.com';
     const resetLink = `${APP_URL}/auth/reset-password?token=${resetToken}`;
@@ -1151,7 +1158,7 @@ export async function sendQuoteSurveyEmail(args: {
   surveyUrl: string;
 }): Promise<boolean> {
   try {
-    if (!process.env.RESEND_API_KEY) return false;
+    if (emailSendingUnavailable()) return false;
     const facility = args.facilityName?.trim() || 'the community';
     const text =
       `Hi — thanks for touring ${facility} through CareLinkAI.\n\n` +


### PR DESCRIPTION
## Summary

Two Sentry noise sources, both rooted in GitHub Actions e2e runs on localhost.

### Issue 1 (main) — CARELINK-AI-16 / -17: "API key is invalid" (637+ events, all `environment: development`)

**Root cause:** the committed `.env` ships the real production `SENTRY_DSN`/`NEXT_PUBLIC_SENTRY_DSN` **and** a placeholder `RESEND_API_KEY=re_placeholder_key_set_on_render`. CI checks out `.env`, so Sentry initializes against the prod project while Resend 401s on the placeholder key. The handled error in `sendConciergeTourNotification` → `captureError` then reports to the prod Sentry from CI, tagged `development`.

**Fix (defense-in-depth):**
- **Gate Sentry init to production.** Added `enabled: process.env.NODE_ENV === 'production'` to the server, edge, and client (`instrumentation-client.ts`) configs, plus a `beforeSend` backstop that drops every non-production event. CI runs at `NODE_ENV=development`, so nothing is reported.
- **Blank the DSNs in CI (backup).** Added a workflow-level `env` to `e2e-family.yml` blanking `SENTRY_DSN` and `NEXT_PUBLIC_SENTRY_DSN` so Sentry never even initializes in CI. Empty values stay *set*, so Next.js won't override them with the committed `.env`. Both are blanked because the config falls back to `NEXT_PUBLIC_SENTRY_DSN`.
- **Short-circuit doomed sends in non-production.** New `emailSendingUnavailable()` guard in `src/lib/email.ts` (used by all 12 send helpers): when the key is missing *or* the non-prod placeholder, log once, return `false`, and never hit Resend / `captureError`.

### Issue 2 (same PR) — async params warning

`POST /api/discharge-planner/concierge/[id]/tour` read `params.id` without awaiting (Next 15 sync-dynamic-APIs warning, fired twice per request). Converted to the async params pattern (`params: Promise<{ id }>` + `await params`) and applied the same fix to the sibling `admin/concierge/[id]` route (GET + PATCH), the only other DP/concierge dynamic route.

### No code change — CARELINK-AI-Z ("No signatures found" on `/api/webhooks/stripe`)

That's a legacy **Tenth Power Ventures test-mode webhook** still pointed at the site. Stripe auto-disables it **7/27**, so it will stop on its own — intentionally untouched here.

## Testing
- `email`, `concierge`, and `resend-webhook` jest suites pass (15/15). The "absent key" no-op test still returns `false` with no send.
- `tsc --noEmit` clean across the project.

## Acceptance
- A full e2e CI run produces **zero** new Sentry events (gate + blanked DSNs + short-circuit).
- Production reporting unchanged: `enabled` is true and `beforeSend` passes events only when `NODE_ENV === 'production'`.
- No `params` warnings on the DP/concierge routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Paj9CDkeVhSXa6dqeQkqPg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Paj9CDkeVhSXa6dqeQkqPg)_